### PR TITLE
Use crates.io trusted publishing (OIDC) in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,21 @@ jobs:
     name: publish to crates.io
     needs: build
     runs-on: ubuntu-latest
+    # Trusted publishing: crates.io issues a short-lived token in exchange
+    # for a GitHub-signed OIDC assertion, so no CARGO_REGISTRY_TOKEN secret
+    # is stored in the repo. The trust relationship is configured once on
+    # crates.io ("Trusted Publishing" on the crate settings page) pinning
+    # this repo + workflow filename.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
           toolchain: stable
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
       - run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `CARGO_REGISTRY_TOKEN` secret with OIDC-based [trusted publishing](https://crates.io/docs/trusted-publishing) in the `publish` job of `release.yml`.
- Add `rust-lang/crates-io-auth-action@v1.0.4` (SHA-pinned) to mint a short-lived token per run.
- Narrow publish-job permissions to `id-token: write` + `contents: read`; workflow-level `contents: write` still covers the binary-upload job.

## Why
Removes a long-lived secret from the repo, satisfies CONSTITUTION §6 (fewer moving parts, less attack surface), and matches the project's SHA-pinning convention for third-party actions.

## Manual pre-merge step (done)
Trusted publisher registered on crates.io for `ferrocv`, pinned to this repo + `release.yml`.

## Test plan
- [ ] CI passes on this PR (no runtime behavior changed, but sanity check on workflow parse).
- [ ] Next `v*` tag cut by release-please triggers `release.yml` and `cargo publish` succeeds via the minted OIDC token.
- [ ] After first green publish: delete the `CARGO_REGISTRY_TOKEN` GitHub secret and revoke the token on crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
