### PR TITLE
Accept schema-valid-but-sparse resumes in the typst-jsonresume-cv adapter

### DIFF
--- a/assets/themes/typst-jsonresume-cv/VENDORING.md
+++ b/assets/themes/typst-jsonresume-cv/VENDORING.md
@@ -35,9 +35,10 @@ preserved in-tree.
 
 ## Patches applied
 
-Two patches were applied to the upstream theme source to make it
-compile under `ferrocv::render::FerrocvWorld`. Both are recorded below
-with before/after snippets.
+Three patches were applied to the upstream theme source to make it
+compile under `ferrocv::render::FerrocvWorld` against arbitrary
+schema-valid JSON Resume documents. All three are recorded below with
+before/after snippets.
 
 ### 1. `base.typ`: remove `@preview/scienceicons` import
 
@@ -102,6 +103,92 @@ source (see the smoke tests in `tests/render.rs`).
 
 **Behavioral impact:** none — the theme reads the same JSON Resume
 fields from the same parsed structure. Only the lookup path changes.
+
+### 3. `resume.typ`: optional-field shim
+
+**Why:** JSON Resume v1.0.0 has zero required fields — the schema
+allows `{}` as a valid document — but the upstream template reads
+several fields directly (`r.meta.language`, `r.basics.location.city`,
+`r.basics.location.region`, `r.basics.email`, `r.basics.phone`) and
+dereferences the top-level `work`/`projects`/`education` arrays
+without an `in`-check. Any schema-valid document omitting one of
+those fields produces a Typst dictionary-lookup error at render time,
+directly conflicting with `CONSTITUTION.md` §1 ("JSON Resume is the
+canonical input, unmodified"). This patch wraps every such read in
+`.at(..., default: ...)` and guards the top-level section checks
+with `"<key>" in r` so that any schema-valid resume renders.
+
+**Before** (upstream shape):
+
+```typst
+#let getProfile(resume, network) = {
+  let profile = none
+  if "profiles" in resume.basics and resume.basics.profiles != none {
+    ...
+
+#let lang = r.meta.language
+#let name = r.basics.name
+#let address = r.basics.location.city + ", " + r.basics.location.region
+#let emailAddress = r.basics.email
+#let phoneNumber = r.basics.phone
+
+#if show_work and r.work != none and r.work.len() > 0 { ... }
+#if show_projects and r.projects != none and r.projects.len() > 0 { ... }
+#if show_education and r.education != none and r.education.len() > 0 { ... }
+```
+
+**After:**
+
+```typst
+#let getProfile(resume, network) = {
+  let profile = none
+  let basics = resume.at("basics", default: (:))
+  if "profiles" in basics and basics.profiles != none {
+    ...
+
+#let basics = r.at("basics", default: (:))
+#let meta = r.at("meta", default: (:))
+#let location = basics.at("location", default: (:))
+
+#let lang = meta.at("language", default: "en")
+#let name = basics.at("name", default: "")
+#let city = location.at("city", default: "")
+#let region = location.at("region", default: "")
+#let address = if city != "" and region != "" {
+  city + ", " + region
+} else if city != "" {
+  city
+} else {
+  region
+}
+#let emailAddress = basics.at("email", default: "")
+#let phoneNumber = basics.at("phone", default: "")
+
+#if show_work and "work" in r and r.work != none and r.work.len() > 0 { ... }
+#if show_projects and "projects" in r and r.projects != none and r.projects.len() > 0 { ... }
+#if show_education and "education" in r and r.education != none and r.education.len() > 0 { ... }
+```
+
+**Behavioral impact:** a full-field resume renders identically — the
+`render_theme` golden test confirms byte-for-byte stability of the
+extracted text against the committed `render_full.json` fixture.
+Sparse resumes that previously crashed now render with sensible
+defaults: missing language falls back to `"en"` (so the English
+section titles apply), missing contact fields produce empty strings
+(which `contact-item` already filters out of the contact line), and
+missing location components collapse (`city, region` → just `city`
+or just `region` or empty).
+
+**What the shim does not address:** fields inside work/education/
+projects/skills entries (`job.name`, `job.position`,
+`education_item.institution`, `education_item.studyType`,
+`education_item.area`, `skill.name`, `skill.keywords`, etc.) are
+still read unconditionally inside `base.typ`'s section builders.
+JSON Resume v1.0.0 treats these as optional, but in practice every
+realistic entry carries them. If a future bug report surfaces a
+schema-valid document that's sparse *inside* an entry, extend the
+shim (or fix it at the ferrocv Rust layer by normalizing the JSON
+before handing it to Typst) at that point.
 
 ## What was NOT patched
 

--- a/assets/themes/typst-jsonresume-cv/resume.typ
+++ b/assets/themes/typst-jsonresume-cv/resume.typ
@@ -2,16 +2,18 @@
 
 #let getProfile(resume, network) = {
   let profile = none
-
-  if "profiles" in resume.basics and resume.basics.profiles != none {
-    for p in resume.basics.profiles {
+  // ferrocv vendor patch: `basics` itself is optional per JSON Resume v1.0.0.
+  // See VENDORING.md ("optional-field shim").
+  let basics = resume.at("basics", default: (:))
+  if "profiles" in basics and basics.profiles != none {
+    for p in basics.profiles {
       if "network" in p and p.network == network {
         profile = p
         break
       }
     }
   }
-  
+
   profile
 }
 
@@ -20,12 +22,30 @@
 // build script copies the user's resume.json there). In ferrocv, the FerrocvWorld
 // serves the JSON Resume bytes at the virtual path "/resume.json". See VENDORING.md.
 #let r = json("/resume.json")
-#let lang = r.meta.language
-#let name = r.basics.name
-#let address = r.basics.location.city + ", " + r.basics.location.region
-#let emailAddress = r.basics.email
-#let phoneNumber = r.basics.phone
-#let website = r.basics.at("url", default:none) //Set to none if you want to hide it
+
+// ferrocv vendor patch (optional-field shim): JSON Resume v1.0.0 has zero
+// required fields, but upstream assumed `meta.language`, `basics.location.city`,
+// `basics.location.region`, `basics.email`, and `basics.phone` would always
+// be present. Each read is wrapped in `.at(..., default: ...)` so any
+// schema-valid document renders. See VENDORING.md.
+#let basics = r.at("basics", default: (:))
+#let meta = r.at("meta", default: (:))
+#let location = basics.at("location", default: (:))
+
+#let lang = meta.at("language", default: "en")
+#let name = basics.at("name", default: "")
+#let city = location.at("city", default: "")
+#let region = location.at("region", default: "")
+#let address = if city != "" and region != "" {
+  city + ", " + region
+} else if city != "" {
+  city
+} else {
+  region
+}
+#let emailAddress = basics.at("email", default: "")
+#let phoneNumber = basics.at("phone", default: "")
+#let website = basics.at("url", default: none) //Set to none if you want to hide it
 #let githubProfile = none
 #let linkedinProfile = none
 #if getProfile(r, "GitHub") != none {
@@ -62,15 +82,18 @@
 )
 
 // Section work experience
