### PR TITLE
Add fantastic-cv theme adapter

### DIFF
--- a/assets/themes/fantastic-cv/LICENSE
+++ b/assets/themes/fantastic-cv/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/assets/themes/fantastic-cv/VENDORING.md
+++ b/assets/themes/fantastic-cv/VENDORING.md
@@ -1,0 +1,123 @@
+# Vendoring record — `fantastic-cv`
+
+This directory contains a vendored copy of [`austinyu/fantastic-cv`]'s
+Typst source, plus a ferrocv-authored glue entrypoint that maps
+JSON Resume v1.0.0 data to fantastic-cv's argument shapes. Vendoring
+satisfies the constitutional no-network constraint (see
+`CONSTITUTION.md` §6.1), and keeping the mapping isolated in
+`resume.typ` preserves the adapter/native separation (see `CONSTITUTION.md`
+§4).
+
+[`austinyu/fantastic-cv`]: https://github.com/austinyu/fantastic-cv
+
+## Provenance
+
+| Field                | Value                                                  |
+| -------------------- | ------------------------------------------------------ |
+| Upstream             | https://github.com/austinyu/fantastic-cv               |
+| Commit SHA           | `37e4ab219abbc8fa9419b7e71a8acddfafa7dfa9`             |
+| Commit date          | 2025-05-14 (upstream `main`)                           |
+| Package version      | 0.1.0 (first and only release, published 2025-05-15)   |
+| Upstream source path | `src/fantastic-cv.typ`                                 |
+| Vendor date          | 2026-04-19                                             |
+
+We do **not** vendor the upstream `src/lib.typ`; it is a 3-line
+re-export shim whose sole purpose is Typst Universe packaging. Our
+glue imports directly from `fantastic-cv.typ`.
+
+## License
+
+The upstream repository ships two slightly inconsistent license
+declarations:
+
+- `typst.toml` declares the license as **MIT**.
+- The committed `LICENSE` file is [**The Unlicense**] (a public-domain
+  dedication).
+
+[**The Unlicense**]: https://unlicense.org/
+
+We vendor the actual `LICENSE` file's text as [`LICENSE`](./LICENSE) in
+this directory because that's the license text upstream actually ships
+alongside the source. The `typst.toml` `MIT` string appears to be a
+packaging-time mis-statement.
+
+The discrepancy does not affect our ability to redistribute:
+public-domain dedications under the Unlicense explicitly permit copy,
+modify, publish, and distribute under any terms, which makes Unlicense
+compatible with `ferrocv`'s **MIT OR Apache-2.0** dual license. This is
+the same precedent we relied on when vendoring
+[`typst-jsonresume-cv`](../typst-jsonresume-cv/VENDORING.md) (whose
+upstream also traces back to an Unlicense root).
+
+Upstream LICENSE for reference:
+<https://github.com/austinyu/fantastic-cv/blob/37e4ab219abbc8fa9419b7e71a8acddfafa7dfa9/LICENSE>
+
+## Patches applied
+
+No patches applied to the vendored source (`fantastic-cv.typ`). All
+JSON-Resume → fantastic-cv field mapping and the optional-field shim
+live in the adjacent `resume.typ` glue entrypoint. The glue is authored
+code, not a patch record — the vendored file stays byte-for-byte
+upstream so re-vendoring is a mechanical copy.
+
+The upstream source does **not** import any `@preview/...` packages at
+the pinned SHA, so there is no network-fetch patch to apply (contrast
+with the `typst-jsonresume-cv` vendor). A `grep -n "@preview/"
+fantastic-cv.typ` returns no matches — re-check this on every re-vendor.
+
+## What was NOT patched
+
+The following are deliberately upstream-as-is:
+
+- `fantastic-cv.typ` function signatures (`config`, `render-basic-info`,
+  `render-education`, `render-work`, `render-project`, `render-volunteer`,
+  `render-award`, `render-certificate`, `render-publication`,
+  `render-custom`).
+- The `config` show-rule body (font/page/heading styles).
+- All `render-*` builder bodies — entry layout, `_section` helper,
+  `_format_dates` and `_entry_heading` internals.
+- Default font ("New Computer Modern"), default font size (10pt),
+  default paper ("a4"), default margins (0.5in all sides), and
+  default accent color (`#26428b`).
+
+The `resume.typ` glue invokes `config.with()` with zero overrides —
+CONSTITUTION §5 says a second caller is the trigger to expose knobs,
+not the first.
+
+## JSON Resume mapping notes
+
+The ferrocv glue `resume.typ` handles these shape frictions without
+touching `fantastic-cv.typ`:
+
+- **Key pluralization:** JSON Resume singular keys (`work`, `education`,
+  `volunteer`) map to fantastic-cv plural argument names (`works`,
+  `educations`, `volunteers`).
+- **Field renames:** JSON Resume `work[].summary` →
+  fantastic-cv `work.description`.
+- **Fields fantastic-cv expects that JSON Resume lacks:**
+  `work[].location`, `education[].location`, `volunteer[].location`
+  (all defaulted to `""`), `project[].source_code` (defaulted to `""`).
+- **Fields JSON Resume has in two places:** `project[].roles` is read
+  first; `project[].keywords` is the fallback (both are schema-legal).
+- **Skills:** fantastic-cv has no dedicated skills builder, so JSON
+  Resume `skills` surface via `render-custom` as a "Skills" section.
+  Empty or missing `skills` emits no section.
+
+## Updating
+
+To re-vendor from a newer upstream:
+
+1. Fetch the upstream `src/fantastic-cv.typ` at the new commit SHA
+   (e.g., `curl -O
+   https://raw.githubusercontent.com/austinyu/fantastic-cv/<SHA>/src/fantastic-cv.typ`).
+2. Copy it over the file in this directory, overwriting byte-for-byte.
+3. Update the Commit SHA, Commit date, Package version, and Vendor
+   date rows in the Provenance table above.
+4. Adjust `resume.typ` if any of fantastic-cv's `render-*` signatures
+   changed. `grep -n "^#let \(config\|render-\)" fantastic-cv.typ`
+   enumerates the current signatures; `grep -n "render-" resume.typ`
+   enumerates every call site.
+5. Re-verify no new `@preview/...` imports crept in:
+   `grep -n "@preview/" fantastic-cv.typ` must return no matches.
+6. Regenerate goldens: `UPDATE_GOLDEN=1 cargo test --test render_theme`
+   and inspect the diffs before committing.

