### PR TITLE
Bundle JSON Resume v1.0.0 schema in the binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /dist
 Cargo.lock.bak
+.prompts
 
 # Added by ggshield
 .cache_ggshield

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,101 @@ version = 4
 [[package]]
 name = "ferrocv"
 version = "0.0.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ repository = "https://github.com/cacack/ferrocv"
 readme = "README.md"
 keywords = ["resume", "cv", "json-resume", "typst", "pdf"]
 categories = ["command-line-utilities"]
+include = [
+    "src/**/*",
+    "assets/schema/**/*",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE-*",
+]
 
 [lib]
 name = "ferrocv"
@@ -19,3 +26,6 @@ name = "ferrocv"
 path = "src/main.rs"
 
 [dependencies]
+
+[dev-dependencies]
+serde_json = "1"

--- a/assets/schema/SOURCE.md
+++ b/assets/schema/SOURCE.md
@@ -1,0 +1,13 @@
+# JSON Resume schema provenance
+
+| Field | Value |
+| --- | --- |
+| Upstream URL | <https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json> |
+| Git tag | `v1.0.0` |
+| Commit SHA | `7095651fbbb593d2c5dc2db3095412b170d74d2e` |
+| Retrieved on | 2026-04-18 |
+
+Bumping the embedded schema is an intentional release action that requires
+constitutional-style review (see issue #9 rationale and `CONSTITUTION.md`
+sections 5 and 6.1): `ferrocv` makes no network calls at validate or render
+time, so the schema is frozen per release rather than fetched live.

--- a/assets/schema/jsonresume-v1.0.0.json
+++ b/assets/schema/jsonresume-v1.0.0.json
@@ -1,0 +1,500 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "iso8601": {
+      "type": "string",
+      "description": "e.g. 2014-06-29",
+      "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "link to the version of the schema that can validate the resume",
+      "format": "uri"
+    },
+    "basics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "e.g. Web Developer"
+        },
+        "image": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+        },
+        "email": {
+          "type": "string",
+          "description": "e.g. thomas@gmail.com",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string",
+          "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+          "format": "uri"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Write a short 2-3 sentence biography about yourself"
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+            },
+            "postalCode": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+            },
+            "region": {
+              "type": "string",
+              "description": "The general region where you live. Can be a US state, or a province, for instance."
+            }
+          }
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Specify any number of social networks that you participate in",
+          "additionalItems": false,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "network": {
+                "type": "string",
+                "description": "e.g. Facebook or Twitter"
+              },
+              "username": {
+                "type": "string",
+                "description": "e.g. neutralthoughts"
+              },
+              "url": {
+                "type": "string",
+                "description": "e.g. http://twitter.example.com/neutralthoughts",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    },
+    "work": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "location": {
+            "type": "string",
+            "description": "e.g. Menlo Park, CA"
+          },
+          "description": {
+            "type": "string",
+            "description": "e.g. Social Media Company"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "volunteer": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify accomplishments and achievements",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "education": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "institution": {
+            "type": "string",
+            "description": "e.g. Massachusetts Institute of Technology"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "area": {
+            "type": "string",
+            "description": "e.g. Arts"
+          },
+          "studyType": {
+            "type": "string",
+            "description": "e.g. Bachelor"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "score": {
+            "type": "string",
+            "description": "grade point average, e.g. 3.67/4.0"
+          },
+          "courses": {
+            "type": "array",
+            "description": "List notable courses/subjects",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. H1302 - Introduction to American history"
+            }
+          }
+        }
+      }
+    },
+    "awards": {
+      "type": "array",
+      "description": "Specify any awards you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "e.g. One of the 100 greatest minds of the century"
+          },
+          "date": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "awarder": {
+            "type": "string",
+            "description": "e.g. Time Magazine"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Received for my work with Quantum Physics"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "type": "array",
+      "description": "Specify any certificates you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Certified Kubernetes Administrator"
+          },
+          "date": {
+            "type": "string",
+            "description": "e.g. 1989-06-12",
+            "format": "date"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://example.com",
+            "format": "uri"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "e.g. CNCF"
+          }
+        }
+      }
+    },
+    "publications": {
+      "type": "array",
+      "description": "Specify your publications through your career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "e.g. IEEE, Computer Magazine"
+          },
+          "releaseDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html",
+            "format": "uri"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "List out your professional skill-set",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Web Development"
+          },
+          "level": {
+            "type": "string",
+            "description": "e.g. Master"
+          },
+          "keywords": {
+            "type": "array",
+            "description": "List some keywords pertaining to this skill",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. HTML"
+            }
+          }
+        }
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "List any other languages you speak",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "e.g. English, Spanish"
+          },
+          "fluency": {
+            "type": "string",
+            "description": "e.g. Fluent, Beginner"
+          }
+        }
+      }
+    },
+    "interests": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Philosophy"
+          },
+          "keywords": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Friedrich Nietzsche"
+            }
+          }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "List references you have received",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Timothy Cook"
+          },
+          "reference": {
+            "type": "string",
+            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+          }
+        }
+      }
+    },
+    "projects": {
+      "type": "array",
+      "description": "Specify career projects",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short summary of project. e.g. Collated works of 2017."
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple features",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Directs you close but not quite there"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "Specify special elements involved",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. AngularJS"
+            }
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Specify your role on this project or in company",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Team Lead, Speaker, Writer"
+            }
+          },
+          "entity": {
+            "type": "string",
+            "description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+          },
+          "type": {
+            "type": "string",
+            "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "The schema version and any other tooling configuration lives here",
+      "additionalProperties": true,
+      "properties": {
+        "canonical": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to latest version of this document",
+          "format": "uri"
+        },
+        "version": {
+          "type": "string",
+          "description": "A version field which follows semver - e.g. v1.0.0"
+        },
+        "lastModified": {
+          "type": "string",
+          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+        }
+      }
+    }
+  },
+  "title": "Resume Schema",
+  "type": "object"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,16 @@
 //! `ferrocv` renders JSON Resume documents to PDF, HTML, and plain text
 //! via embedded Typst. See `CONSTITUTION.md` for design principles.
