### PR TITLE
Migrate TODO.md roadmap into GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 
 ## Status
 
-**Pre-implementation.** This repository holds the design notes and roadmap.
-See [`TODO.md`](./TODO.md) for the proposal and planned phases.
+**Pre-implementation.** Work is tracked as [GitHub
+issues](https://github.com/cacack/ferrocv/issues), organized into phase
+milestones. Tracking issues stand in for future phases until their scope
+is activated. The non-negotiable design principles live in
+[`CONSTITUTION.md`](./CONSTITUTION.md).
 
 ## Why
 
@@ -42,6 +45,9 @@ schema and replaces the rendering pipeline with something more robust:
   — Typst template that accepts JSON Resume data.
 - [`fantastic-cv`](https://typst.app/universe/package/fantastic-cv/)
   — Typst Universe template with a JSON Resume-shaped API.
+- [`basic-resume`](https://typst.app/universe/package/basic-resume/)
+  and [`modern-cv`](https://typst.app/universe/package/modern-cv/)
+  — Typst Universe resume templates we plan to ship adapters for.
 - [`jsonresume-renderer`](https://lib.rs/crates/jsonresume-renderer)
   — Rust CLI that renders JSON Resume via Tera templates (not Typst).
 - [`typst.ts`](https://github.com/Myriad-Dreamin/typst.ts) — proves Typst

--- a/TODO.md
+++ b/TODO.md
@@ -1,185 +1,29 @@
 # TODO
 
-Working notes, roadmap, and open questions for `ferrocv`. This is the
-handoff document from the design discussion that happened in my personal resume repo.
-
-## Design summary
-
-**Diagnosis.** JSON Resume's *schema* is sound; the *JS theme ecosystem*
-is the weak link (abandoned themes, broken deps). Keep the schema,
-replace the renderer.
-
-**Direction: Typst over LaTeX/HTML-CSS.**
-- LaTeX: gold-standard typography, but huge runtime dep (TeX distro)
-  and hostile ergonomics for theme authors.
-- HTML/CSS (current state of the resume repo): weakest for complex
-  layouts under paged output; Playwright is a heavy subprocess.
-- **Typst**: Rust-native (embeddable as a crate — no subprocess, single
-  static binary), modern LaTeX replacement, growing resume template
-  ecosystem, typography close enough to LaTeX for 1–2 page docs.
-
-**Proposed flow.**
-- `resume.json` (JSON Resume v1.0.0 schema) is the canonical input.
-- `ferrocv` Rust binary that:
-  - Validates the input against the schema (`jsonschema` crate).
-  - Resolves a theme (local path or Typst Universe package).
-  - Compiles via the `typst` crate in-process — no subprocess, no TeX.
-  - Emits PDF directly; HTML via Typst's HTML export; plain text via
-    a built-in minimal "plaintext" theme.
-
-**CLI shape (proposed).**
-```
-ferrocv render --theme <name> --format pdf,html,txt [--output dist/]
-ferrocv validate [resume.json]
-ferrocv new-theme <name>
-```
-
-**Theme strategy.**
-- **Adapter layer (launch):** thin Typst wrappers over 3–5 popular
-  Universe templates that map JSON Resume fields to each template's
-  expected parameters. Per-theme cost is tens-to-low-hundreds of Typst
-  LOC. Breaks if upstream bumps API — acceptable maintenance.
-- **Native theme contract (grow into):** a theme is a Typst module
-  that imports `resume.json` natively (`json()` is built-in) and
-  exports `render(data)` returning content. Mirrors the JSON Resume
-  `render(resume)` convention.
-
-**Coupling model.** Schema ↔ adapter is the real coupling. Adapter ↔
-template is loose. Themes are constrained to "what JSON Resume can
-express"; for a resume that's rarely limiting. The `x-` extension
-prefix handles anything novel.
-
-## Phases
-
-### Phase 0 — Project scaffolding
-- [x] Pick license — dual MIT/Apache-2.0 (Rust convention).
-- [x] CI baseline: GitHub Actions with SHA-pinned actions running
-      `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`,
-      `cargo-deny`, and `cargo-audit`. Jobs guard on `Cargo.toml`
-      existing so they go green until `cargo init` lands.
-- [x] Release pipeline: `release-please` (conventional commits) opens
-      release PRs on `main`; tagged releases trigger cross-platform
-      builds for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`,
-      and `x86_64-pc-windows-msvc` with SHA-256 checksums.
-- [x] Dependabot for `github-actions` and `cargo`.
-- [x] Decide repo layout: **single crate** with `src/main.rs` +
-      `src/lib.rs`. Revisit (promote to workspace) if a second
-      consumer of the library emerges or we split out
-      `ferrocv-themes-*`.
-- [x] `cargo init` with binary + library split in a single `ferrocv`
-      crate. `release-please-config.json` flipped from
-      `release-type: simple` to `release-type: rust` so version bumps
-      target `Cargo.toml`.
-- [ ] Reserve names: register placeholders on
-      [crates.io](https://crates.io/) and
-      [npm](https://www.npmjs.com/) once there's enough to publish.
-- [ ] CI "gate" aggregator job that depends on fmt/clippy/test/deny/
-      audit so branch protection can require a single check
-      (pattern from `gedcom-go`, `my-family`).
-- [ ] Test matrix: `{ubuntu, macOS, windows} × {stable, MSRV}`. We
-      ship binaries for all three OSes, so single-OS CI is a lie —
-      embedded Typst may have platform-specific font/PDF quirks.
-- [ ] [`crate-ci/typos`](https://github.com/crate-ci/typos) as a CI
-      step. High signal for a tool whose output *is* rendered text.
-- [ ] `make preflight` target (or `just preflight`) mirroring CI so
-      there's one local command before pushing.
-- [ ] Auto-rebase workflow for a semi-linear history on `main`
-      (pattern from `my-family`; excludes Dependabot).
-
-### Phase 1 — MVP: validate + render PDF
-- [ ] JSON Resume v1.0.0 schema bundled in-binary
-      (`include_str!`/`include_bytes!`)
-- [ ] `ferrocv validate` — schema validation with clear errors
-- [ ] Embed Typst via the `typst` crate; compile to PDF in-process
-- [ ] Wire the first theme adapter over
-      [`fruggiero/typst-jsonresume-cv`](https://github.com/fruggiero/typst-jsonresume-cv)
-      (it already accepts JSON Resume directly)
-- [ ] `ferrocv render --format pdf` end-to-end on a real `resume.json`
-
-### Phase 2 — Multi-format output
-- [ ] HTML output via Typst's experimental HTML export. Re-confirm
-      maturity at the time we get here.
-- [ ] Plain text output via a built-in minimal Typst theme (or direct
-      from JSON if Typst's text export is weak)
-- [ ] Decide DOCX strategy: drop, or HTML→pandoc fallback
-
-### Phase 3 — Theme adapters
-- [ ] Adapter for [`basic-resume`](https://typst.app/universe/package/basic-resume/)
-- [ ] Adapter for [`modern-cv`](https://typst.app/universe/package/modern-cv/)
-- [ ] Adapter for [`fantastic-cv`](https://typst.app/universe/package/fantastic-cv/)
-      (already JSON Resume-shaped)
-- [ ] Document the adapter pattern so contributors can add more
-- [ ] Theme resolution: local path, bundled, Typst Universe package
-
-### Phase 4 — Native theme contract
-- [ ] Specify the contract: `render(data) -> content`, `data` is the
-      parsed JSON Resume document with extensions surfaced
-- [ ] `ferrocv new-theme <name>` scaffold
-- [ ] Build 1–2 reference native themes (one minimal, one richer)
-
-### Phase 5 — Filtering and audience-aware rendering
-Pulled forward from the resume repo's design notes. The renderer
-should support producing different outputs from the same source:
-- [ ] `--since YYYY` to drop older roles
-- [ ] `--max-bullets N` per role
-- [ ] `--include-salary` / `--redact pii` toggles
-- [ ] Multiple themes per audience (govt application vs. standard
-      resume vs. one-pager)
-
-## Pipeline & test follow-ups (gated on code existing)
-
-These are on the radar but not actionable against an empty crate.
-Activate as the relevant code lands. Surveyed from `gedcom-go` and
-`my-family`; filtered for fit.
-
-- [ ] **Coverage gating** via `cargo-llvm-cov` + Codecov. Per-package
-      thresholds with documented overrides (the `my-family`
-      `.testcoverage.yml` pattern is more maintainable than a single
-      global number). Activate with Phase 1.
-- [ ] **Nightly fuzzing** via `cargo-fuzz` targeting schema
-      validation and JSON Resume parsing. 2-minute budget per target
-      with crash artifacts retained; auto-file issue on failure
-      (`gedcom-go` / `my-family` pattern). Activate with Phase 1.
-- [ ] **`cargo-semver-checks`** on PR once there's a public library
-      API. Rust equivalent of `gedcom-go`'s `apidiff` gate; blocks
-      breaking changes that aren't marked with conventional-commit
-      `!:`. Activate once `ferrocv-core` has stable surface area
-      (Phase 4-ish).
-- [ ] **`cargo-dist`** (or `cargo-release`) for release artifacts.
-      The current handwritten release workflow is fine for now;
-      revisit if it becomes painful or once signing/attestations are
-      added.
-- [ ] **SBOM + sigstore attestations** for release artifacts
-      (CycloneDX/SPDX + cosign). Deferred: Constitution §6 already
-      marks reproducible/verifiable releases as aspirational. Explore
-      once there's a tagged release to sign.
+Planned work is tracked as [GitHub
+issues](https://github.com/cacack/ferrocv/issues); this file now holds
+only unresolved design questions that don't yet have enough shape to
+become actionable issues. Each of these should eventually resolve into
+an ADR (committed to the repo) or get folded into a tracking issue's
+scope, at which point it gets deleted from here. When this file empties
+out, delete it.
 
 ## Open questions
 
-- [ ] Confirm Typst HTML export maturity at the time of implementation.
+- [ ] Confirm Typst HTML export maturity at the time of implementation
+      (blocker on the Phase 2 HTML output issue).
 - [ ] DOCX strategy — drop entirely, or keep an HTML→pandoc fallback?
+      Revisit as part of Phase 2 planning.
 - [ ] How should renderer filter flags interact with themes — preprocess
       JSON in Rust before handing to the theme, or pass as theme
       parameters? Probably preprocess (keeps themes simple), but worth
-      sanity-checking.
+      sanity-checking. Captured in the Phase 5 tracking issue.
 - [ ] Library vs. binary split — is there demand for `ferrocv-core` as
-      a crate others can embed, or is the CLI sufficient?
+      a crate others can embed, or is the CLI sufficient? Revisit once
+      Phase 1 lands and we see whether anyone asks.
 - [ ] Theme distribution: do we host adapters in this repo, or split
       them into per-theme repos under a `ferrocv-themes-*` namespace?
+      Revisit when the third or fourth adapter lands.
 - [ ] How to handle JSON Resume `x-` extension fields cleanly across
       adapters that don't know about them (silent drop vs. warn)?
-
-## References
-
-- [JSON Resume schema v1.0.0](https://github.com/jsonresume/resume-schema)
-- [JSON Resume project](https://jsonresume.org/)
-- [Typst documentation](https://typst.app/docs/)
-- [Typst `json()` data loader](https://typst.app/docs/reference/data-loading/json/)
-- [`typst` crate on crates.io](https://crates.io/crates/typst)
-- [Typst Universe (templates/packages)](https://typst.app/universe/)
-- [`fruggiero/typst-jsonresume-cv`](https://github.com/fruggiero/typst-jsonresume-cv)
-- [`fantastic-cv`](https://typst.app/universe/package/fantastic-cv/)
-- [`basic-resume`](https://typst.app/universe/package/basic-resume/)
-- [`modern-cv`](https://typst.app/universe/package/modern-cv/)
-- [`jsonresume-renderer` (Tera-based, adjacent prior art)](https://lib.rs/crates/jsonresume-renderer)
-- [`typst.ts` / `reflexo-typst`](https://github.com/Myriad-Dreamin/typst.ts)
+      Needs a decision before the adapter count grows past one or two.


### PR DESCRIPTION
## Summary

- Filed 17 GitHub issues (#3–#19) covering remaining Phase 0 work, the Phase 1 MVP, and tracking issues for Phases 2–5.
- Created two milestones (`Phase 0: Project scaffolding`, `Phase 1: MVP — validate + render PDF`) and 13 new labels (`chore`, `tracking`, 5× `area:*`, 3× `value:*`, 3× `effort:*`).
- Reduced `TODO.md` from 186 lines to just the six unresolved design questions; rewrote the file's preamble so it self-deletes once those questions resolve.
- Updated `README.md` Status section to point at the issues list and added `basic-resume` + `modern-cv` to Prior art.

## Why

`TODO.md` was both the design narrative and the work tracker. Splitting those: design narrative lives in `README.md` + `CONSTITUTION.md` (already there), and work tracking lives in GitHub issues where it gets visibility, value/effort labels, milestones, and PR linking. Each issue body is self-contained — duplicates rationale rather than referencing TODO.md, so issues stand on their own once `TODO.md` eventually disappears.

## Issue scoping decisions

- **Phase 0 + Phase 1**: filed as individual issues under milestones (actionable now).
- **Phase 2–5**: one tracking issue each, no milestone. The tracking issue's job is to create the milestone and break down the work when the phase activates.
- **Pipeline follow-ups gated on Phase 1**: filed `cargo-llvm-cov` coverage and `cargo-fuzz` nightly fuzzing now (#18, #19). Deferred `cargo-semver-checks`, `cargo-dist`, and SBOM/sigstore — they need a stable public API or a tagged release to be meaningful.

## Test plan

- [x] All 17 issues visible at https://github.com/cacack/ferrocv/issues with correct labels and milestones.
- [x] `README.md` Status link reaches the issues list.
- [x] `TODO.md` contains only open questions + self-delete instruction.
- [x] No PII anywhere in issue bodies, README, or TODO (the source material was design notes, not personal data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