--- a/assets/themes/fantastic-cv/fantastic-cv.typ
+++ b/assets/themes/fantastic-cv/fantastic-cv.typ
@@ -1,0 +1,343 @@
+
+#let render_space_between_highlight = -0.5em
+#let render_space_between_entry = -0.5em
+#let render_space_between_sections = -0.5em
+
+#let config(
+  font: "New Computer Modern",
+  font-size: 10pt,
+  page-paper: "a4",
+  margin: (
+    top: 0.5in,
+    bottom: 0.5in,
+    left: 0.5in,
+    right: 0.5in,
+  ),
+  accent-color: "#26428b",
+  space-between-sections: -0.5em,
+  space-between-highlight: -0.5em,
+  body
+) = {
+  let font_size_title = font-size * 1.5
+  let font_size_section = font-size * 1.3
+  let font_size_entry = font-size * 1.1
+
+  set text(
+    font: font,
+    size: font-size,
+    lang: "en",
+    ligatures: false,
+  )
+
+  set page(
+    margin: margin,
+    paper: page-paper,
+  )
+
+  set par(justify: true)
+
+  show link: underline
+
+  show heading: set text(fill: rgb(accent-color))
+
+  show link: set text(fill: rgb(accent-color))
+
+  // name heading
+  show heading.where(level: 1): it => [#text(font_size_title, weight: "extrabold")[#it]]
+
+  // section heading
+  show heading.where(level: 2): it => [#text(font_size_section, weight: "bold")[#it]]
+
+  // entry heading
+  show heading.where(level: 3): it => [#text(size: font_size_entry, weight: "semibold")[#it]]
+
+  body
+}
+
+
+#let _format_dates(
+  start-date: "",
+  end-date: "",
+) = {
+  start-date + " " + $dash.em$ + " " + end-date
+}
+
+
+#let _entry_heading(
+  main: "", // top left
+  dates: "", // top right
+  description: "", // bottom left
+  bottom_right: "", // bottom right
+) = {
+  [
+    === #main #h(1fr) #dates \
+    #description #h(1fr) #bottom_right
+  ]
+}
+
+#let _section(title, body) = {
+ [ == #smallcaps(title)]
+ v(-0.5em)
+ line(length: 100%, stroke: stroke(thickness: 0.4pt))
+  v(-0.5em)
+  body
+  v(render_space_between_sections)
+}
+
+
+#let render-basic-info(
+  name: "",
+  location: "",
+  phone: "",
+  email: "",
+  url: "",
+  profiles: [],
+) = {
+  set document(
+    author: name,
+    title: name,
+    description: "Resume of " + name,
+    keywords: "resume, cv, curriculum vitae",
+  )
+
+  align(
+    left,
+    [= #name #h(1fr) #location],
+  )
+
+
+  pad(
+    top: 0.25em,
+    [
+      #{
+        let items = (
+          phone,
+          link(email)[#email],
+          link(url)[#url],
+        )
+        items.filter(x => x != none).join("  |  ")
+        "  |  "
+        profiles
+          .map(profile => {
+            profile.network + ": "
+            link(profile.url)[#profile.username]
+          })
+          .join("  |  ")
+      }
+    ],
+  )
+}
+
+#let render-education(educations) = {
+  if educations.len() == 0 {
+    return
+  }
+  let section_body = {
+    educations
+      .map(education => {
+        let main = link(education.url)[#education.institution]
+        if education.url.len() == 0 {
+          main = education.institution
+        }
+        _entry_heading(
+          main: main,
+          dates: _format_dates(start-date: education.startDate, end-date: education.endDate),
+          description: (
+            emph(education.studyType),
+            education.area,
+            "GPA: " + strong(education.score),
+          ).join(" | "),
+          bottom_right: education.location,
+        )
+        [
+          - #emph[Selected coursework]: #education.courses.join(", ")
+        ]
+      })
+      .join(v(render_space_between_entry))
+  }
+  _section("Education", section_body)
+}
+
+#let render-work(works) = {
+  if works.len() == 0 {
+    return
+  }
+  let section_body = {
+    works
+      .map(work => {
+        let main = link(work.url)[#work.name]
+        if work.url.len() == 0 {
+          main = work.name
+        }
+        [
+          #_entry_heading(
+            main: main,
+            dates: _format_dates(start-date: work.startDate, end-date: work.endDate),
+            description: (
+              emph(work.position),
+              work.description,
+            ).join(" | "),
+            bottom_right: work.location,
+          )
+          #work.highlights.map(it => [- #it]).join(v(render_space_between_highlight))
+        ]
+      })
+      .join(v(render_space_between_entry))
+  }
+  _section("Work", section_body)
+}
+
+#let render-project(projects) = {
+  if projects.len() == 0 {
+    return
+  }
+  let section_body = {
+    projects
+      .map(project => {
+        let main = link(project.url)[#project.name]
+        if project.url.len() == 0 {
+          main = project.name
+        }
+        let source_code = link(project.source_code)[Source code]
+        if project.source_code.len() == 0 {
+          source_code = ""
+        }
+        [
+          #_entry_heading(
+            main: main,
+            dates: _format_dates(start-date: project.startDate, end-date: project.endDate),
+            description: project.roles.map(emph).join(" | "),
+            bottom_right: source_code,
+          )
+          #v(-2em) \
+          #project.description
+          #project.highlights.map(it => [- #it]).join(v(render_space_between_highlight))
+        ]
+      })
+      .join(v(render_space_between_entry))
+  }
+  _section("Projects", section_body)
+}
+
+#let render-volunteer(volunteers) = {
+  if volunteers.len() == 0 {
+    return
+  }
+  let section_body = {
+    volunteers
+      .map(volunteer => {
+        let main = link(volunteer.url)[#volunteer.organization]
+        if volunteer.url.len() == 0 {
+          main = volunteer.organization
+        }
+        [
+          #_entry_heading(
+            main: main,
+            dates: _format_dates(start-date: volunteer.startDate, end-date: volunteer.endDate),
+            description: emph(volunteer.position),
+            bottom_right: volunteer.location,
+          )
+          #v(-2em) \
+          #volunteer.summary
+          #volunteer.highlights.map(it => [- #it]).join(v(render_space_between_highlight))
+        ]
+      })
+      .join(v(render_space_between_entry))
+  }
+  _section("Volunteering", section_body)
+}
+
+#let render-award(awards) = {
+  if awards.len() == 0 {
+    return
+  }
+  let section_body = [
+    #(
+      awards
+        .map(award => {
+          let awarder_str = " - Awarded by " + award.awarder
+          if award.awarder.len() == 0 {
+            awarder_str = ""
+          }
+          let prefix = link(award.url)[#award.title]
+          if award.url.len() == 0 {
+            prefix = award.title
+          }
+          let summary_str = [#award.summary]
+          if award.summary.len() == 0 {
+            summary_str = ""
+          }
+          [- #prefix#awarder_str #h(1fr) #award.date \ #summary_str]
+        })
+        .join(v(render_space_between_highlight))
+    )
+  ]
+  _section("Awards", section_body)
+}
+
+#let render-certificate(certificates) = {
+  if certificates.len() == 0 {
+    return
+  }
+  let section_body = certificates
+    .map(certificate => {
+      let post_fix = h(1fr) + certificate.date
+      let issue_str = " - issued by " + certificate.issuer
+      if certificate.issuer.len() == 0 {
+        issue_str = ""
+      }
+      let prefix = link(certificate.url)[#certificate.name]
+      if certificate.url.len() == 0 {
+        prefix = certificate.name
+      }
+      [- #prefix#issue_str #post_fix]
+    })
+    .join(v(render_space_between_highlight))
+  _section("Certificates", section_body)
+}
+
+
+
+#let render-publication(publications) = {
+  if publications.len() == 0 {
+    return
+  }
+  let section_body = [
+    #(
+      publications
+        .map(publication => {
+          let prefix = link(publication.url)[#publication.name]
+          if publication.url.len() == 0 {
+            prefix = publication.name
+          }
+          let publisher_str = " - published by " + publication.publisher
+          if publication.publisher.len() == 0 {
+            publisher_str = ""
+          }
+          let summary_str = [#publication.summary]
+          if publication.summary.len() == 0 {
+            summary_str = ""
+          }
+          [- #prefix#publisher_str #h(1fr) #publication.releaseDate \ #summary_str]
+        })
+        .join(v(render_space_between_highlight))
+    )
+  ]
+  _section("Publications", section_body)
+}
+
+#let render-custom(custom_section) = {
+  let section_body = {
+    custom_section.highlights
+      .map(highlight => {
+        let summary_str = highlight.summary + ": "
+        let description_str = highlight.description
+        if highlight.description.len() == 0 {
+          description_str = ""
+        }
+        [- #text(weight: "bold")[#summary_str]#description_str]
+      })
+      .join(v(render_space_between_highlight))
+  }
+  _section(custom_section.title, section_body)
+}

--- a/assets/themes/fantastic-cv/resume.typ
+++ b/assets/themes/fantastic-cv/resume.typ
@@ -1,0 +1,172 @@
+// ferrocv glue entrypoint for the vendored `fantastic-cv` theme.
+//
+// This file is authored by ferrocv (NOT vendored). It imports the
+// verbatim upstream `fantastic-cv.typ` builders and adapts JSON Resume
+// v1.0.0 data to the argument shapes fantastic-cv expects. The adapter
+// layer lives here so the vendored file stays byte-for-byte upstream —
+// re-vendoring is a mechanical copy. See VENDORING.md.
+//
+// CONSTITUTION §1: JSON Resume is the canonical input; every field is
+// optional per the v1.0.0 schema. Every read uses `.at(..., default: ...)`.
+// CONSTITUTION §5: no section-toggle knobs; every section with data renders.
+
+#import "fantastic-cv.typ": config, render-basic-info, render-education, render-work, render-project, render-volunteer, render-award, render-certificate, render-publication, render-custom
+
+// The FerrocvWorld serves the JSON Resume bytes at the virtual path
+// "/resume.json". Same convention as every other ferrocv theme.
+#let r = json("/resume.json")
+
+// Optional-field shim for `basics` — absent, null, or partially-filled
+// sub-objects must all render without a dict-lookup panic.
+#let basics = r.at("basics", default: (:))
+#let location = basics.at("location", default: (:))
+#let city = location.at("city", default: "")
+#let region = location.at("region", default: "")
+#let address = if city != "" and region != "" {
+  city + ", " + region
+} else if city != "" {
+  city
+} else {
+  region
+}
+#let basics_name = basics.at("name", default: "")
+#let basics_email = basics.at("email", default: "")
+#let basics_phone = basics.at("phone", default: "")
+#let basics_url = basics.at("url", default: "")
+
+// Profiles: fantastic-cv's render-basic-info reads `profile.network`,
+// `profile.url`, and `profile.username` on every profile. Project each
+// JSON Resume profile entry so those three fields always exist.
+#let basics_profiles = basics.at("profiles", default: ()).map(p => (
+  network: p.at("network", default: ""),
+  url: p.at("url", default: ""),
+  username: p.at("username", default: ""),
+))
+
+// Apply fantastic-cv's page/text config with its default knobs.
+// CONSTITUTION §5: no user-facing configuration yet — a second caller
+// is the trigger to generalize.
+#show: config.with()
+
+#render-basic-info(
+  name: basics_name,
+  location: address,
+  phone: basics_phone,
+  email: basics_email,
+  url: basics_url,
+  profiles: basics_profiles,
+)
+
+// Section: work. JSON Resume key is singular `work`; fantastic-cv
+// expects an argument named `works`. Per-entry: JSON Resume `summary`
+// → fantastic-cv `description`. JSON Resume has no work-level
+// `location`; default to empty.
+#if "work" in r and r.work != none and r.work.len() > 0 {
+  render-work(r.work.map(w => (
+    name: w.at("name", default: ""),
+    location: w.at("location", default: ""),
+    url: w.at("url", default: ""),
+    // ferrocv glue: JSON Resume `summary` → fantastic-cv `description`.
+    description: w.at("summary", default: ""),
+    position: w.at("position", default: ""),
+    startDate: w.at("startDate", default: ""),
+    endDate: w.at("endDate", default: ""),
+    highlights: w.at("highlights", default: ()),
+  )))
+}
+
+// Section: education. JSON Resume has no education-level `location`;
+// default to empty. fantastic-cv `educations` (plural) ← JSON Resume
+// `education` (singular).
+#if "education" in r and r.education != none and r.education.len() > 0 {
+  render-education(r.education.map(e => (
+    institution: e.at("institution", default: ""),
+    location: e.at("location", default: ""),
+    url: e.at("url", default: ""),
+    area: e.at("area", default: ""),
+    studyType: e.at("studyType", default: ""),
+    startDate: e.at("startDate", default: ""),
+    endDate: e.at("endDate", default: ""),
+    score: e.at("score", default: ""),
+    courses: e.at("courses", default: ()),
+  )))
+}
+
+// Section: projects. fantastic-cv reads `source_code` (no JSON Resume
+// equivalent; leave empty) and `roles` (JSON Resume schema has `roles`
+// and also `keywords`; prefer `roles`, fall back to `keywords`).
+#if "projects" in r and r.projects != none and r.projects.len() > 0 {
+  render-project(r.projects.map(p => (
+    name: p.at("name", default: ""),
+    url: p.at("url", default: ""),
+    source_code: "",
+    roles: p.at("roles", default: p.at("keywords", default: ())),
+    startDate: p.at("startDate", default: ""),
+    endDate: p.at("endDate", default: ""),
+    description: p.at("description", default: ""),
+    highlights: p.at("highlights", default: ()),
+  )))
+}
+
+// Section: volunteer. JSON Resume key is singular `volunteer`;
+// fantastic-cv expects `volunteers`. JSON Resume has no volunteer-level
+// `location`; default to empty.
+#if "volunteer" in r and r.volunteer != none and r.volunteer.len() > 0 {
+  render-volunteer(r.volunteer.map(v => (
+    organization: v.at("organization", default: ""),
+    position: v.at("position", default: ""),
+    url: v.at("url", default: ""),
+    startDate: v.at("startDate", default: ""),
+    endDate: v.at("endDate", default: ""),
+    summary: v.at("summary", default: ""),
+    location: v.at("location", default: ""),
+    highlights: v.at("highlights", default: ()),
+  )))
+}
+
+// Section: awards.
+#if "awards" in r and r.awards != none and r.awards.len() > 0 {
+  render-award(r.awards.map(a => (
+    title: a.at("title", default: ""),
+    date: a.at("date", default: ""),
+    url: a.at("url", default: ""),
+    awarder: a.at("awarder", default: ""),
+    summary: a.at("summary", default: ""),
+  )))
+}
+
+// Section: certificates.
+#if "certificates" in r and r.certificates != none and r.certificates.len() > 0 {
+  render-certificate(r.certificates.map(c => (
+    name: c.at("name", default: ""),
+    issuer: c.at("issuer", default: ""),
+    url: c.at("url", default: ""),
+    date: c.at("date", default: ""),
+  )))
+}
+
+// Section: publications.
+#if "publications" in r and r.publications != none and r.publications.len() > 0 {
+  render-publication(r.publications.map(pub => (
+    name: pub.at("name", default: ""),
+    publisher: pub.at("publisher", default: ""),
+    releaseDate: pub.at("releaseDate", default: ""),
+    url: pub.at("url", default: ""),
+    summary: pub.at("summary", default: ""),
+  )))
+}
+
+// Section: skills. fantastic-cv has no dedicated skills builder; we
+// surface the JSON Resume `skills` array via `render-custom` as a
+// "Skills" custom section. Each skill entry becomes one highlight
+// where `summary` is the skill name and `description` is the joined
+// keywords. If `skills` is empty or missing, emit nothing.
+#if "skills" in r and r.skills != none and r.skills.len() > 0 {
+  render-custom((
+    title: "Skills",
+    highlights: r.skills.map(s => (
+      summary: s.at("name", default: ""),
+      description: s.at("keywords", default: ()).join(", "),
+    )),
+  ))
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -62,6 +62,13 @@ pub struct Theme {
 /// in [`TYPST_JSONRESUME_CV`] updates in one place.
 const TYPST_JSONRESUME_CV_PREFIX: &str = "/themes/typst-jsonresume-cv";
 
+/// Virtual-path prefix for this theme's files inside the World.
+///
+/// Centralized as a private `const` so the `files` and `entrypoint`
+/// fields stay in lockstep. If this prefix changes, every file path
+/// in [`FANTASTIC_CV`] updates in one place.
+const FANTASTIC_CV_PREFIX: &str = "/themes/fantastic-cv";
+
 /// Adapter for [`fruggiero/typst-jsonresume-cv`]'s `basic-resume`
 /// theme, vendored under `assets/themes/typst-jsonresume-cv/`.
 ///
@@ -99,11 +106,46 @@ const _: () = {
     assert!(!TYPST_JSONRESUME_CV_PREFIX.is_empty());
 };
 
+/// Adapter for [`austinyu/fantastic-cv`], vendored under
+/// `assets/themes/fantastic-cv/`.
+///
+/// The entrypoint is our authored glue `resume.typ`, which
+/// `#import`s the byte-for-byte vendored `fantastic-cv.typ` from the
+/// same virtual directory. All JSON-Resume → fantastic-cv field
+/// mapping lives in the glue; the vendored source is untouched. See
+/// `assets/themes/fantastic-cv/VENDORING.md` for the provenance record
+/// and the glue-not-patch rationale.
+///
+/// [`austinyu/fantastic-cv`]: https://github.com/austinyu/fantastic-cv
+pub const FANTASTIC_CV: Theme = Theme {
+    name: "fantastic-cv",
+    files: &[
+        (
+            // Must agree with FANTASTIC_CV_PREFIX + "/fantastic-cv.typ".
+            concat!("/themes/fantastic-cv", "/fantastic-cv.typ"),
+            include_bytes!("../assets/themes/fantastic-cv/fantastic-cv.typ"),
+        ),
+        (
+            concat!("/themes/fantastic-cv", "/resume.typ"),
+            include_bytes!("../assets/themes/fantastic-cv/resume.typ"),
+        ),
+    ],
+    entrypoint: concat!("/themes/fantastic-cv", "/resume.typ"),
+};
+
+// Compile-time sanity check: same shape as for TYPST_JSONRESUME_CV.
+const _: () = {
+    assert!(!FANTASTIC_CV_PREFIX.is_empty());
+};
+
 /// All themes registered with this build of `ferrocv`.
 ///
-/// Phase 1 ships one adapter. See the module doc for why this is a
-/// `&[&Theme]` rather than a `HashMap` or a builder pattern.
-pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV];
+/// Two adapters are registered today (`typst-jsonresume-cv` and
+/// `fantastic-cv`). See the module doc for why this is a `&[&Theme]`
+/// rather than a `HashMap` or a builder pattern — a linear scan over
+/// a handful of entries is fine, and CONSTITUTION §5 calls for the
+/// narrower solution until a caller actually needs more.
+pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.
 ///

