### PR TITLE
Add CI aggregator gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,24 @@ jobs:
           tool: cargo-audit
       - if: steps.detect.outputs.has_lock == 'true'
         run: cargo audit
+
+  # Aggregator gate: branch protection targets this single check instead of
+  # each upstream job. Add new jobs to `needs:` as they land (e.g. typos, #6).
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [fmt, clippy, test, deny, audit]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "Some jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed"


### PR DESCRIPTION
## Summary

Adds a single `ci-success` aggregator job to `.github/workflows/ci.yml` that depends on the 5 existing CI jobs (`fmt`, `clippy`, `test`, `deny`, `audit`) and fails if any of them failed or were cancelled. Branch protection can now target this one check instead of each upstream job individually.

Pattern ported from sibling repo [`cacack/gedcom-go`](https://github.com/cacack/gedcom-go/blob/main/.github/workflows/ci.yml). Uses `if: always()` so the gate still reports out when upstream jobs fail/cancel.

`typos` is intentionally deferred — issue #6 will add it to the `needs:` list when that check lands.

## Follow-up (not in this PR)

After merge, update branch protection settings to require only **CI Success** and drop the individual job requirements. This is a GitHub settings change, not a code change.

## Test plan

- [ ] New `CI Success` check appears on this PR
- [ ] Turns green once the 5 upstream jobs pass
- [ ] Post-merge: update branch protection to require only this check

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)