### PR TITLE
Implement ferrocv validate subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,448 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "ferrocv"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "jsonschema",
+ "predicates",
  "serde_json",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -16,10 +453,251 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -40,12 +718,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom",
+ "hashbrown",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -82,6 +854,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,10 +883,264 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,23 @@ name = "ferrocv"
 path = "src/main.rs"
 
 [dependencies]
+# CLI argument parsing. Derive API keeps the surface declarative.
+clap = { version = "4", features = ["derive"] }
+# JSON Schema validator. Default features pull in `reqwest` for remote
+# `$ref` resolution; we disable them to uphold CONSTITUTION.md §6
+# (no network calls at validate time) since our schema is vendored
+# and self-contained.
+jsonschema = { version = "0.46", default-features = false }
+# CLI-layer error propagation. Library code stays anyhow-free.
+anyhow = "1"
+serde_json = "1"
 
 [dev-dependencies]
 serde_json = "1"
+# Spawn the built `ferrocv` binary in integration tests to exercise real
+# CLI surface (exit codes, stdout/stderr, stdin). Dev-only — must not
+# leak into the shipped binary.
+assert_cmd = "2"
+# Readable substring / predicate assertions on captured stdout/stderr.
+# Paired with assert_cmd.
+predicates = "3"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ schema and replaces the rendering pipeline with something more robust:
 - Define a native theme contract so new themes can target JSON Resume
   directly.
 
+## Usage
+
+The only subcommand available today is `validate`, which checks a
+document against the bundled JSON Resume v1.0.0 schema. Exits `0` on
+valid input, `1` on schema violations (diagnostics on stderr), and `2`
+on IO or JSON parse errors.
+
+```sh
+# From a file
+ferrocv validate resume.json
+
+# From stdin
+cat resume.json | ferrocv validate
+```
+
+No network is touched — the schema is compiled into the binary.
+
 ## Non-goals
 
 - Replacing the JSON Resume schema or project.

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,9 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
+    # MIT-0 is MIT No Attribution; required by `borrow-or-share`
+    # (transitive: jsonschema -> referencing -> fluent-uri -> borrow-or-share).
+    "MIT-0",
     "MPL-2.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,84 @@
