### PR TITLE
CI test matrix across OS and MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,23 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
-    name: cargo test
-    runs-on: ubuntu-latest
+    name: cargo test (${{ matrix.os }}, ${{ matrix.rust }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # MSRV mirrors Cargo.toml `rust-version`. Bump both together.
+        rust: [stable, "1.85"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: detect
+        shell: bash
         run: echo "has_cargo=$([ -f Cargo.toml ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
       - if: steps.detect.outputs.has_cargo == 'true'
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
       - if: steps.detect.outputs.has_cargo == 'true'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - if: steps.detect.outputs.has_cargo == 'true'


### PR DESCRIPTION
## Summary

- Expands the CI `test` job to a matrix of `{ubuntu-latest, macos-latest, windows-latest} × {stable, 1.85}` (6 shards, `fail-fast: false`).
- MSRV value mirrors `Cargo.toml`'s `rust-version`; inline comment flags the invariant.
- `fmt`, `clippy`, `deny`, `audit`, `typos` stay single-shard on ubuntu+stable (platform/toolchain-invariant). `ci-success` aggregator waits for all matrix shards via its existing `needs:` entry — no wiring change.
- `detect` step gets `shell: bash` so its POSIX syntax works on `windows-latest`.

Rationale: ferrocv ships release binaries for Linux/macOS/Windows and will embed Typst (platform-specific font/PDF quirks). Single-OS CI is a lie against that release surface.

Closes #5

## Test plan
- [x] `make preflight` passes locally (fmt-check, clippy, test, deny, audit, typos).
- [x] YAML parses; exactly one `strategy:` block in the file.
- [x] Action SHA pins unchanged; `ci-success.needs` byte-identical.
- [ ] CI: verify 6 `test (<os>, <rust>)` shards appear in Checks and `ci-success` gates on all of them.
- [ ] CI: confirm `rust-cache` keys per-(os, toolchain) without collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
