### PR TITLE
Move Phase 2 open questions from TODO.md to tracking issues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,6 @@ out, delete it.
 
 ## Open questions
 
-- [ ] Confirm Typst HTML export maturity at the time of implementation
-      (blocker on the Phase 2 HTML output issue).
-- [ ] DOCX strategy — drop entirely, or keep an HTML→pandoc fallback?
-      Revisit as part of Phase 2 planning.
 - [ ] How should renderer filter flags interact with themes — preprocess
       JSON in Rust before handing to the theme, or pass as theme
       parameters? Probably preprocess (keeps themes simple), but worth


### PR DESCRIPTION
## Summary

Activating Phase 2 turned two `TODO.md` open questions into real tracking issues:

- Typst HTML export maturity check → now part of #44 (HTML output)
- DOCX strategy decision → now owned by #46 (ADR-deliverable)

Removing both bullets from `TODO.md` since that file only holds unresolved questions that don't yet have enough shape to become issues. These now do.

See #14 for the Phase 2 activation comment and full child-issue list.

## Test plan

- [x] No code changes; `TODO.md`-only edit
- [x] Remaining bullets still reference unresolved phases (Phase 5 filtering, library split, theme distribution, x-field handling)