+//! Command-line interface for `ferrocv`.
+//!
+//! This module owns argument parsing (via `clap`), input acquisition
+//! (file or stdin), and exit-code handling. The library in
+//! [`crate::validate`] stays CLI-free so it can be reused by tests and
+//! future embedders.
+//!
+//! Exit codes (contractual):
+//! - `0` — document validates against JSON Resume v1.0.0
+//! - `1` — document parsed as JSON but failed schema validation
+//! - `2` — usage error, IO error, or malformed JSON
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use serde_json::Value;
+
+use crate::validate_value;
+
+/// Render JSON Resume documents via embedded Typst.
+#[derive(Debug, Parser)]
+#[command(name = "ferrocv", version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Validate a JSON Resume document against the bundled schema.
+    ///
+    /// Reads from PATH if given, otherwise from stdin. Exits 0 on
+    /// valid input, 1 on schema violations (diagnostics on stderr),
+    /// and 2 on IO or parse errors.
+    Validate {
+        /// Path to a JSON Resume document. Reads stdin if omitted.
+        path: Option<PathBuf>,
+    },
+}
+
+/// Entry point invoked from `main`.
+///
+/// Returns an `ExitCode` rather than calling `std::process::exit` so
+/// destructors run normally.
+pub fn run() -> Result<ExitCode> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Validate { path } => run_validate(path.as_deref()),
+    }
+}
+
+fn run_validate(path: Option<&std::path::Path>) -> Result<ExitCode> {
+    // Step 1: read input. IO failures are exit code 2.
+    let input =
+        match path {
+            Some(p) => std::fs::read_to_string(p)
+                .with_context(|| format!("failed to read {}", p.display()))?,
+            None => std::io::read_to_string(std::io::stdin())
+                .context("failed to read JSON from stdin")?,
+        };
+
+    // Step 2: parse JSON. Parse failures are exit code 2 and print a
+    // single `error: ...` line to stderr rather than a validation list.
+    let value: Value = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return Ok(ExitCode::from(2));
+        }
+    };
+
+    // Step 3: validate. On failure, one diagnostic per error to stderr.
+    match validate_value(&value) {
+        Ok(()) => Ok(ExitCode::SUCCESS),
+        Err(errors) => {
+            for err in errors {
+                eprintln!("{err}");
+            }
+            Ok(ExitCode::from(1))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 //! `ferrocv` renders JSON Resume documents to PDF, HTML, and plain text
 //! via embedded Typst. See `CONSTITUTION.md` for design principles.
 
+pub mod cli;
+pub mod validate;
+
+pub use validate::{ValidationError, validate_value};
+
 /// JSON Resume v1.0.0 schema, embedded at compile time.
 ///
 /// Per `CONSTITUTION.md` section 6.1, `ferrocv` makes no network calls at

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
-fn main() {
-    println!("ferrocv {}", env!("CARGO_PKG_VERSION"));
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    ferrocv::cli::run().unwrap_or_else(|err| {
+        eprintln!("error: {err:#}");
+        ExitCode::from(2)
+    })
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,113 @@
+//! JSON Resume schema validation.
+//!
+//! Validates `serde_json::Value` inputs against the embedded JSON Resume
+//! v1.0.0 schema (see [`crate::JSON_RESUME_SCHEMA`]). Per
+//! `CONSTITUTION.md` §6.1, no network calls happen here: the schema is
+//! compiled once from the in-binary string constant and cached for the
+//! lifetime of the process.
+//!
+//! This module is library-only. It does not know about stdin, files,
+//! exit codes, or clap — those concerns live in `crate::cli`.
+//!
+//! # Example
+//!
+//! ```
+//! use serde_json::json;
+//!
+//! let doc = json!({ "basics": { "name": "Ada Lovelace" } });
+//! assert!(ferrocv::validate_value(&doc).is_ok());
+//! ```
+use std::fmt;
+use std::sync::OnceLock;
+
+use jsonschema::Validator;
+use serde_json::Value;
+
+use crate::JSON_RESUME_SCHEMA;
+
+/// A single JSON Resume schema validation failure.
+///
+/// `path` is a JSON Pointer (RFC 6901) to the failing instance location,
+/// or the empty string for a root-level error. `message` is the
+/// human-readable diagnostic produced by the underlying validator.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError {
+    /// JSON Pointer to the failing location, or empty for the root.
+    pub path: String,
+    /// Human-readable error message.
+    pub message: String,
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Format: "<path>: <message>". The empty-path case still emits
+        // the leading colon so diagnostics have a consistent shape that
+        // tooling can parse without special-casing the root.
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Validate `value` against the embedded JSON Resume v1.0.0 schema.
+///
+/// Returns `Ok(())` on success. On failure, returns `Err` with at least
+/// one [`ValidationError`]; order matches the underlying validator's
+/// iteration order and is not otherwise sorted or de-duplicated.
+///
+/// The compiled schema validator is cached in a process-wide
+/// [`OnceLock`]; the first call pays the compile cost, subsequent calls
+/// are cheap.
+///
+/// # Panics
+///
+/// Panics only if the embedded schema itself fails to parse or compile,
+/// which would indicate a build-time bug (the schema is frozen in the
+/// binary per `CONSTITUTION.md` §6.1). A schema-embedding regression
+/// test in `tests/` guards this.
+pub fn validate_value(value: &Value) -> Result<(), Vec<ValidationError>> {
+    let validator = compiled_validator();
+
+    // Fast path: avoid collecting errors when the document is valid.
+    if validator.is_valid(value) {
+        return Ok(());
+    }
+
+    let errors: Vec<ValidationError> = validator
+        .iter_errors(value)
+        .map(|err| ValidationError {
+            path: err.instance_path().as_str().to_owned(),
+            message: err.to_string(),
+        })
+        .collect();
+
+    // Defensive: if the document is invalid, iter_errors must yield at
+    // least one error. If this invariant is ever violated (e.g. by an
+    // upstream bug), surface a synthetic diagnostic rather than
+    // silently returning Ok.
+    if errors.is_empty() {
+        return Err(vec![ValidationError {
+            path: String::new(),
+            message: "document failed validation but no errors were reported".to_owned(),
+        }]);
+    }
+
+    Err(errors)
+}
+
+/// Return the cached validator, compiling it on first use.
+fn compiled_validator() -> &'static Validator {
+    static VALIDATOR: OnceLock<Validator> = OnceLock::new();
+    VALIDATOR.get_or_init(|| {
+        let schema: Value = serde_json::from_str(JSON_RESUME_SCHEMA)
+            .expect("embedded JSON Resume schema must parse as JSON");
+        // JSON Resume v1.0.0 declares `$schema: draft-04`. We pin to
+        // draft 4 explicitly and enable format validation so things
+        // like `format: email` / `format: uri` / `format: date` are
+        // actually checked rather than treated as annotations.
+        jsonschema::draft4::options()
+            .should_validate_formats(true)
+            .build(&schema)
+            .expect("embedded JSON Resume schema must compile as a draft-04 schema")
+    })
+}

--- a/tests/fixtures/invalid_array_item_type.json
+++ b/tests/fixtures/invalid_array_item_type.json
@@ -1,0 +1,11 @@
+{
+  "basics": {
+    "name": "Ada Lovelace"
+  },
+  "skills": [
+    {
+      "name": "Programming",
+      "keywords": "should-be-an-array"
+    }
+  ]
+}

--- a/tests/fixtures/invalid_bad_date_format.json
+++ b/tests/fixtures/invalid_bad_date_format.json
@@ -1,0 +1,11 @@
+{
+  "basics": {
+    "name": "Ada Lovelace"
+  },
+  "work": [
+    {
+      "name": "Analytical Engines Ltd",
+      "startDate": "not-a-date"
+    }
+  ]
+}

--- a/tests/fixtures/invalid_bad_email_format.json
+++ b/tests/fixtures/invalid_bad_email_format.json
@@ -1,0 +1,6 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "email": "not-an-email"
+  }
+}