-#if show_work and r.work != none and r.work.len() > 0 {
+// ferrocv vendor patch (optional-field shim): top-level `work`/`projects`/
+// `education` keys are all optional per JSON Resume v1.0.0, so guard with
+// `in r` before reading.
+#if show_work and "work" in r and r.work != none and r.work.len() > 0 {
   work(work: r.work, lang: lang)
 }
 // Section projects
-#if show_projects and r.projects != none and r.projects.len() > 0 {
+#if show_projects and "projects" in r and r.projects != none and r.projects.len() > 0 {
   projects(projects: r.projects, lang: lang)
 }
 // Section education
-#if show_education and r.education != none and r.education.len() > 0 {
+#if show_education and "education" in r and r.education != none and r.education.len() > 0 {
   edu(education: r.education, lang: lang)
 }
 // Section certificates, skills and interests

--- a/tests/fixtures/render_sparse.json
+++ b/tests/fixtures/render_sparse.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Grace Hopper",
+    "label": "Computer Scientist",
+    "summary": "Rear admiral and pioneer of computer programming."
+  },
+  "work": [
+    {
+      "name": "US Navy",
+      "position": "Rear Admiral",
+      "startDate": "1944-07-01",
+      "highlights": [
+        "Worked on the Mark I computer at Harvard.",
+        "Developed the first compiler for a computer programming language."
+      ]
+    }
+  ]
+}

