### PR TITLE
Bump feat to minor pre-1.0 in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Remove `bump-patch-for-minor-pre-major` from release-please config so `feat:` commits bump the minor version while pre-1.0 (0.1.0 → 0.2.0) rather than patch.
- Treats the entire 0.x.x range as pre-stable, where `feat` → minor and `feat!` → minor match expected semver shape pre-1.0.

## Test plan
- [ ] Next release-please PR after a `feat:` commit lands bumps minor (e.g. 0.1.0 → 0.2.0) rather than patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)