### PR TITLE
Publish to crates.io on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,16 @@ jobs:
           archive: $bin-$target
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
+        with:
+          toolchain: stable
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `publish` job to `.github/workflows/release.yml` that runs `cargo publish` after the binary build matrix succeeds on a `v*` tag push.
- Rescopes issue #3 from manual name reservation to automated publishing; the first tagged release claims the `ferrocv` name on crates.io as a side effect.

## Prerequisites (user action, outside this PR)

- [ ] **Enable** "Allow GitHub Actions to create and approve pull requests" — Settings → Actions → General. Release-please is currently failing on every push to `main` because of this setting; enabling it will let it open its first release PR.
- [ ] **Add** repo secret `CARGO_REGISTRY_TOKEN` (Settings → Secrets and variables → Actions). Token from <https://crates.io/settings/tokens> — scope to publish-new + publish-update for `ferrocv`.

## Flow once merged

1. Repo setting + secret added (steps above).
2. Any push to `main` triggers release-please → opens a release PR bumping `0.0.0` → `0.0.1` and generating `CHANGELOG.md`.
3. Merging that release PR cuts tag `v0.0.1` → `release.yml` fires → binaries built → `cargo publish` claims the name.

## Out of scope

npm / PyPI / Go Packages name reservations — `ferrocv` is Rust-only and the cross-ecosystem squatting concern doesn't justify the ongoing multi-registry maintenance.

## Test plan

- [ ] `cargo publish --dry-run` locally (verified — passes)
- [ ] Workflow file parses (no syntax errors surfaced on merge)
- [ ] After merge, watch release-please workflow succeed and open a release PR
- [ ] Merge release PR, watch `release.yml` complete both `build` and `publish` jobs

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
