### PR TITLE
Add typos spellcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,20 @@ jobs:
       - if: steps.detect.outputs.has_lock == 'true'
         run: cargo audit
 
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
+
   # Aggregator gate: branch protection targets this single check instead of
-  # each upstream job. Add new jobs to `needs:` as they land (e.g. typos, #6).
+  # each upstream job. Add new jobs to `needs:` as they land.
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [fmt, clippy, test, deny, audit]
+    needs: [fmt, clippy, test, deny, audit, typos]
     if: always()
     steps:
       - name: Check all jobs passed


### PR DESCRIPTION
## Summary
- Adds a `typos` job to `.github/workflows/ci.yml` using [`crate-ci/typos`](https://github.com/crate-ci/typos) pinned to v1.45.1 (`cf5f1c2…`)
- Wires the new job into the `ci-success` aggregator so branch protection picks it up automatically
- Removes the now-stale "(e.g. typos, #6)" hint from the aggregator comment

Typos is a high-signal check for a tool whose primary output *is* rendered text — resume typos are embarrassing in a way the tool's own output should defend against.

Closes #6

## Test plan
- [ ] `typos` job runs and passes on this PR
- [ ] `CI Success` aggregator waits on `typos` before reporting green
- [x] Local `typos` run is clean (verified: exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