--- a/tests/fixtures/invalid_bad_url_format.json
+++ b/tests/fixtures/invalid_bad_url_format.json
@@ -1,0 +1,6 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "url": "not a url"
+  }
+}

--- a/tests/fixtures/invalid_nested_wrong_type.json
+++ b/tests/fixtures/invalid_nested_wrong_type.json
@@ -1,0 +1,10 @@
+{
+  "basics": {
+    "name": "Ada Lovelace"
+  },
+  "work": [
+    {
+      "name": 42
+    }
+  ]
+}

--- a/tests/fixtures/invalid_wrong_type_email.json
+++ b/tests/fixtures/invalid_wrong_type_email.json
@@ -1,0 +1,6 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "email": 12345
+  }
+}

--- a/tests/fixtures/malformed.json
+++ b/tests/fixtures/malformed.json
@@ -1,0 +1,1 @@
+{not valid json}

--- a/tests/fixtures/valid_full.json
+++ b/tests/fixtures/valid_full.json
@@ -1,0 +1,40 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "url": "https://example.com/ada",
+    "location": {
+      "city": "London",
+      "countryCode": "GB"
+    },
+    "profiles": [
+      {
+        "network": "GitHub",
+        "username": "ada",
+        "url": "https://github.example.com/ada"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Analytical Engines Ltd",
+      "position": "Programmer",
+      "startDate": "1843-01-01",
+      "endDate": "1852-11-27"
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of London",
+      "area": "Mathematics",
+      "studyType": "Self-directed"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Programming",
+      "level": "Pioneer",
+      "keywords": ["Analytical Engine", "Algorithms"]
+    }
+  ]
+}