--- a/tests/goldens/typst-jsonresume-cv-sparse.txt
+++ b/tests/goldens/typst-jsonresume-cv-sparse.txt
@@ -1,0 +1,6 @@
+Grace Hopper
+
+WORK EXPERIENCE
+US Navy Jul 1944  —  Present
+Rear Admiral• Worked on the Mark I computer at Harvard.
+• Developed the first compiler for a computer programming language.

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -73,6 +73,43 @@ fn render_writes_pdf_to_output_path() {
     assert!(size > 1024, "PDF should be > 1 KiB, was {size} bytes");
 }
 
+/// Regression guard for CONSTITUTION §1 ("JSON Resume unmodified"): any
+/// resume that schema-validates must render, even if it omits optional
+/// fields the adapter's upstream template happens to reference.
+///
+/// `render_sparse.json` carries only `basics.name`, a brief `summary`,
+/// and one `work` entry — every other field is absent (no `meta`, no
+/// `basics.location`, no `basics.email`/`phone`, no `projects`, no
+/// `education`, no `skills`). JSON Resume v1.0.0 has zero required
+/// fields, so this is a valid document; the adapter must cope.
+#[test]
+fn render_accepts_sparse_schema_valid_resume() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_sparse"))
+        .arg("--theme")
+        .arg("typst-jsonresume-cv")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    assert_eq!(
+        read_prefix(&out, 5),
+        b"%PDF-",
+        "output must start with the PDF magic bytes",
+    );
+    let size = std::fs::metadata(&out).expect("stat").len();
+    assert!(size > 1024, "PDF should be > 1 KiB, was {size} bytes");
+}
+
 #[test]
 fn render_rejects_unknown_theme_with_exit_two() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/tests/render_theme.rs
+++ b/tests/render_theme.rs
@@ -1,14 +1,14 @@
-//! Golden-file test for the `typst-jsonresume-cv` theme adapter.
+//! Golden-file tests for the `typst-jsonresume-cv` theme adapter.
 //!
 //! Enforces CONSTITUTION testing doctrine:
 //! - **§2** — every theme has a golden-file test. We compile the
-//!   adapter against a fixed fixture, extract the rendered text with
-//!   `pdf-extract`, and compare against a committed reference. PDF
-//!   bytes are fragile across Typst patch versions; a normalized text
-//!   extraction is substantially more stable and still catches real
-//!   regressions (missing sections, re-ordered fields, lost fields,
-//!   etc.).
-//! - **§4** — no mocking Typst. This test drives the real embedded
+//!   adapter against a committed fixture, extract the rendered text
+//!   with `pdf-extract`, and compare against a committed reference.
+//!   PDF bytes are fragile across Typst patch versions; a normalized
+//!   text extraction is substantially more stable and still catches
+//!   real regressions (missing sections, re-ordered fields, lost
+//!   fields, etc.).
+//! - **§4** — no mocking Typst. These tests drive the real embedded
 //!   compiler via [`ferrocv::compile_theme`] against the real vendored
 //!   theme sources. No stubs, no feature-gated "lite" mode.
 //!
@@ -16,21 +16,44 @@
 //! adapter imports nothing under `@preview/...`, and `compile_theme`
 //! goes through the same [`FerrocvWorld`] that rejects package
 //! coordinates unconditionally. If a future vendored-theme update
-//! introduced a network-requiring import, this test would fail loudly
-//! (the compile would error) rather than silently succeeding.
+//! introduced a network-requiring import, these tests would fail
+//! loudly (the compile would error) rather than silently succeeding.
 //!
-//! # Updating the golden
+//! # Fixture coverage
 //!
