### PR TITLE
Add summary header to validation error output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use serde_json::Value;
 
-use crate::{THEMES, compile_theme, find_theme, validate_value};
+use crate::{THEMES, ValidationError, compile_theme, find_theme, validate_value};
 
 /// Render JSON Resume documents via embedded Typst.
 #[derive(Debug, Parser)]
@@ -106,15 +106,28 @@ fn run_validate(path: Option<&Path>) -> Result<ExitCode> {
         }
     };
 
-    // Step 3: validate. On failure, one diagnostic per error to stderr.
+    // Step 3: validate. On failure, a summary header plus one indented
+    // diagnostic per error to stderr.
     match validate_value(&value) {
         Ok(()) => Ok(ExitCode::SUCCESS),
         Err(errors) => {
-            for err in errors {
-                eprintln!("{err}");
-            }
+            report_validation_errors(&errors, "");
             Ok(ExitCode::from(1))
         }
+    }
+}
+
+/// Print schema validation errors to stderr with a summary header.
+///
+/// `suffix` is appended to the header line (after the error count) so
+/// `render` can add "; no output written" without `validate` having to
+/// lie about emitting an output.
+fn report_validation_errors(errors: &[ValidationError], suffix: &str) {
+    let n = errors.len();
+    let plural = if n == 1 { "" } else { "s" };
+    eprintln!("error: schema validation failed ({n} error{plural}){suffix}");
+    for err in errors {
+        eprintln!("  {err}");
     }
 }
 
@@ -138,11 +151,11 @@ fn run_render(
     };
 
     // Step 3: validate. Render is defined to run validate first so
-    // users get a clean schema diagnostic before any Typst noise.
+    // users get a clean schema diagnostic before any Typst noise. The
+    // header calls out the render-specific consequence (no output
+    // written) so a terse validator message doesn't read as a warning.
     if let Err(errors) = validate_value(&value) {
-        for err in errors {
-            eprintln!("{err}");
-        }
+        report_validation_errors(&errors, "; no output written");
         return Ok(ExitCode::from(1));
     }
 


### PR DESCRIPTION
## Summary

- `validate` and `render` used to print a bare list of validation errors to stderr — no header, no scope. In `render` this was especially confusing because a reader could miss that no output file was written.
- Adds a small `report_validation_errors` helper that prints a summary header (`error: schema validation failed (N errors)`) followed by one indented diagnostic per error. `render` passes a suffix so its header explicitly reads `...; no output written`.

## Before / after

Before:
```
/basics/email: "not-an-email" is not a valid email address
/work/0/startDate: "not-a-date" is not a valid date
```

After (validate):
```
error: schema validation failed (2 errors)
  /basics/email: "not-an-email" is not a valid email address
  /work/0/startDate: "not-a-date" is not a valid date
```

After (render):
```
error: schema validation failed (2 errors); no output written
  /basics/email: "not-an-email" is not a valid email address
  /work/0/startDate: "not-a-date" is not a valid date
```

## Compatibility

Existing stderr-grep test assertions all use substring matches (`"error:"`, JSON pointer paths like `"/basics/email"`) — both still present, so this is behavior-compatible for any scripts or tests pattern-matching on stderr.

## Test plan

- [x] `make preflight` passes (fmt, clippy, test, deny, audit, typos).
- [x] 32 tests pass; no test changes required.
- [x] Manual spot-check: `validate` and `render` against `tests/fixtures/invalid_wrong_type_email.json` produce the new header format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