--- a/tests/fixtures/valid_minimal.json
+++ b/tests/fixtures/valid_minimal.json
@@ -1,0 +1,6 @@
+{
+  "basics": {
+    "name": "Ada Lovelace"
+  },
+  "work": []
+}

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -1,0 +1,115 @@
+//! Scenario-style black-box tests for the `ferrocv validate` subcommand.
+//!
+//! These tests spawn the real built binary via `assert_cmd` and assert
+//! on observable behavior only: exit code, stdout, stderr. They do not
+//! call into the library API — see `validate_unit.rs` for that.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #1, every CLI-visible
+//! behavior gets a scenario test. The exit-code contract under test:
+//! 0 = valid, 1 = schema-invalid, 2 = IO / parse error.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Absolute path to a fixture file by filename stem (no extension).
+fn fixture(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(format!("{name}.json"));
+    path
+}
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
+}
+
+#[test]
+fn validate_accepts_minimal_resume() {
+    ferrocv()
+        .arg("validate")
+        .arg(fixture("valid_minimal"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn validate_accepts_full_resume() {
+    ferrocv()
+        .arg("validate")
+        .arg(fixture("valid_full"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn validate_rejects_wrong_type_email() {
+    ferrocv()
+        .arg("validate")
+        .arg(fixture("invalid_wrong_type_email"))
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("/basics/email"));
+}
+
+#[test]
+fn validate_reports_parse_error_with_exit_code_two() {
+    ferrocv()
+        .arg("validate")
+        .arg(fixture("malformed"))
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        // The parse diagnostic comes from serde_json; we only assert
+        // that the error-prefixed line is present and mentions either
+        // "line" (serde_json's default wording) or "column" so the
+        // test survives minor upstream wording changes.
+        .stderr(predicate::str::contains("error:"))
+        .stderr(predicate::str::contains("line").or(predicate::str::contains("column")));
+}
+
+#[test]
+fn validate_reports_missing_file_with_exit_code_two() {
+    let missing = "/nonexistent/path/that/does/not/exist.json";
+    ferrocv()
+        .arg("validate")
+        .arg(missing)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(missing));
+}
+
+#[test]
+fn validate_accepts_valid_json_on_stdin() {
+    let input = std::fs::read_to_string(fixture("valid_minimal"))
+        .expect("fixture `valid_minimal.json` must be readable");
+    ferrocv()
+        .arg("validate")
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn validate_rejects_invalid_json_on_stdin() {
+    let input = std::fs::read_to_string(fixture("invalid_bad_email_format"))
+        .expect("fixture `invalid_bad_email_format.json` must be readable");
+    ferrocv()
+        .arg("validate")
+        .write_stdin(input)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("/basics/email"));
+}

--- a/tests/validate_unit.rs
+++ b/tests/validate_unit.rs
@@ -1,0 +1,151 @@
+//! Negative unit tests for the `ferrocv::validate_value` library API.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #3, every class of invalid
+//! input we claim to catch has a dedicated test asserting (a) we reject
+//! it and (b) the diagnostic is useful — i.e. it carries the JSON
+//! Pointer to the offending location and a non-empty message.
+//!
+//! These tests call the public library API directly, bypassing the
+//! CLI. They do not assert on exact `jsonschema` error strings (those
+//! change across crate versions); they use substring checks.
+
+use std::path::PathBuf;
+
+use ferrocv::{ValidationError, validate_value};
+use serde_json::Value;
+
+/// Load and parse a fixture JSON file by filename stem.
+fn load_fixture(name: &str) -> Value {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(format!("{name}.json"));
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("fixture {name}.json must be readable: {err}"));
+    serde_json::from_str(&text)
+        .unwrap_or_else(|err| panic!("fixture {name}.json must parse as JSON: {err}"))
+}
+
+/// Assert that `validate_value` rejects `fixture_name` and at least one
+/// reported `ValidationError` has `path == expected_path`. Returns the
+/// matching error so callers can make further assertions on it.
+fn expect_error_at(fixture_name: &str, expected_path: &str) -> ValidationError {
+    let value = load_fixture(fixture_name);
+    let errors = match validate_value(&value) {
+        Ok(()) => panic!("expected fixture {fixture_name} to fail validation but it was accepted"),
+        Err(e) => e,
+    };
+    assert!(
+        !errors.is_empty(),
+        "validate_value returned Err with empty error list for {fixture_name}",
+    );
+    errors
+        .iter()
+        .find(|e| e.path == expected_path)
+        .cloned()
+        .unwrap_or_else(|| {
+            let paths: Vec<&str> = errors.iter().map(|e| e.path.as_str()).collect();
+            panic!("no error at path `{expected_path}` for {fixture_name}; got paths: {paths:?}")
+        })
+}
+
+/// Assert the Display output is non-empty and contains at least the
+/// JSON pointer path (so diagnostic consumers can locate the error).
+fn assert_display_useful(err: &ValidationError) {
+    let rendered = err.to_string();
+    assert!(
+        !rendered.is_empty(),
+        "ValidationError Display must not be empty",
+    );
+    assert!(
+        rendered.contains(&err.path),
+        "ValidationError Display `{rendered}` must contain its path `{}`",
+        err.path,
+    );
+    assert!(
+        !err.message.is_empty(),
+        "ValidationError message must not be empty (path {})",
+        err.path,
+    );
+}
+
+#[test]
+fn wrong_type_email_is_reported_at_basics_email() {
+    let err = expect_error_at("invalid_wrong_type_email", "/basics/email");
+    assert_display_useful(&err);
+    // Schema keyword that fails here is `type`. Message should mention
+    // the offending value (12345) or the expected type ("string").
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("string") || rendered.contains("12345"),
+        "expected diagnostic to mention expected type or offending value; got: {rendered}",
+    );
+}
+
+#[test]
+fn bad_email_format_is_reported_at_basics_email() {
+    let err = expect_error_at("invalid_bad_email_format", "/basics/email");
+    assert_display_useful(&err);
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("email") || rendered.contains("not-an-email"),
+        "expected diagnostic to mention `email` format or offending value; got: {rendered}",
+    );
+}
+
+#[test]
+fn bad_url_format_is_reported_at_basics_url() {
+    let err = expect_error_at("invalid_bad_url_format", "/basics/url");
+    assert_display_useful(&err);
+    let rendered = err.to_string();
+    // The schema uses format: "uri"; the jsonschema message echoes that
+    // keyword or the offending value.
+    assert!(
+        rendered.contains("uri") || rendered.contains("not a url"),
+        "expected diagnostic to mention `uri` format or offending value; got: {rendered}",
+    );
+}
+
+#[test]
+fn bad_date_format_is_reported_at_work_start_date() {
+    let err = expect_error_at("invalid_bad_date_format", "/work/0/startDate");
+    assert_display_useful(&err);
+    let rendered = err.to_string();
+    // iso8601 is enforced via `pattern`; messages usually mention
+    // "pattern" or echo the bad value.
+    assert!(
+        rendered.contains("pattern")
+            || rendered.contains("match")
+            || rendered.contains("not-a-date"),
+        "expected diagnostic to mention pattern failure or offending value; got: {rendered}",
+    );
+}
+
+#[test]
+fn array_item_type_is_reported_at_skills_keywords() {
+    let err = expect_error_at("invalid_array_item_type", "/skills/0/keywords");
+    assert_display_useful(&err);
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("array") || rendered.contains("should-be-an-array"),
+        "expected diagnostic to mention array type or offending value; got: {rendered}",
+    );
+}
+
+#[test]
+fn nested_wrong_type_is_reported_at_work_name() {
+    let err = expect_error_at("invalid_nested_wrong_type", "/work/0/name");
+    assert_display_useful(&err);
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("string") || rendered.contains("42"),
+        "expected diagnostic to mention expected type or offending value; got: {rendered}",
+    );
+    // Sanity: the path must traverse through a numeric array index, so
+    // consumers can locate the failing entry in a multi-entry `work`.
+    assert!(
+        err.path.starts_with("/work/0/"),
+        "path `{}` must anchor at `/work/0/`",
+        err.path,
+    );
+}