-//! If Typst patch changes or an intentional theme edit legitimately
-//! shift the rendered text, regenerate with:
+//! Two fixtures are exercised, each pinned to its own golden so that a
+//! regression in either "shape" shows up as a committed diff:
+//!
+//! - `render_full.json` (Ada Lovelace) — every field the theme reads
+//!   is populated, including all optional contact fields, all section
+//!   arrays, and `meta.language`. Pins the "full-field" output shape.
+//! - `render_sparse.json` (Grace Hopper) — a schema-valid but
+//!   deliberately-sparse document: no `meta`, no `basics.location`,
+//!   no `basics.email`/`phone`, no `projects`/`education`/`skills`.
+//!   Pins the optional-field shim in
+//!   `assets/themes/typst-jsonresume-cv/resume.typ`
+//!   (see that file's `VENDORING.md` patch #3). A silent regression
+//!   in how missing fields degrade becomes a committed diff here.
+//!
+//! Fixture contents use public-domain pioneers of computing to keep
+//! test data PII-free and recognizable at a glance. These fixtures are
+//! *test-shaped* — narrow, deliberate coverage of specific adapter
+//! code paths. A realistic, demo-quality resume (the kind a user
+//! would actually author) belongs in the forkable starter-template
+//! repo tracked by issue #43, not here.
+//!
+//! # Updating the goldens
+//!
+//! If a Typst patch bump or an intentional theme edit legitimately
+//! shifts the rendered text, regenerate with:
 //!
 //! ```sh
 //! UPDATE_GOLDEN=1 cargo test --test render_theme
 //! ```
 //!
-//! Inspect the diff on `tests/goldens/typst-jsonresume-cv.txt`
-//! before committing. A golden update should always have an obvious
-//! cause; an unexplained diff is a regression, not a golden bump.
+//! Inspect the diffs under `tests/goldens/` before committing. A
+//! golden update should always have an obvious cause; an unexplained
+//! diff is a regression, not a golden bump.
 
 use std::fs;
 use std::path::PathBuf;
@@ -40,25 +63,39 @@ use serde_json::Value;
 /// PDF magic bytes; every valid PDF stream must start with `%PDF-`.
 const PDF_MAGIC: &[u8] = b"%PDF-";
 
-/// Path (relative to the crate root) of the committed normalized text
-/// the adapter must render to.
-const GOLDEN_PATH: &str = "tests/goldens/typst-jsonresume-cv.txt";
-
-/// Path (relative to the crate root) of the enriched JSON Resume
-/// fixture the adapter is exercised against. `valid_full.json` cannot
-/// be used here because the vendored theme does unconditional reads on
-/// `meta`, `basics.location.region`, `basics.phone`, and `projects` —
-/// fields the minimal validation fixture does not carry.
-const FIXTURE_PATH: &str = "tests/fixtures/render_full.json";
-
 /// Environment variable that, when set to any non-empty value, rewrites
-/// the golden with the current run's normalized output instead of
-/// asserting equality.
+/// the relevant golden with the current run's normalized output
+/// instead of asserting equality.
 const UPDATE_ENV: &str = "UPDATE_GOLDEN";
 
 #[test]
 fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