--- a/tests/goldens/fantastic-cv-sparse.txt
+++ b/tests/goldens/fantastic-cv-sparse.txt
@@ -1,0 +1,10 @@
+Grace Hopper
+
+  |     |     |
+
+Work
+US Navy 1944-07-01  —
+
+Rear Admiral  |
+• Worked on the Mark I computer at Harvard.
+• Developed the first compiler for a computer programming language.

--- a/tests/goldens/fantastic-cv.txt
+++ b/tests/goldens/fantastic-cv.txt
@@ -1,0 +1,28 @@
+Ada Lovelace London, England
+
++44-20-0000-0000  |   ada@example.com   |   https://example.com/ada   |  GitHub:  ada   |  LinkedIn:  ada-lovelace
+
+Work
+Analytical Engines Ltd 1843-01-01  —  1852-11-27
+
+Programmer  | Translated and annotated Menabrea's paper on the Analytical Engine; wrote the first published algorithm
+intended for machine execution.• Published the first algorithm designed for a machine (Bernoulli numbers)
+• Introduced the concept of a general-purpose computing device
+
+Education
+ University of London 1833-01-01  —  1843-01-01
+
+Self-directed  | Mathematics | GPA:
+• Selected coursework :
+
+Projects
+Notes on the Analytical Engine 1842-01-01  —  1843-07-01
+
+Expanded translation of Menabrea's sketch, including the first published algorithm for a computing machine.• Note G — the Bernoulli-number algorithm
+
+Certificates
+ • Honorary Fellowship in Computing History  - issued by Analytical Engines Ltd 1843-09-01
+
+Skills
+• Programming:  Analytical Engine, Algorithms
+• Mathematics:  Calculus, Symbolic logic