### PR DESCRIPTION
## Summary

Implements the first user-facing CLI feature: `ferrocv validate [PATH]`, which validates a JSON Resume document against the bundled v1.0.0 schema and exits 0 / 1 / 2 for valid / invalid / IO-or-parse-error. Reads from stdin when no path is given. Diagnostics print to stderr as `<json-pointer>: <message>`.

- Library in `src/validate.rs` exposes `ValidationError` and `validate_value`; CLI in `src/cli.rs` wires up the subcommand via `clap`. The library stays CLI-free (no `clap` / `anyhow` / `std::process`).
- Uses the `jsonschema` crate (0.46, `default-features = false` to drop the reqwest/TLS stack) with draft-04 format validation enabled. Schema comes from the embedded `JSON_RESUME_SCHEMA` constant — no runtime fetch.
- Negative tests cover every class of invalid input the subcommand claims to catch (Testing doctrine §3): wrong scalar type, bad email/uri/date format, wrong array-item type, nested type error. Plus 7 scenario-style CLI tests via `assert_cmd`.
- `deny.toml`: `MIT-0` added for `borrow-or-share` (transitive via `jsonschema` → `referencing` → `fluent-uri`).

Closes #10.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 18 tests passing (7 CLI + 6 unit + 4 schema-embedding + 1 doctest), none ignored
- [x] `cargo deny check` — advisories / bans / licenses / sources all OK
- [x] Manual smoke test — exit codes 0 / 1 / 2 / 2 for valid / invalid / nonexistent / malformed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