+
+/// JSON Resume v1.0.0 schema, embedded at compile time.
+///
+/// Per `CONSTITUTION.md` section 6.1, `ferrocv` makes no network calls at
+/// render or validate time. The schema is vendored under `assets/schema/`
+/// and frozen per release; bumping it is an intentional release action.
+pub const JSON_RESUME_SCHEMA: &str = include_str!("../assets/schema/jsonresume-v1.0.0.json");
+
+/// Version of the embedded JSON Resume schema (see [`JSON_RESUME_SCHEMA`]).
+///
+/// Pinned at compile time alongside the schema bytes. See
+/// `CONSTITUTION.md` section 6.1 for the no-network commitment that this
+/// embedding upholds.
+pub const JSON_RESUME_SCHEMA_VERSION: &str = "1.0.0";

--- a/tests/schema_embedding.rs
+++ b/tests/schema_embedding.rs
@@ -1,0 +1,38 @@
+//! Sanity checks that the JSON Resume schema is correctly embedded at
+//! compile time. These tests deliberately do not compile the file as a
+//! JSON Schema; that is the job of issue #10 (`ferrocv validate`).
+
+use ferrocv::{JSON_RESUME_SCHEMA, JSON_RESUME_SCHEMA_VERSION};
+
+#[test]
+fn schema_is_non_empty() {
+    assert!(
+        !JSON_RESUME_SCHEMA.is_empty(),
+        "embedded JSON Resume schema must not be empty",
+    );
+}
+
+#[test]
+fn schema_parses_as_json() {
+    serde_json::from_str::<serde_json::Value>(JSON_RESUME_SCHEMA)
+        .expect("embedded JSON Resume schema must parse as JSON");
+}
+
+#[test]
+fn schema_has_expected_basics_section() {
+    let value: serde_json::Value = serde_json::from_str(JSON_RESUME_SCHEMA)
+        .expect("embedded JSON Resume schema must parse as JSON");
+    let basics = value
+        .get("properties")
+        .and_then(|properties| properties.get("basics"))
+        .expect("schema must define properties.basics");
+    assert!(
+        basics.is_object(),
+        "properties.basics must be a JSON object, got: {basics}",
+    );
+}
+
+#[test]
+fn version_constant_matches_expected() {
+    assert_eq!(JSON_RESUME_SCHEMA_VERSION, "1.0.0");
+}


### PR DESCRIPTION
## Summary

- Vendors the JSON Resume v1.0.0 schema under `assets/schema/` (upstream tag `v1.0.0`, commit `7095651fbbb593d2c5dc2db3095412b170d74d2e`) and ships it in the published crate via `Cargo.toml` `include`.
- Exposes `ferrocv::JSON_RESUME_SCHEMA` and `ferrocv::JSON_RESUME_SCHEMA_VERSION` as `pub const`s, embedded with `include_str!`. No runtime network access — per Constitution §6.1.
- Adds a four-case sanity test (`tests/schema_embedding.rs`) covering non-emptiness, JSON parseability, presence of `properties.basics`, and the version constant. `serde_json` lives only under `[dev-dependencies]`; no runtime deps added — issue #10 (`ferrocv validate`) will pick the validation library.
- Drive-by `chore`: ignore the local `.prompts/` scratch directory used by the cacack workflow.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — all 4 sanity tests pass
- [x] `cargo package --list` includes `assets/schema/jsonresume-v1.0.0.json` and `assets/schema/SOURCE.md`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)