-    let fixture_path = crate_path(FIXTURE_PATH);
+    run_golden(
+        "tests/fixtures/render_full.json",
+        "tests/goldens/typst-jsonresume-cv.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn typst_jsonresume_cv_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/typst-jsonresume-cv-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
+/// Shared golden-file workflow: compile the adapter against the named
+/// fixture, extract and normalize the PDF text, and compare against
+/// (or rewrite, under `UPDATE_GOLDEN`) the committed golden.
+///
+/// `required_name` is a substring the extracted text must contain
+/// before we'll consider writing a golden from it — a cheap sanity
+/// check that `pdf-extract` hasn't degenerated and we're not about to
+/// freeze garbage.
+fn run_golden(fixture: &str, golden: &str, required_name: &str) {
+    let fixture_path = crate_path(fixture);
     let fixture_bytes = fs::read(&fixture_path)
         .unwrap_or_else(|e| panic!("read fixture {}: {e}", fixture_path.display()));
     let data: Value = serde_json::from_slice(&fixture_bytes)
@@ -67,8 +104,12 @@ fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
     let theme =
         ferrocv::find_theme("typst-jsonresume-cv").expect("theme must be registered in THEMES");
 
-    let bytes = ferrocv::compile_theme(theme, &data)
-        .expect("typst-jsonresume-cv must compile against render_full.json");
+    let bytes = ferrocv::compile_theme(theme, &data).unwrap_or_else(|e| {
+        panic!(
+            "typst-jsonresume-cv must compile against {}: {e}",
+            fixture_path.display()
+        )
+    });
 
     assert!(
         bytes.starts_with(PDF_MAGIC),
@@ -89,14 +130,14 @@ fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
     // returns empty or degenerate text, we refuse to regenerate the
     // golden from that garbage.
     assert!(
-        normalized.contains("Ada Lovelace"),
-        "extracted PDF text must contain the fixture's name `Ada Lovelace`; \
+        normalized.contains(required_name),
+        "extracted PDF text must contain the fixture's name `{required_name}`; \
          got {} bytes of normalized text starting with:\n{}",
         normalized.len(),
         normalized.chars().take(200).collect::<String>(),
     );
 
-    let golden_path = crate_path(GOLDEN_PATH);
+    let golden_path = crate_path(golden);
 
     if std::env::var_os(UPDATE_ENV).is_some_and(|v| !v.is_empty()) {
         if let Some(parent) = golden_path.parent() {
@@ -128,10 +169,12 @@ fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
     let expected = normalize(&expected_raw);
 
     assert_eq!(
-        normalized, expected,
-        "theme golden mismatch for typst-jsonresume-cv. \
+        normalized,
+        expected,
+        "theme golden mismatch for {}. \
          Regenerate with `UPDATE_GOLDEN=1 cargo test --test render_theme` \
-         if the difference is expected (e.g., Typst version bump)."
+         if the difference is expected (e.g., Typst version bump).",
+        golden_path.display(),
     );
 }
 


### PR DESCRIPTION
## Summary

- The vendored `typst-jsonresume-cv` adapter made unconditional reads on optional JSON Resume fields and crashed at render time against any schema-valid document that happened to omit one of them (my own `resume.json` was omitting `meta.language`, for example). This conflicted with CONSTITUTION §1 ("JSON Resume is the canonical input, unmodified").
- Adapter now wraps every optional read in `.at(..., default: ...)` and guards `work`/`projects`/`education` with `"<key>" in r`. Language defaults to `"en"`; location components collapse sensibly; missing contact fields disappear from the contact line via the existing `contact-item` filter.
- Two new test artifacts pin this behavior: a CLI-level acceptance test in `tests/render_cli.rs`, and a second `render_theme` golden against a deliberately-sparse Grace Hopper fixture. The existing full-field (Ada Lovelace) golden is byte-stable.

## What changed

- `assets/themes/typst-jsonresume-cv/resume.typ` — optional-field shim.
- `assets/themes/typst-jsonresume-cv/VENDORING.md` — records the new patch (#3) with before/after, behavioral impact, and explicit non-goals (fields *inside* work/education/project entries are still read unconditionally; extend the shim if a real report surfaces that case).
- `tests/fixtures/render_sparse.json` — new Grace Hopper fixture, schema-valid but carries only `basics.name`, `summary`, and one `work` entry.
- `tests/goldens/typst-jsonresume-cv-sparse.txt` — sparse golden.
- `tests/render_theme.rs` — refactored to a shared `run_golden` helper driving both goldens.
- `tests/render_cli.rs` — `render_accepts_sparse_schema_valid_resume` test (written before the fix; failed with `dictionary does not contain key "meta"`, now passes).

## Persona convention

Fixtures use public-domain pioneers of computing (Ada Lovelace for full-field, Grace Hopper for sparse) to stay PII-free and recognizable at a glance. These are *test-shaped* — narrow, deliberate coverage of specific adapter paths. A realistic, demo-quality resume belongs in the forkable starter-template repo tracked by #43, not here.

## Test plan

- [x] `make preflight` passes (fmt, clippy, test, deny, audit, typos).
- [x] 32 tests pass (30 pre-existing + new sparse golden + new CLI acceptance test).
- [x] Full-field `render_theme` golden is byte-stable — no regression in existing behavior.
- [x] End-to-end smoke: `target/debug/ferrocv render --theme typst-jsonresume-cv ../resume/resume.json` now produces a 4-page, 46 KB PDF (previously crashed on `meta.language`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