--- a/tests/render_theme.rs
+++ b/tests/render_theme.rs
@@ -68,9 +68,11 @@ const PDF_MAGIC: &[u8] = b"%PDF-";
 /// instead of asserting equality.
 const UPDATE_ENV: &str = "UPDATE_GOLDEN";
 
+// typst-jsonresume-cv adapter goldens.
 #[test]
 fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
     run_golden(
+        "typst-jsonresume-cv",
         "tests/fixtures/render_full.json",
         "tests/goldens/typst-jsonresume-cv.txt",
         "Ada Lovelace",
@@ -80,33 +82,55 @@ fn typst_jsonresume_cv_renders_ada_lovelace_to_expected_text() {
 #[test]
 fn typst_jsonresume_cv_renders_grace_hopper_sparse_to_expected_text() {
     run_golden(
+        "typst-jsonresume-cv",
         "tests/fixtures/render_sparse.json",
         "tests/goldens/typst-jsonresume-cv-sparse.txt",
         "Grace Hopper",
     );
 }
 
-/// Shared golden-file workflow: compile the adapter against the named
-/// fixture, extract and normalize the PDF text, and compare against
-/// (or rewrite, under `UPDATE_GOLDEN`) the committed golden.
+// fantastic-cv adapter goldens.
+#[test]
+fn fantastic_cv_renders_ada_lovelace_to_expected_text() {
+    run_golden(
+        "fantastic-cv",
+        "tests/fixtures/render_full.json",
+        "tests/goldens/fantastic-cv.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn fantastic_cv_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "fantastic-cv",
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/fantastic-cv-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
+/// Shared golden-file workflow: compile the named adapter against the
+/// named fixture, extract and normalize the PDF text, and compare
+/// against (or rewrite, under `UPDATE_GOLDEN`) the committed golden.
 ///
 /// `required_name` is a substring the extracted text must contain
 /// before we'll consider writing a golden from it — a cheap sanity
 /// check that `pdf-extract` hasn't degenerated and we're not about to
 /// freeze garbage.
-fn run_golden(fixture: &str, golden: &str, required_name: &str) {
+fn run_golden(theme_name: &str, fixture: &str, golden: &str, required_name: &str) {
     let fixture_path = crate_path(fixture);
     let fixture_bytes = fs::read(&fixture_path)
         .unwrap_or_else(|e| panic!("read fixture {}: {e}", fixture_path.display()));
     let data: Value = serde_json::from_slice(&fixture_bytes)
         .unwrap_or_else(|e| panic!("parse fixture {}: {e}", fixture_path.display()));
 
-    let theme =
-        ferrocv::find_theme("typst-jsonresume-cv").expect("theme must be registered in THEMES");
+    let theme = ferrocv::find_theme(theme_name)
+        .unwrap_or_else(|| panic!("theme `{theme_name}` must be registered in THEMES"));
 
     let bytes = ferrocv::compile_theme(theme, &data).unwrap_or_else(|e| {
         panic!(
-            "typst-jsonresume-cv must compile against {}: {e}",
+            "{theme_name} must compile against {}: {e}",
             fixture_path.display()
         )
     });


### PR DESCRIPTION
## Summary

- Adds `fantastic-cv` as the second selectable theme in `ferrocv`, closing Phase 3's first adapter (issue #39). After this merges, `ferrocv render resume.json --theme fantastic-cv` produces a valid PDF end-to-end.
- Vendors [`austinyu/fantastic-cv`](https://github.com/austinyu/fantastic-cv) at pinned commit `37e4ab2` unpatched; all JSON-Resume ↔ fantastic-cv field mapping and the optional-field shim live in our authored `resume.typ` glue entrypoint so re-vendoring stays a mechanical copy.
- Adds golden-file tests for both the full (Ada Lovelace) and sparse (Grace Hopper) fixtures per CONSTITUTION §2. The sparse fixture stresses every optional-field default in the glue.

## Notable decisions

- **Glue, not patches.** Upstream `fantastic-cv` has no `@preview/...` imports (CONSTITUTION §6.1 satisfied without patching) but reads JSON-Resume-adjacent fields unconditionally. All `.at(key, default: ...)` guards and key remapping (e.g., JSON Resume `work.summary` → fantastic-cv `work.description`; `volunteer` → `volunteers`) live in `assets/themes/fantastic-cv/resume.typ`. `VENDORING.md` records this boundary explicitly.
- **License discrepancy documented.** Upstream ships [The Unlicense](https://unlicense.org/) despite `typst.toml` declaring MIT. We vendor the actual Unlicense text (public-domain dedication; compatible with our MIT/Apache-2.0 dual license, same precedent as `typst-jsonresume-cv`) and call the mismatch out in `VENDORING.md`.
- **`run_golden` gained a `theme_name: &str` parameter.** The existing helper hard-coded `"typst-jsonresume-cv"`, which couldn't serve a second theme. Both existing callers now pass the name explicitly; no behavior change for the original tests.
- **Registry stays simple.** Two themes is not the trigger to generalize the `THEMES: &[&Theme]` linear-scan (CONSTITUTION §5). If a third theme lands and the doc comment starts lying, revisit then.

## Test plan

- [x] `make preflight` passed locally (fmt, clippy `-D warnings`, all tests, cargo-deny, cargo-audit, typos)
- [x] Both new golden tests pass deterministically (ran without `UPDATE_GOLDEN` after a fresh `UPDATE_GOLDEN=1` bootstrap)
- [x] Existing `typst-jsonresume-cv` goldens byte-identical (no cross-theme regression)
- [x] Smoke render against both `tests/fixtures/render_full.json` and `tests/fixtures/render_sparse.json` produces valid PDFs (`%PDF-` magic, >1KB)
- [x] `grep @preview/ assets/themes/fantastic-cv/fantastic-cv.typ` returns no matches (CONSTITUTION §6.1)

## Audit note

`cargo audit` continues to report three pre-existing **unmaintained** advisories on transitive deps pulled in via Typst (`bincode 1.3.3`, `paste 1.0.15`, `yaml-rust 0.4.5`). Not introduced by this PR and not failing the audit step; flagging for awareness.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
