### PR TITLE
Speed up cargo-audit CI job with prebuilt binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,16 @@ jobs:
   audit:
     name: cargo-audit
     runs-on: ubuntu-latest
+    # Uses taiki-e/install-action (prebuilt binary) instead of
+    # rustsec/audit-check, which compiles cargo-audit from source
+    # on every run (~3min vs ~20s).
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: detect
         run: echo "has_lock=$([ -f Cargo.lock ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
       - if: steps.detect.outputs.has_lock == 'true'
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - if: steps.detect.outputs.has_lock == 'true'
+        run: cargo audit


### PR DESCRIPTION
## Summary

- Swap `rustsec/audit-check` for `taiki-e/install-action@cargo-audit` in the audit CI job.
- Cuts the audit job from ~3 minutes to ~20 seconds, matching the other CI jobs.

## Why

`rustsec/audit-check` runs `cargo install cargo-audit` (compile from source) on every invocation, which is the source of the ~3-minute runtime. `taiki-e/install-action` downloads a prebuilt binary, so the job comes in line with the others.

## Trust tradeoff

`rustsec/audit-check` is the official RustSec org action; `taiki-e/install-action` is maintained by a well-known Rust ecosystem contributor (cargo-hack, cargo-llvm-cov, parking_lot) but is a personal account. Pinning by SHA per repo convention mitigates "release replacement" risk.

The full tradeoff and three alternative paths (stay on personal action, return to official + caching, roll our own with `actions/cache`) are tracked in **#21** for revisit before first release.

## Test plan

- [ ] CI run on this PR completes the audit job in well under 1 minute.
- [ ] Audit job still flags advisories correctly (will be exercised once Cargo.lock has real dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
