### PR TITLE
Plain text output via Frame-walk extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 
 ## Status
 
-**Early.** PDF rendering via the `typst-jsonresume-cv` theme works today.
-HTML and plain-text output, additional themes, and native-theme tooling
-are tracked as [GitHub issues](https://github.com/cacack/ferrocv/issues)
-and organized into phase milestones. The non-negotiable design
-principles live in [`CONSTITUTION.md`](./CONSTITUTION.md).
+**Early.** PDF and plain-text output work today (PDF via the
+`typst-jsonresume-cv` theme adapter, text via the native `text-minimal`
+theme). HTML output, additional themes, and native-theme tooling are
+tracked as [GitHub issues](https://github.com/cacack/ferrocv/issues)
+(HTML lives at #44) and organized into phase milestones. The
+non-negotiable design principles live in
+[`CONSTITUTION.md`](./CONSTITUTION.md).
 
 ## Why
 
@@ -41,11 +43,17 @@ ferrocv validate resume.json
 
 # Render to PDF using the typst-jsonresume-cv theme
 ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
+
+# Render to plain text (defaults to the native `text-minimal` theme;
+# `--theme` is optional for text)
+ferrocv render resume.json --format text
 ```
 
-`render` defaults to `--format pdf` (the only format in Phase 1; HTML
-and plain text are coming). When `--output` is omitted, the PDF is
-written to `dist/resume.pdf`; parent directories are created as needed.
+`render` defaults to `--format pdf`; HTML output is tracked at #44.
+`--theme` is required for `--format pdf` and optional for
+`--format text` (defaults to `text-minimal`). When `--output` is
+omitted, the output lands at `dist/resume.pdf` for PDF and
+`dist/resume.txt` for text; parent directories are created as needed.
 Both subcommands read from stdin if no path is given.
 
 Exit codes (same for both subcommands):

--- a/assets/themes/text-minimal/LICENSE
+++ b/assets/themes/text-minimal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Clonch and ferrocv contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/themes/text-minimal/resume.typ
+++ b/assets/themes/text-minimal/resume.typ
@@ -1,0 +1,238 @@
+// text-minimal — a native ferrocv theme optimized for plain-text
+// extraction via the Frame-walk extractor in `crate::render::compile_text`.
+//
+// Design constraints (see CLAUDE.md, CONSTITUTION.md §3, §4):
+// - Single column. No tables, no grids, no figures, no images, no
+//   columns(). Multi-column layout produces zig-zag reading order
+//   under y-then-x sort.
+// - Plain ASCII only. No bullets like `•`, no arrows, no decorative
+//   glyphs — those survive frame extraction and add ATS noise.
+// - Generous `linebreak()` and `parbreak()` so visual lines in the
+//   compiled frame map cleanly onto extracted text lines.
+// - Default font and size — no font-family directives so the output
+//   is reproducible across hosts (CONSTITUTION §6).
+// - Defensive optional-field reads — JSON Resume v1.0.0 has zero
+//   required fields; every accessor must tolerate missing keys.
+
+#let resume = json("/resume.json")
+
+// --- Optional-field helpers ----------------------------------------
+//
+// `opt(d, k)` returns `d.at(k)` if `d` is a dictionary and `k` is
+// present, otherwise `none`. Lets per-section code stay readable
+// without sprinkling `if "x" in d { ... }` everywhere.
+#let opt(d, k) = if type(d) == dictionary and k in d { d.at(k) } else { none }
+
+// `nz(s)` collapses both absent and empty-string values to `none` so
+// sections can uniformly check `if value != none`.
+#let nz(s) = if s == none or s == "" { none } else { s }
+
+// Join a list of optional strings with `sep`, dropping `none`/empty.
+// Used for location ("city, region, country") where any subset of
+// components may be missing.
+#let join_present(parts, sep) = {
+  let kept = parts.filter(p => p != none and p != "")
+  kept.join(sep)
+}
+
+// Format a date range. Either bound may be missing; an absent
+// `endDate` becomes "Present". Returns `none` if both are absent so
+// the caller can skip the line entirely.
+#let date_range(item) = {
+  let start = nz(opt(item, "startDate"))
+  let end = nz(opt(item, "endDate"))
+  if start == none and end == none {
+    none
+  } else if start != none and end != none {
+    start + " - " + end
+  } else if start != none {
+    start + " - Present"
+  } else {
+    end
+  }
+}
+
+// --- Page setup ----------------------------------------------------
+//
+// 1in margins keep things readable in PDF preview without affecting
+// extraction. Default font (no `set text(font: ...)` call) — the
+// typst-assets default ships with the binary.
+#set page(margin: 1in, header: none, footer: none, numbering: none)
+#set par(justify: false, leading: 0.65em)
+
+// --- Header --------------------------------------------------------
+#let basics = opt(resume, "basics")
+#if basics != none {
+  let name = nz(opt(basics, "name"))
+  let label = nz(opt(basics, "label"))
+  let email = nz(opt(basics, "email"))
+  let phone = nz(opt(basics, "phone"))
+  let url = nz(opt(basics, "url"))
+  let location = opt(basics, "location")
+  let location_line = if location != none {
+    let city = nz(opt(location, "city"))
+    let region = nz(opt(location, "region"))
+    let country = nz(opt(location, "countryCode"))
+    let joined = join_present((city, region, country), ", ")
+    if joined == "" { none } else { joined }
+  } else { none }
+
+  if name != none {
+    text(weight: "bold", size: 14pt)[#name]
+    linebreak()
+  }
+  for line in (label, email, phone, url, location_line) {
+    if line != none {
+      [#line]
+      linebreak()
+    }
+  }
+  parbreak()
+}
+
+// --- Summary -------------------------------------------------------
+#let summary = if basics != none { nz(opt(basics, "summary")) } else { none }
+#if summary != none {
+  text(weight: "bold")[Summary]
+  parbreak()
+  [#summary]
+  parbreak()
+}
+
+// --- Work ----------------------------------------------------------
+#let work = opt(resume, "work")
+#if work != none and type(work) == array and work.len() > 0 {
+  text(weight: "bold")[Work]
+  parbreak()
+  for entry in work {
+    let name = nz(opt(entry, "name"))
+    let position = nz(opt(entry, "position"))
+    let header = if name != none and position != none {
+      position + " - " + name
+    } else if name != none {
+      name
+    } else if position != none {
+      position
+    } else { none }
+    if header != none {
+      text(weight: "bold")[#header]
+      linebreak()
+    }
+    let dates = date_range(entry)
+    if dates != none {
+      [#dates]
+      linebreak()
+    }
+    let work_summary = nz(opt(entry, "summary"))
+    if work_summary != none {
+      [#work_summary]
+      linebreak()
+    }
+    let highlights = opt(entry, "highlights")
+    if highlights != none and type(highlights) == array {
+      for h in highlights {
+        if h != none and h != "" {
+          // Pre-build the prefixed string in code mode so the literal
+          // "- " never enters Typst markup mode, where it would be
+          // parsed as a list item and rendered with a `•` bullet.
+          // Bullets survive frame extraction and add ATS noise.
+          let prefixed = "- " + h
+          [#prefixed]
+          linebreak()
+        }
+      }
+    }
+    parbreak()
+  }
+}
+
+// --- Education -----------------------------------------------------
+#let education = opt(resume, "education")
+#if education != none and type(education) == array and education.len() > 0 {
+  text(weight: "bold")[Education]
+  parbreak()
+  for entry in education {
+    let institution = nz(opt(entry, "institution"))
+    if institution != none {
+      text(weight: "bold")[#institution]
+      linebreak()
+    }
+    let study_type = nz(opt(entry, "studyType"))
+    let area = nz(opt(entry, "area"))
+    let study_line = join_present((study_type, area), ", ")
+    if study_line != "" {
+      [#study_line]
+      linebreak()
+    }
+    let dates = date_range(entry)
+    if dates != none {
+      [#dates]
+      linebreak()
+    }
+    parbreak()
+  }
+}
+
+// --- Skills --------------------------------------------------------
+#let skills = opt(resume, "skills")
+#if skills != none and type(skills) == array and skills.len() > 0 {
+  text(weight: "bold")[Skills]
+  parbreak()
+  for skill in skills {
+    let name = nz(opt(skill, "name"))
+    let level = nz(opt(skill, "level"))
+    let keywords = opt(skill, "keywords")
+    let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+      keywords.filter(k => k != none and k != "").join(", ")
+    } else { none }
+    let label_part = if name != none and level != none {
+      name + " (" + level + ")"
+    } else if name != none {
+      name
+    } else if level != none {
+      level
+    } else { none }
+    let line = if label_part != none and keywords_str != none and keywords_str != "" {
+      label_part + ": " + keywords_str
+    } else if label_part != none {
+      label_part
+    } else if keywords_str != none {
+      keywords_str
+    } else { none }
+    if line != none {
+      [#line]
+      linebreak()
+    }
+  }
+  parbreak()
+}
+
+// --- Projects ------------------------------------------------------
+#let projects = opt(resume, "projects")
+#if projects != none and type(projects) == array and projects.len() > 0 {
+  text(weight: "bold")[Projects]
+  parbreak()
+  for entry in projects {
+    let name = nz(opt(entry, "name"))
+    if name != none {
+      text(weight: "bold")[#name]
+      linebreak()
+    }
+    let description = nz(opt(entry, "description"))
+    if description != none {
+      [#description]
+      linebreak()
+    }
+    let url = nz(opt(entry, "url"))
+    if url != none {
+      [#url]
+      linebreak()
+    }
+    let dates = date_range(entry)
+    if dates != none {
+      [#dates]
+      linebreak()
+    }
+    parbreak()
+  }
+}

--- a/assets/themes/text-minimal/resume.typ
+++ b/assets/themes/text-minimal/resume.typ
@@ -87,6 +87,35 @@
       linebreak()
     }
   }
+  // basics.profiles — emit each as a contact-style line. Treated as
+  // header continuation rather than a separate section so the
+  // rendering matches how social profiles read on a real resume.
+  let profiles = opt(basics, "profiles")
+  if profiles != none and type(profiles) == array {
+    for profile in profiles {
+      let network = nz(opt(profile, "network"))
+      let username = nz(opt(profile, "username"))
+      let url = nz(opt(profile, "url"))
+      let label_part = if network != none and username != none {
+        network + ": " + username
+      } else if network != none {
+        network
+      } else if username != none {
+        username
+      } else { none }
+      let line = if label_part != none and url != none {
+        label_part + " - " + url
+      } else if label_part != none {
+        label_part
+      } else if url != none {
+        url
+      } else { none }
+      if line != none {
+        [#line]
+        linebreak()
+      }
+    }
+  }
   parbreak()
 }
 
@@ -231,6 +260,204 @@
     let dates = date_range(entry)
     if dates != none {
       [#dates]
+      linebreak()
+    }
+    parbreak()
+  }
+}
+
+// --- Volunteer -----------------------------------------------------
+#let volunteer = opt(resume, "volunteer")
+#if volunteer != none and type(volunteer) == array and volunteer.len() > 0 {
+  text(weight: "bold")[Volunteer]
+  parbreak()
+  for entry in volunteer {
+    let organization = nz(opt(entry, "organization"))
+    let position = nz(opt(entry, "position"))
+    let header = if organization != none and position != none {
+      position + " - " + organization
+    } else if organization != none {
+      organization
+    } else if position != none {
+      position
+    } else { none }
+    if header != none {
+      text(weight: "bold")[#header]
+      linebreak()
+    }
+    let dates = date_range(entry)
+    if dates != none {
+      [#dates]
+      linebreak()
+    }
+    let v_summary = nz(opt(entry, "summary"))
+    if v_summary != none {
+      [#v_summary]
+      linebreak()
+    }
+    let highlights = opt(entry, "highlights")
+    if highlights != none and type(highlights) == array {
+      for h in highlights {
+        if h != none and h != "" {
+          let prefixed = "- " + h
+          [#prefixed]
+          linebreak()
+        }
+      }
+    }
+    parbreak()
+  }
+}
+
+// --- Awards --------------------------------------------------------
+#let awards = opt(resume, "awards")
+#if awards != none and type(awards) == array and awards.len() > 0 {
+  text(weight: "bold")[Awards]
+  parbreak()
+  for entry in awards {
+    let title = nz(opt(entry, "title"))
+    if title != none {
+      text(weight: "bold")[#title]
+      linebreak()
+    }
+    let awarder = nz(opt(entry, "awarder"))
+    let date = nz(opt(entry, "date"))
+    let meta = join_present((awarder, date), " - ")
+    if meta != "" {
+      [#meta]
+      linebreak()
+    }
+    let a_summary = nz(opt(entry, "summary"))
+    if a_summary != none {
+      [#a_summary]
+      linebreak()
+    }
+    parbreak()
+  }
+}
+
+// --- Certificates --------------------------------------------------
+#let certificates = opt(resume, "certificates")
+#if certificates != none and type(certificates) == array and certificates.len() > 0 {
+  text(weight: "bold")[Certificates]
+  parbreak()
+  for entry in certificates {
+    let name = nz(opt(entry, "name"))
+    if name != none {
+      text(weight: "bold")[#name]
+      linebreak()
+    }
+    let issuer = nz(opt(entry, "issuer"))
+    let date = nz(opt(entry, "date"))
+    let meta = join_present((issuer, date), " - ")
+    if meta != "" {
+      [#meta]
+      linebreak()
+    }
+    let url = nz(opt(entry, "url"))
+    if url != none {
+      [#url]
+      linebreak()
+    }
+    parbreak()
+  }
+}
+
+// --- Publications --------------------------------------------------
+#let publications = opt(resume, "publications")
+#if publications != none and type(publications) == array and publications.len() > 0 {
+  text(weight: "bold")[Publications]
+  parbreak()
+  for entry in publications {
+    let name = nz(opt(entry, "name"))
+    if name != none {
+      text(weight: "bold")[#name]
+      linebreak()
+    }
+    let publisher = nz(opt(entry, "publisher"))
+    let release = nz(opt(entry, "releaseDate"))
+    let meta = join_present((publisher, release), " - ")
+    if meta != "" {
+      [#meta]
+      linebreak()
+    }
+    let url = nz(opt(entry, "url"))
+    if url != none {
+      [#url]
+      linebreak()
+    }
+    let p_summary = nz(opt(entry, "summary"))
+    if p_summary != none {
+      [#p_summary]
+      linebreak()
+    }
+    parbreak()
+  }
+}
+
+// --- Languages -----------------------------------------------------
+#let languages = opt(resume, "languages")
+#if languages != none and type(languages) == array and languages.len() > 0 {
+  text(weight: "bold")[Languages]
+  parbreak()
+  for entry in languages {
+    let language = nz(opt(entry, "language"))
+    let fluency = nz(opt(entry, "fluency"))
+    let line = if language != none and fluency != none {
+      language + " (" + fluency + ")"
+    } else if language != none {
+      language
+    } else if fluency != none {
+      fluency
+    } else { none }
+    if line != none {
+      [#line]
+      linebreak()
+    }
+  }
+  parbreak()
+}
+
+// --- Interests -----------------------------------------------------
+#let interests = opt(resume, "interests")
+#if interests != none and type(interests) == array and interests.len() > 0 {
+  text(weight: "bold")[Interests]
+  parbreak()
+  for entry in interests {
+    let name = nz(opt(entry, "name"))
+    let keywords = opt(entry, "keywords")
+    let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+      keywords.filter(k => k != none and k != "").join(", ")
+    } else { none }
+    let line = if name != none and keywords_str != none and keywords_str != "" {
+      name + ": " + keywords_str
+    } else if name != none {
+      name
+    } else if keywords_str != none {
+      keywords_str
+    } else { none }
+    if line != none {
+      [#line]
+      linebreak()
+    }
+  }
+  parbreak()
+}
+
+// --- References ----------------------------------------------------
+#let references = opt(resume, "references")
+#if references != none and type(references) == array and references.len() > 0 {
+  text(weight: "bold")[References]
+  parbreak()
+  for entry in references {
+    let name = nz(opt(entry, "name"))
+    if name != none {
+      text(weight: "bold")[#name]
+      linebreak()
+    }
+    let reference = nz(opt(entry, "reference"))
+    if reference != none {
+      [#reference]
       linebreak()
     }
     parbreak()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,11 @@
 //! Exit codes (contractual, shared across subcommands):
 //! - `0` — operation succeeded
 //!   - `validate`: document is valid
-//!   - `render`: PDF written to `--output`
+//!   - `render`: PDF or text written to `--output`
 //! - `1` — document parsed as JSON but failed schema validation
-//! - `2` — usage error, IO error, malformed JSON, unknown theme,
-//!   unknown format, or Typst render error
+//! - `2` — usage error (e.g. `--theme` missing for `--format pdf`),
+//!   IO error, malformed JSON, unknown theme, unknown format, or
+//!   Typst render error
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -20,7 +21,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use serde_json::Value;
 
-use crate::{THEMES, ValidationError, compile_theme, find_theme, validate_value};
+use crate::{THEMES, ValidationError, compile_text, compile_theme, find_theme, validate_value};
 
 /// Render JSON Resume documents via embedded Typst.
 #[derive(Debug, Parser)]
@@ -41,23 +42,32 @@ enum Commands {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
     },
-    /// Render a JSON Resume document to PDF via the named theme.
+    /// Render a JSON Resume document to PDF or plain text via the
+    /// named theme.
+    ///
+    /// `--theme` is required for `--format pdf` (no sensible default
+    /// adapter to pick). For `--format text` it defaults to the native
+    /// `text-minimal` theme so plain-text output works out of the box.
     ///
     /// Exit codes:
-    /// - 0 — rendered successfully; PDF written to --output
+    /// - 0 — rendered successfully; output written to --output
     /// - 1 — JSON parsed but failed schema validation
-    /// - 2 — IO error, parse error, unknown theme, or render error
+    /// - 2 — usage error (missing required `--theme` for pdf), IO
+    ///   error, parse error, unknown theme, or render error
     Render {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
         /// Theme name. See the registered themes in `ferrocv::THEMES`.
+        /// Optional for `--format text` (defaults to `text-minimal`);
+        /// required for `--format pdf`.
         #[arg(long)]
-        theme: String,
-        /// Output format. Only `pdf` is supported in Phase 1.
+        theme: Option<String>,
+        /// Output format. Defaults to `pdf`.
         #[arg(long, default_value = "pdf")]
         format: Format,
         /// Output file path. Parent directories are created as needed.
-        /// Defaults to `dist/resume.pdf`.
+        /// Defaults to `dist/resume.pdf` for `--format pdf` and
+        /// `dist/resume.txt` for `--format text`.
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
     },
@@ -65,13 +75,39 @@ enum Commands {
 
 /// Output formats supported by `ferrocv render`.
 ///
-/// Phase 1 ships PDF only. HTML and plain text land in Phase 2 (#14)
-/// — adding them is a matter of new variants plus a matching arm in
-/// [`run_render`]'s format dispatch, not a refactor.
+/// Phase 2 ships PDF and plain text. HTML is tracked separately
+/// (issue #44).
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Format {
     Pdf,
-    // TODO Phase 2 (#14): Html, Text
+    Text,
+    // TODO Phase 2 (#44): Html
+}
+
+/// Resolve which theme name to use given the format and the optional
+/// `--theme` argument.
+///
+/// Returns `Err` when the user must explicitly pick a theme but did not
+/// (currently only `--format pdf`). Returning `&'static str` for the
+/// error keeps allocation off the hot path; the caller prints it
+/// verbatim.
+fn resolve_theme_name(format: Format, requested: Option<&str>) -> Result<&str, &'static str> {
+    match (format, requested) {
+        (_, Some(name)) => Ok(name),
+        (Format::Text, None) => Ok("text-minimal"),
+        (Format::Pdf, None) => Err("error: --theme is required for --format pdf"),
+    }
+}
+
+/// Default output path for a given format.
+///
+/// Centralized so the CLI's defaulting logic and any future docs/tests
+/// agree on a single source of truth.
+fn default_output_path(format: Format) -> PathBuf {
+    match format {
+        Format::Pdf => PathBuf::from("dist/resume.pdf"),
+        Format::Text => PathBuf::from("dist/resume.txt"),
+    }
 }
 
 /// Entry point invoked from `main`.
@@ -87,7 +123,7 @@ pub fn run() -> Result<ExitCode> {
             theme,
             format,
             output,
-        } => run_render(path.as_deref(), &theme, format, output.as_deref()),
+        } => run_render(path.as_deref(), theme.as_deref(), format, output.as_deref()),
     }
 }
 
@@ -133,15 +169,25 @@ fn report_validation_errors(errors: &[ValidationError], suffix: &str) {
 
 fn run_render(
     path: Option<&Path>,
-    theme_name: &str,
+    theme_name: Option<&str>,
     format: Format,
     output: Option<&Path>,
 ) -> Result<ExitCode> {
-    // Step 1: read input. IO failures bubble up via anyhow and main
+    // Step 1: resolve theme name first. A missing `--theme` for pdf is
+    // a usage error and we want to fail before doing IO work.
+    let theme_name = match resolve_theme_name(format, theme_name) {
+        Ok(name) => name,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return Ok(ExitCode::from(2));
+        }
+    };
+
+    // Step 2: read input. IO failures bubble up via anyhow and main
     // maps them to exit code 2 (same as validate).
     let input = read_input(path)?;
 
-    // Step 2: parse JSON.
+    // Step 3: parse JSON.
     let value: Value = match serde_json::from_str(&input) {
         Ok(v) => v,
         Err(err) => {
@@ -150,7 +196,7 @@ fn run_render(
         }
     };
 
-    // Step 3: validate. Render is defined to run validate first so
+    // Step 4: validate. Render is defined to run validate first so
     // users get a clean schema diagnostic before any Typst noise. The
     // header calls out the render-specific consequence (no output
     // written) so a terse validator message doesn't read as a warning.
@@ -159,7 +205,7 @@ fn run_render(
         return Ok(ExitCode::from(1));
     }
 
-    // Step 4: resolve theme. Unknown names list the alternatives so
+    // Step 5: resolve theme. Unknown names list the alternatives so
     // users know what they could have typed.
     let theme = match find_theme(theme_name) {
         Some(t) => t,
@@ -171,8 +217,10 @@ fn run_render(
         }
     };
 
-    // Step 5: format dispatch. Phase 1 ships PDF only.
-    let bytes = match format {
+    // Step 6: format dispatch. PDF returns bytes; text returns a
+    // String which we convert to UTF-8 bytes for the shared write
+    // path below.
+    let bytes: Vec<u8> = match format {
         Format::Pdf => match compile_theme(theme, &value) {
             Ok(bytes) => bytes,
             Err(err) => {
@@ -180,15 +228,21 @@ fn run_render(
                 return Ok(ExitCode::from(2));
             }
         },
-        // TODO Phase 2 (#14): Html, Text
+        Format::Text => match compile_text(theme, &value) {
+            Ok(text) => text.into_bytes(),
+            Err(err) => {
+                eprintln!("{err}");
+                return Ok(ExitCode::from(2));
+            }
+        },
     };
 
-    // Step 6: write output. Default path is `dist/resume.pdf`; parent
+    // Step 7: write output. Default path depends on format; parent
     // directories are created as needed. Overwrites without prompting
     // — this is a build tool.
     let out_path: PathBuf = output
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("dist/resume.pdf"));
+        .unwrap_or_else(|| default_output_path(format));
     if let Some(parent) = out_path.parent()
         && !parent.as_os_str().is_empty()
         && let Err(err) = std::fs::create_dir_all(parent)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod render;
 pub mod theme;
 pub mod validate;
 
-pub use render::{RenderDiagnostic, RenderError, compile_pdf, compile_theme};
+pub use render::{RenderDiagnostic, RenderError, compile_pdf, compile_text, compile_theme};
 pub use theme::{THEMES, Theme, find_theme};
 pub use validate::{ValidationError, validate_value};
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,17 +1,25 @@
-//! In-process Typst compilation to PDF.
+//! In-process Typst compilation to PDF and plain text.
 //!
 //! Wraps the embedded `typst` crate behind a small library surface.
-//! Two public entry points:
+//! Three public entry points:
 //!
 //! - [`compile_pdf`] — compile a single Typst source string against a
 //!   JSON Resume value. Intended for smoke tests, one-off rendering,
 //!   and callers who supply Typst source directly.
 //! - [`compile_theme`] — compile a [`crate::theme::Theme`] (a bundle
 //!   of Typst files shipped with `ferrocv`) against a JSON Resume
-//!   value. This is the path the CLI `render` subcommand uses.
+//!   value. This is the path the CLI `render` subcommand uses for
+//!   PDF output.
+//! - [`compile_text`] — compile a [`crate::theme::Theme`] against a
+//!   JSON Resume value and extract a UTF-8 plain-text rendering by
+//!   walking the compiled frame tree. This is the foundation for
+//!   `ferrocv render --format text` (issue #45). Typst 0.13 has no
+//!   dedicated text exporter, so we read glyph runs directly off
+//!   the [`PagedDocument`] rather than round-tripping through PDF
+//!   or HTML.
 //!
-//! Both run the real Typst compiler in-process (no subprocess, no
-//! shell-out) and return the produced PDF byte vector.
+//! All three run the real Typst compiler in-process (no subprocess,
+//! no shell-out) and return either PDF bytes or extracted text.
 //!
 //! # Constitutional commitments
 //!
@@ -61,7 +69,7 @@ use std::sync::OnceLock;
 use serde_json::Value;
 use typst::diag::{FileError, FileResult, PackageError, Warned};
 use typst::foundations::{Bytes, Datetime};
-use typst::layout::PagedDocument;
+use typst::layout::{Frame, FrameItem, PagedDocument};
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -178,6 +186,64 @@ pub fn compile_theme(theme: &Theme, data: &Value) -> Result<Vec<u8>, RenderError
     render_world(&world)
 }
 
+/// Compile a [`Theme`] bundle to a UTF-8 plain-text rendering against
+/// a JSON Resume value.
+///
+/// Mirrors [`compile_theme`] but produces text instead of PDF bytes,
+/// using the same [`FerrocvWorld`] and the same Typst compilation
+/// path. Both functions therefore inherit the same constitutional
+/// guarantees — no subprocess (§2), no network (§6.1), no extended
+/// sandbox capabilities (§6.4).
+///
+/// # Why frame-walk extraction?
+///
+/// Issue #45's open question was *how* to produce plain text. The
+/// candidates were:
+///
+/// 1. A dedicated Typst text exporter — none exists in 0.13.
+/// 2. `typst-html` then strip tags — Typst 0.13 marks HTML export
+///    experimental; coupling text output to an experimental exporter
+///    would bake instability into the surface.
+/// 3. `pdf-extract` round-trip — would promote a dev-only dep into
+///    the runtime, double the work (PDF then re-parse), and produce
+///    text already shaped by PDF layout quirks.
+/// 4. Skip Typst entirely and walk JSON Resume directly — would
+///    diverge from the §3 first-class-target principle (the text
+///    output should reflect the chosen theme's structure, not a
+///    parallel implementation).
+///
+/// We pick the frame walk: after `typst::compile::<PagedDocument>`
+/// returns, every visible glyph run lives in a [`FrameItem::Text`]
+/// inside some [`Frame`]. Walking the tree, recording each text
+/// item's absolute `(page, y, x)`, sorting by reading order, and
+/// joining into lines yields a plain-text rendering that follows the
+/// theme's layout decisions. Zero new dependencies.
+///
+/// # Heuristics
+///
+/// Two pragmatic constants govern grouping:
+///
+/// - `LINE_TOLERANCE_PT` — items whose absolute y differs by less
+///   than this (in points) belong to the same visual line.
+/// - `PARAGRAPH_GAP_PT` — vertical gaps larger than this between
+///   adjacent lines insert a blank line (paragraph break) into the
+///   output.
+///
+/// Both are Phase-2 starting points, tunable as theme golden tests
+/// land in subsequent prompts. Per CONSTITUTION §5, we deliberately
+/// avoid adaptive line-height detection or per-theme configuration
+/// until a real caller demonstrates the need.
+///
+/// # Errors
+///
+/// Returns the same [`RenderError`] type as the PDF path; Typst
+/// compilation diagnostics flow through the shared
+/// `diagnostics_to_error` helper unchanged.
+pub fn compile_text(theme: &Theme, data: &Value) -> Result<String, RenderError> {
+    let world = FerrocvWorld::from_theme(theme, data);
+    render_world_to_text(&world)
+}
+
 /// Shared compile + PDF-serialize path used by both entry points.
 fn render_world(world: &FerrocvWorld) -> Result<Vec<u8>, RenderError> {
     // `typst::compile` returns Warned { output, warnings }. Drop
@@ -192,6 +258,222 @@ fn render_world(world: &FerrocvWorld) -> Result<Vec<u8>, RenderError> {
     // (e.g. for unsupported font features) — surface them via the
     // same RenderError path.
     typst_pdf::pdf(&document, &PdfOptions::default()).map_err(diagnostics_to_error)
+}
+
+/// Shared compile + frame-walk path used by [`compile_text`].
+///
+/// Mirrors [`render_world`]'s shape: drive the same Typst compiler,
+/// surface diagnostics through the same path, then replace the
+/// `typst_pdf::pdf` step with [`extract_text`] over the resulting
+/// [`PagedDocument`].
+fn render_world_to_text(world: &FerrocvWorld) -> Result<String, RenderError> {
+    let Warned {
+        output,
+        warnings: _,
+    } = typst::compile::<PagedDocument>(world);
+    let document = output.map_err(diagnostics_to_error)?;
+    Ok(extract_text(&document))
+}
+
+/// Maximum vertical distance (in PostScript points) between two text
+/// items for them to be considered part of the same visual line.
+///
+/// Tuned empirically: Typst y-coordinates for items on the same line
+/// are typically identical, but rounding through the layout engine
+/// can introduce sub-point jitter. 1pt is generous enough to absorb
+/// jitter without merging genuinely separate lines (most theme
+/// line-spacing is at least 8pt).
+const LINE_TOLERANCE_PT: f64 = 1.0;
+
+/// Minimum vertical gap (in PostScript points) between two
+/// consecutive lines that triggers a paragraph break (blank line) in
+/// the output.
+///
+/// Roughly 1.5× a typical 10pt body line height — chosen to insert a
+/// blank line between section blocks while keeping tight in-paragraph
+/// line wraps glued together. Tunable as theme goldens land.
+const PARAGRAPH_GAP_PT: f64 = 8.0;
+
+/// One text run's position in the compiled document, flattened into
+/// a comparable scalar form.
+///
+/// `y_pt` and `x_pt` are absolute coordinates in points within the
+/// containing page (Typst's origin is top-left, so larger y is lower
+/// on the page). The page index is implicit in the outer container —
+/// per-page items live in their own `Vec` so cross-page y deltas
+/// never get conflated with intra-page paragraph gaps.
+struct TextItemPosition {
+    y_pt: f64,
+    x_pt: f64,
+    text: String,
+}
+
+/// Extract a plain-text rendering from a compiled [`PagedDocument`].
+///
+/// Walks every page's frame tree, collects each [`FrameItem::Text`]
+/// run with its absolute coordinates, sorts by reading order
+/// `(page, y, x)`, groups items into visual lines using
+/// [`LINE_TOLERANCE_PT`], and joins them with paragraph breaks
+/// inserted whenever the vertical gap exceeds [`PARAGRAPH_GAP_PT`].
+/// Pages are separated by a blank line.
+///
+/// The output is normalized so each line has no trailing whitespace,
+/// runs of blank lines collapse to a single blank, leading/trailing
+/// blanks are stripped, and the string ends with exactly one `\n`.
+fn extract_text(document: &PagedDocument) -> String {
+    // Gather per-page items so we can preserve a blank line between
+    // pages without conflating cross-page y deltas with paragraph
+    // gaps.
+    let mut pages: Vec<Vec<TextItemPosition>> = Vec::with_capacity(document.pages.len());
+    for page in &document.pages {
+        let mut page_items: Vec<TextItemPosition> = Vec::new();
+        collect_from_frame(&page.frame, 0.0, 0.0, &mut page_items);
+        pages.push(page_items);
+    }
+
+    let mut page_strings: Vec<String> = Vec::with_capacity(pages.len());
+    for mut items in pages {
+        // Sort within page by reading order. Cross-page ordering is
+        // implicit in the outer Vec.
+        items.sort_by(|a, b| {
+            a.y_pt
+                .partial_cmp(&b.y_pt)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| {
+                    a.x_pt
+                        .partial_cmp(&b.x_pt)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+        });
+
+        let lines = group_into_lines(&items);
+        page_strings.push(join_lines_with_paragraph_breaks(&lines));
+    }
+
+    // Pages are joined by a blank line (paragraph-style separator).
+    let joined = page_strings.join("\n\n");
+    normalize_text(&joined)
+}
+
+/// Recursively walk a [`Frame`], pushing a [`TextItemPosition`] for
+/// every [`FrameItem::Text`] encountered. Group items recurse with
+/// their position added to the running offset so coordinates remain
+/// "absolute" relative to the page origin.
+///
+/// The group's `transform` is intentionally **not** applied: for
+/// reading-order extraction we only need a stable y/x ordering, not
+/// pixel-accurate placement, and applying transforms would force a
+/// 2-D matrix multiply for every nested item without changing the
+/// output line order in any theme we ship.
+fn collect_from_frame(
+    frame: &Frame,
+    offset_x_pt: f64,
+    offset_y_pt: f64,
+    out: &mut Vec<TextItemPosition>,
+) {
+    for (point, item) in frame.items() {
+        let item_x = offset_x_pt + point.x.to_pt();
+        let item_y = offset_y_pt + point.y.to_pt();
+        match item {
+            FrameItem::Text(text_item) => {
+                out.push(TextItemPosition {
+                    y_pt: item_y,
+                    x_pt: item_x,
+                    text: text_item.text.to_string(),
+                });
+            }
+            FrameItem::Group(group) => {
+                collect_from_frame(&group.frame, item_x, item_y, out);
+            }
+            // Shape, Image, Link, Tag carry no plain-text payload we
+            // can render. Links in particular embed their visible
+            // label as separate Text items elsewhere in the frame.
+            _ => {}
+        }
+    }
+}
+
+/// Group a y/x-sorted slice of text items into visual lines.
+///
+/// Items whose `y_pt` is within [`LINE_TOLERANCE_PT`] of the current
+/// line's anchor y join that line; the line's text becomes the
+/// space-joined concatenation of its items. Returns
+/// `(anchor_y_pt, joined_text)` per line so the caller can decide
+/// where to insert paragraph breaks.
+fn group_into_lines(items: &[TextItemPosition]) -> Vec<(f64, String)> {
+    let mut lines: Vec<(f64, String)> = Vec::new();
+    for item in items {
+        match lines.last_mut() {
+            Some((anchor_y, text)) if (item.y_pt - *anchor_y).abs() <= LINE_TOLERANCE_PT => {
+                if !text.is_empty() && !item.text.is_empty() {
+                    text.push(' ');
+                }
+                text.push_str(&item.text);
+            }
+            _ => {
+                lines.push((item.y_pt, item.text.clone()));
+            }
+        }
+    }
+    lines
+}
+
+/// Join `(y_pt, text)` lines into a single string, inserting a blank
+/// line between consecutive lines whose vertical gap exceeds
+/// [`PARAGRAPH_GAP_PT`].
+fn join_lines_with_paragraph_breaks(lines: &[(f64, String)]) -> String {
+    let mut out = String::new();
+    let mut prev_y: Option<f64> = None;
+    for (y, text) in lines {
+        if let Some(prev) = prev_y {
+            let gap = y - prev;
+            if gap > PARAGRAPH_GAP_PT {
+                out.push_str("\n\n");
+            } else {
+                out.push('\n');
+            }
+        }
+        out.push_str(text);
+        prev_y = Some(*y);
+    }
+    out
+}
+
+/// Normalize an extracted-text string for stable downstream use.
+///
+/// - Trim trailing whitespace per line.
+/// - Collapse runs of blank lines to a single blank.
+/// - Strip leading and trailing blank lines.
+/// - Ensure exactly one trailing `\n` (empty input yields `""`).
+///
+/// Mirrors the spirit of `tests/render_theme.rs::normalize` but
+/// operates on extractor output rather than `pdf-extract` output.
+/// The two helpers will likely converge in a later refactor; for
+/// Phase 2 a small duplication is fine (CONSTITUTION §5).
+fn normalize_text(raw: &str) -> String {
+    let trimmed: Vec<String> = raw.lines().map(|l| l.trim_end().to_string()).collect();
+    let mut collapsed: Vec<String> = Vec::with_capacity(trimmed.len());
+    let mut prev_blank = false;
+    for line in trimmed {
+        let is_blank = line.is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        collapsed.push(line);
+        prev_blank = is_blank;
+    }
+    while collapsed.first().is_some_and(|s| s.is_empty()) {
+        collapsed.remove(0);
+    }
+    while collapsed.last().is_some_and(|s| s.is_empty()) {
+        collapsed.pop();
+    }
+    if collapsed.is_empty() {
+        return String::new();
+    }
+    let mut out = collapsed.join("\n");
+    out.push('\n');
+    out
 }
 
 /// Map a Typst `EcoVec<SourceDiagnostic>` into our public error type.
@@ -405,5 +687,76 @@ impl World for FerrocvWorld {
         //   if a theme calls it — a clear, fail-loud signal we can
         //   then address by passing in an explicit reference date.
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test-only helper: extract plain text from an inline Typst
+    /// source string. Mirrors the relationship between
+    /// [`compile_pdf`] and [`compile_theme`] — both go through the
+    /// same [`FerrocvWorld`] and [`render_world_to_text`] paths;
+    /// this just lets the unit tests build a one-file world without
+    /// needing a [`Theme`] bundle.
+    fn compile_text_from_source(source: &str, data: &Value) -> Result<String, RenderError> {
+        let world = FerrocvWorld::from_single_source(source, data);
+        render_world_to_text(&world)
+    }
+
+    #[test]
+    fn extract_text_single_line() {
+        let out = compile_text_from_source("Hello, world.", &Value::Object(Default::default()))
+            .expect("trivial source must compile");
+        assert!(
+            out.contains("Hello, world."),
+            "extracted text must contain the source text; got: {out:?}"
+        );
+        assert!(
+            out.ends_with('\n'),
+            "extracted text must end with exactly one newline; got: {out:?}"
+        );
+        assert!(
+            !out.ends_with("\n\n"),
+            "extracted text must not end with multiple newlines; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn extract_text_paragraph_break_inserts_blank_line() {
+        // Two paragraphs separated by a hard parbreak. The frame walk
+        // should see a vertical gap between the two text runs that
+        // exceeds PARAGRAPH_GAP_PT and emit a blank line between
+        // them.
+        let source = "First paragraph.\n\nSecond paragraph.";
+        let out = compile_text_from_source(source, &Value::Object(Default::default()))
+            .expect("two-paragraph source must compile");
+        assert!(
+            out.contains("First paragraph."),
+            "missing first paragraph; got: {out:?}"
+        );
+        assert!(
+            out.contains("Second paragraph."),
+            "missing second paragraph; got: {out:?}"
+        );
+        assert!(
+            out.contains("\n\n"),
+            "expected a blank line between paragraphs; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn extract_text_empty_document_is_empty_string() {
+        // `#hide()` produces a frame with no visible text items; an
+        // empty string source produces a single blank page. We assert
+        // the empty case yields an empty String (no spurious newline)
+        // — the contract documented on `normalize_text`.
+        let out = compile_text_from_source("", &Value::Object(Default::default()))
+            .expect("empty source must compile");
+        assert_eq!(
+            out, "",
+            "empty document must extract to empty string; got: {out:?}"
+        );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -24,16 +24,17 @@
 //! # Constitutional commitments
 //!
 //! - **§2 — Embed Typst, never subprocess it.** The whole compilation
-//!   path is `typst::compile(&world)` followed by `typst_pdf::pdf(...)`,
-//!   both linked statically. No `std::process::Command`, no shelling
+//!   path is `typst::compile(&world)` followed by either
+//!   `typst_pdf::pdf(...)` (PDF) or a frame-walk extractor (text),
+//!   all linked statically. No `std::process::Command`, no shelling
 //!   out to the `typst` CLI, ever.
 //! - **§6.1 — No network calls at render time.** The [`FerrocvWorld`]
 //!   does not implement a package resolver. Any `FileId` carrying a
 //!   `PackageSpec` (i.e. `@preview/...` imports) returns
 //!   [`FileError::Package(PackageError::NotFound(_))`]. There is no
 //!   code path by which Typst can reach the network from inside
-//!   `compile_pdf` or `compile_theme`. A test in `tests/render.rs`
-//!   enforces this.
+//!   `compile_pdf`, `compile_theme`, or `compile_text`. A test in
+//!   `tests/render.rs` enforces this.
 //! - **§6.4 — Themes run under Typst's native sandbox, nothing more.**
 //!   We do not add filesystem-wide access, shell-escape, or any
 //!   custom capabilities. The World exposes exactly the virtual

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -8,28 +8,34 @@
 //!
 //! # Adapters vs. native themes — CONSTITUTION §4
 //!
-//! Every [`Theme`] in *this* module is an **adapter**: it wraps an
-//! upstream Typst template (e.g. `typst-jsonresume-cv`) and hands it a
-//! JSON Resume structure through the conventional `/resume.json`
-//! virtual file. Adapters accept that upstream layout changes may
-//! break them; in return they give `ferrocv` visual variety without
-//! re-implementing a full resume renderer.
+//! This module's registry currently holds a mix:
 //!
-//! **Native themes** — themes that implement a `render(data) ->
-//! content` contract directly against parsed JSON Resume data — live
-//! in a different module (to be added when Phase 4 begins). Per
-//! CONSTITUTION §4 the two layers are kept separable: adapter code
-//! does not leak into native themes, and native themes do not depend
-//! on adapter internals.
+//! - **Adapters** wrap an upstream Typst template (e.g.
+//!   `typst-jsonresume-cv`) and hand it a JSON Resume structure
+//!   through the conventional `/resume.json` virtual file. Adapters
+//!   accept that upstream layout changes may break them; in return
+//!   they give `ferrocv` visual variety without re-implementing a
+//!   full resume renderer.
+//! - **Native themes** implement a `render(data) -> content` contract
+//!   directly against parsed JSON Resume data. The `text-minimal`
+//!   theme below is the first native theme — it exists to feed clean
+//!   plain-text output to [`crate::render::compile_text`].
+//!
+//! Per CONSTITUTION §4 the two layers are kept separable: adapter
+//! code does not leak into native themes, and native themes do not
+//! depend on adapter internals. §4 also promises that native themes
+//! will eventually live in a dedicated module. For Phase 2, with one
+//! native theme to ship, that split would be premature abstraction
+//! (CONSTITUTION §5: "simple now, iterate later"); the split is
+//! deferred until a second native theme materializes.
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 1 ships with one adapter and Phase 2 is planned to ship with
-//! at most one more. A linear scan over `THEMES` is O(n) for n ≤ 2.
-//! CONSTITUTION §5 ("simple now, iterate later") calls for the
-//! narrower solution here; generalizing to a hashed lookup or a
-//! builder pattern should wait for a second caller that actually
-//! needs it.
+//! Phase 2 ships with two themes total. A linear scan over `THEMES`
+//! is O(n) for n ≤ 2. CONSTITUTION §5 ("simple now, iterate later")
+//! calls for the narrower solution here; generalizing to a hashed
+//! lookup or a builder pattern should wait for a second caller that
+//! actually needs it.
 
 /// A themed Typst source bundle that [`crate::render::compile_theme`]
 /// can compile against a JSON Resume document.
@@ -138,14 +144,66 @@ const _: () = {
     assert!(!FANTASTIC_CV_PREFIX.is_empty());
 };
 
+/// Virtual-path prefix for the `text-minimal` native theme's files.
+///
+/// Same centralization rationale as [`TYPST_JSONRESUME_CV_PREFIX`].
+const TEXT_MINIMAL_PREFIX: &str = "/themes/text-minimal";
+
+/// `text-minimal` — a **native theme** (per CONSTITUTION §4) authored
+/// directly against the JSON Resume v1.0.0 schema, with no upstream
+/// template to wrap.
+///
+/// It exists to produce clean output for
+/// [`crate::render::compile_text`]. The Frame-walk extractor sorts
+/// glyph runs by `(page, y, x)` and joins same-line items with a
+/// space; multi-column or floated layouts therefore produce zig-zag
+/// reading order. `text-minimal` is single-column, uses explicit
+/// `linebreak()` and `parbreak()` for line and paragraph boundaries,
+/// avoids decorative glyphs (no bullets, arrows, dingbats — those
+/// survive frame extraction and add ATS noise), and sticks with the
+/// default font for cross-host reproducibility (CONSTITUTION §6).
+///
+/// Every field access in the theme source is wrapped in
+/// `dict.at(k, default: none)` so any schema-valid JSON Resume
+/// document compiles, including documents that exercise only
+/// `basics.name` (the `render_sparse.json` fixture is the lower
+/// bound).
+///
+/// The MIT-licensed source under `assets/themes/text-minimal/` is
+/// also redistributable under the `ferrocv` crate's MIT-or-Apache-2.0
+/// dual license; the file-level `LICENSE` is duplicated so the theme
+/// remains self-contained if it is ever extracted into its own
+/// package.
+///
+/// CONSTITUTION §4 promises a separate native-themes module
+/// eventually. For Phase 2, with one native theme registered,
+/// splitting is premature abstraction (§5: "simple now, iterate
+/// later"); the split is deferred until a second native theme exists.
+pub const TEXT_MINIMAL: Theme = Theme {
+    name: "text-minimal",
+    files: &[(
+        // Must agree with TEXT_MINIMAL_PREFIX + "/resume.typ".
+        concat!("/themes/text-minimal", "/resume.typ"),
+        include_bytes!("../assets/themes/text-minimal/resume.typ"),
+    )],
+    entrypoint: concat!("/themes/text-minimal", "/resume.typ"),
+};
+
+// Compile-time sanity check, mirror of the one above for the adapter.
+const _: () = {
+    assert!(!TEXT_MINIMAL_PREFIX.is_empty());
+};
+
 /// All themes registered with this build of `ferrocv`.
 ///
-/// Two adapters are registered today (`typst-jsonresume-cv` and
-/// `fantastic-cv`). See the module doc for why this is a `&[&Theme]`
-/// rather than a `HashMap` or a builder pattern — a linear scan over
-/// a handful of entries is fine, and CONSTITUTION §5 calls for the
-/// narrower solution until a caller actually needs more.
-pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV];
+/// Phase 2 ships two adapters (`typst-jsonresume-cv`, `fantastic-cv`)
+/// and one native theme (`text-minimal`). See the module doc for why
+/// this is a `&[&Theme]` rather than a `HashMap` or a builder
+/// pattern — a linear scan over a handful of entries is fine, and
+/// CONSTITUTION §5 calls for the narrower solution until a caller
+/// actually needs more. See the module doc as well for the §4
+/// deferral on splitting native themes into their own module.
+pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV, &TEXT_MINIMAL];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.
 ///

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -144,10 +144,17 @@ const _: () = {
     assert!(!FANTASTIC_CV_PREFIX.is_empty());
 };
 
-/// Virtual-path prefix for the `text-minimal` native theme's files.
+/// Virtual path of the `text-minimal` theme's entrypoint.
 ///
-/// Same centralization rationale as [`TYPST_JSONRESUME_CV_PREFIX`].
-const TEXT_MINIMAL_PREFIX: &str = "/themes/text-minimal";
+/// Single per-file constant used by both the [`Theme::files`] key and
+/// the [`Theme::entrypoint`] field below, so the two cannot drift out
+/// of sync. This is the cleanup CodeRabbit flagged on the original PR
+/// — the previous "prefix" constant was declared but unused (the
+/// `concat!` calls hardcoded the literal), making the centralization
+/// claim cosmetic. The adapter above still uses the older
+/// prefix-as-const pattern; tightening it the same way is its own
+/// scope.
+const TEXT_MINIMAL_RESUME_PATH: &str = "/themes/text-minimal/resume.typ";
 
 /// `text-minimal` — a **native theme** (per CONSTITUTION §4) authored
 /// directly against the JSON Resume v1.0.0 schema, with no upstream
@@ -182,16 +189,10 @@ const TEXT_MINIMAL_PREFIX: &str = "/themes/text-minimal";
 pub const TEXT_MINIMAL: Theme = Theme {
     name: "text-minimal",
     files: &[(
-        // Must agree with TEXT_MINIMAL_PREFIX + "/resume.typ".
-        concat!("/themes/text-minimal", "/resume.typ"),
+        TEXT_MINIMAL_RESUME_PATH,
         include_bytes!("../assets/themes/text-minimal/resume.typ"),
     )],
-    entrypoint: concat!("/themes/text-minimal", "/resume.typ"),
-};
-
-// Compile-time sanity check, mirror of the one above for the adapter.
-const _: () = {
-    assert!(!TEXT_MINIMAL_PREFIX.is_empty());
+    entrypoint: TEXT_MINIMAL_RESUME_PATH,
 };
 
 /// All themes registered with this build of `ferrocv`.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,8 +31,8 @@
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 2 ships with two themes total. A linear scan over `THEMES`
-//! is O(n) for n ≤ 2. CONSTITUTION §5 ("simple now, iterate later")
+//! Phase 2 ships with three themes total. A linear scan over `THEMES`
+//! is O(n) for n ≤ 3. CONSTITUTION §5 ("simple now, iterate later")
 //! calls for the narrower solution here; generalizing to a hashed
 //! lookup or a builder pattern should wait for a second caller that
 //! actually needs it.
@@ -209,7 +209,7 @@ pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV, &TEXT_MINIM
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.
 ///
 /// Linear scan over [`THEMES`]; O(n) for n themes. Acceptable for
-/// the current n ≤ 2 regime (CONSTITUTION §5).
+/// the current n ≤ 3 regime (CONSTITUTION §5).
 pub fn find_theme(name: &str) -> Option<&'static Theme> {
     THEMES.iter().copied().find(|t| t.name == name)
 }

--- a/tests/goldens/text-minimal-sparse.txt
+++ b/tests/goldens/text-minimal-sparse.txt
@@ -1,0 +1,17 @@
+Grace Hopper
+
+Computer Scientist
+
+Summary
+
+Rear admiral and pioneer of computer programming.
+
+Work
+
+Rear Admiral - US Navy
+
+1944-07-01 - Present
+
+- Worked on the Mark I computer at Harvard.
+
+- Developed the first compiler for a computer programming language.

--- a/tests/goldens/text-minimal.txt
+++ b/tests/goldens/text-minimal.txt
@@ -10,6 +10,10 @@ https://example.com/ada
 
 London, England, GB
 
+GitHub: ada - https://github.example.com/ada
+
+LinkedIn: ada-lovelace - https://linkedin.example.com/in/ada-lovelace
+
 Summary
 
 Mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical
@@ -55,3 +59,15 @@ machine.
 https://example.com/notes-g
 
 1842-01-01 - 1843-07-01
+
+Certificates
+
+Honorary Fellowship in Computing History
+
+Analytical Engines Ltd - 1843-09-01
+
+https://example.com/cert
+
+Interests
+
+Poetical Science: Imagination, Mathematics

--- a/tests/goldens/text-minimal.txt
+++ b/tests/goldens/text-minimal.txt
@@ -1,0 +1,57 @@
+Ada Lovelace
+
+Computing Pioneer
+
+ada@example.com
+
++44-20-0000-0000
+
+https://example.com/ada
+
+London, England, GB
+
+Summary
+
+Mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical
+
+general-purpose computer, the Analytical Engine.
+
+Work
+
+Programmer - Analytical Engines Ltd
+
+1843-01-01 - 1852-11-27
+
+Translated and annotated Menabrea's paper on the Analytical Engine; wrote the first published
+
+algorithm intended for machine execution.
+
+- Published the first algorithm designed for a machine (Bernoulli numbers)
+
+- Introduced the concept of a general-purpose computing device
+
+Education
+
+University of London
+
+Self-directed, Mathematics
+
+1833-01-01 - 1843-01-01
+
+Skills
+
+Programming (Pioneer): Analytical Engine, Algorithms
+
+Mathematics (Expert): Calculus, Symbolic logic
+
+Projects
+
+Notes on the Analytical Engine
+
+Expanded translation of Menabrea's sketch, including the first published algorithm for a computing
+
+machine.
+
+https://example.com/notes-g
+
+1842-01-01 - 1843-07-01

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -204,19 +204,174 @@ fn render_rejects_unknown_format_with_exit_two() {
     let out = tmp.path().join("out.pdf");
 
     // clap's ValueEnum mismatch exits 2 before we reach any of our code.
+    // `xml` stands in for "any format we don't ship"; `html` was the
+    // previous canary but is reserved for #44 and may land soon.
     ferrocv()
         .arg("render")
         .arg(fixture("render_full"))
         .arg("--theme")
         .arg("typst-jsonresume-cv")
         .arg("--format")
-        .arg("html")
+        .arg("xml")
         .arg("--output")
         .arg(&out)
         .assert()
         .code(2);
 
     assert!(!out.exists());
+}
+
+// --- Text format scenarios ---------------------------------------------
+//
+// Mirror the PDF scenarios above for `--format text`. The `text-minimal`
+// native theme is exercised end-to-end through the CLI (file existence,
+// recognizable content, exit-code contract). Byte-level structure of the
+// extracted text is asserted by the golden test in `tests/render_text.rs`,
+// not here.
+
+#[test]
+fn render_writes_text_to_output_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("text-minimal")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(!body.is_empty(), "text output must not be empty");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "text output must contain the rendered name; got: {body:?}"
+    );
+}
+
+#[test]
+fn render_text_uses_text_minimal_when_theme_omitted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "text output must contain the rendered name; got: {body:?}"
+    );
+}
+
+#[test]
+fn render_text_default_output_path_is_dist_resume_txt() {
+    // No `--output`, no `--theme`. `current_dir` is set to a tempdir so
+    // the default `dist/resume.txt` lands under the temp tree rather
+    // than polluting the workspace.
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    ferrocv()
+        .current_dir(tmp.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--format")
+        .arg("text")
+        .assert()
+        .success();
+
+    let expected = tmp.path().join("dist/resume.txt");
+    assert!(
+        expected.exists(),
+        "default text output must land at <cwd>/dist/resume.txt; expected {}",
+        expected.display()
+    );
+}
+
+#[test]
+fn render_text_rejects_invalid_resume_with_exit_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("invalid_wrong_type_email"))
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("/basics/email"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written when validation fails",
+    );
+}
+
+#[test]
+fn render_pdf_requires_theme_flag() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    // No `--theme`; explicit `--format pdf` (also the default).
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("--theme is required"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written when --theme is missing",
+    );
+}
+
+#[test]
+fn render_text_accepts_resume_on_stdin() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+    let input =
+        std::fs::read_to_string(fixture("render_full")).expect("fixture `render_full.json`");
+
+    ferrocv()
+        .arg("render")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .write_stdin(input)
+        .assert()
+        .success();
+
+    assert!(out.exists());
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "text output must contain the rendered name; got: {body:?}"
+    );
 }
 
 #[test]

--- a/tests/render_text.rs
+++ b/tests/render_text.rs
@@ -1,0 +1,183 @@
+//! Golden-file tests for the `text-minimal` native theme.
+//!
+//! Enforces CONSTITUTION testing doctrine:
+//! - **§2** — every theme has a golden-file test. We compile the
+//!   `text-minimal` native theme against committed fixtures via
+//!   [`ferrocv::compile_text`] (the same path the `render --format text`
+//!   CLI takes) and compare its normalized output against committed
+//!   reference files. Where the PDF golden in `tests/render_theme.rs`
+//!   defends against PDF-extraction regressions in an *adapter*, this
+//!   golden defends against text-extraction regressions in our own
+//!   *native* theme; both are first-class, per CONSTITUTION §3.
+//! - **§4** — no mocking Typst. Runs the real embedded compiler.
+//!
+//! Mirrors the structure of `tests/render_theme.rs`; the small
+//! `normalize()` helper is intentionally duplicated rather than
+//! refactored into a shared module so the two test files stay
+//! independently runnable and the no-shared-helper rule is preserved
+//! per the prompt that introduced this file (CONSTITUTION §5: simple
+//! now, iterate later — share when there's a third caller, not the
+//! second).
+//!
+//! # Updating the goldens
+//!
+//! If a Typst patch bump or an intentional theme edit legitimately
+//! shifts the rendered text, regenerate with:
+//!
+//! ```sh
+//! UPDATE_GOLDEN=1 cargo test --test render_text
+//! ```
+//!
+//! Inspect the diffs under `tests/goldens/` before committing. A
+//! golden update should always have an obvious cause; an unexplained
+//! diff is a regression, not a golden bump.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+/// Environment variable that, when set to any non-empty value, rewrites
+/// the relevant golden with the current run's normalized output
+/// instead of asserting equality.
+const UPDATE_ENV: &str = "UPDATE_GOLDEN";
+
+#[test]
+fn text_minimal_renders_ada_lovelace_to_expected_text() {
+    run_golden(
+        "tests/fixtures/render_full.json",
+        "tests/goldens/text-minimal.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn text_minimal_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/text-minimal-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
+/// Shared golden-file workflow: compile `text-minimal` against the
+/// named fixture, normalize the extracted text, and compare against
+/// (or rewrite, under `UPDATE_GOLDEN`) the committed golden.
+///
+/// `required_name` is a substring the extracted text must contain
+/// before we'll consider writing a golden from it — a cheap sanity
+/// check that the extractor hasn't degenerated and we're not about to
+/// freeze garbage.
+fn run_golden(fixture: &str, golden: &str, required_name: &str) {
+    let fixture_path = crate_path(fixture);
+    let fixture_bytes = fs::read(&fixture_path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", fixture_path.display()));
+    let data: Value = serde_json::from_slice(&fixture_bytes)
+        .unwrap_or_else(|e| panic!("parse fixture {}: {e}", fixture_path.display()));
+
+    let theme = ferrocv::find_theme("text-minimal").expect("theme must be registered in THEMES");
+
+    let raw = ferrocv::compile_text(theme, &data).unwrap_or_else(|e| {
+        panic!(
+            "text-minimal must compile against {}: {e}",
+            fixture_path.display()
+        )
+    });
+    let normalized = normalize(&raw);
+
+    // Sanity check runs BEFORE any golden write. If the extractor ever
+    // returns empty or degenerate text, we refuse to regenerate the
+    // golden from that garbage.
+    assert!(
+        normalized.contains(required_name),
+        "extracted text must contain the fixture's name `{required_name}`; \
+         got {} bytes of normalized text starting with:\n{}",
+        normalized.len(),
+        normalized.chars().take(200).collect::<String>(),
+    );
+
+    let golden_path = crate_path(golden);
+
+    if std::env::var_os(UPDATE_ENV).is_some_and(|v| !v.is_empty()) {
+        if let Some(parent) = golden_path.parent() {
+            fs::create_dir_all(parent)
+                .unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+        }
+        fs::write(&golden_path, &normalized)
+            .unwrap_or_else(|e| panic!("write golden {}: {e}", golden_path.display()));
+        eprintln!(
+            "{UPDATE_ENV} set: wrote {} bytes to {}. \
+             Re-run without {UPDATE_ENV} to verify.",
+            normalized.len(),
+            golden_path.display(),
+        );
+        return;
+    }
+
+    let expected_raw = fs::read_to_string(&golden_path).unwrap_or_else(|e| {
+        panic!(
+            "read golden {}: {e}\nTo create it, run: \
+             UPDATE_GOLDEN=1 cargo test --test render_text",
+            golden_path.display(),
+        )
+    });
+    // Normalize the on-disk golden too so CRLF-delimited checkouts
+    // (Windows + git autocrlf) match the always-LF output of
+    // `normalize()`.
+    let expected = normalize(&expected_raw);
+
+    assert_eq!(
+        normalized,
+        expected,
+        "text-minimal golden mismatch for {}. \
+         Regenerate with `UPDATE_GOLDEN=1 cargo test --test render_text` \
+         if the difference is expected (e.g., Typst version bump or an \
+         intentional theme edit).",
+        golden_path.display(),
+    );
+}
+
+/// Normalize extracted text so the golden is stable against trivial
+/// whitespace differences without hiding real regressions.
+///
+/// Kept deliberately narrow:
+/// - trim trailing whitespace on each line
+/// - collapse runs of blank lines to a single blank
+/// - strip leading and trailing blank lines
+/// - ensure exactly one trailing newline
+///
+/// Do NOT lowercase, Unicode-normalize, or collapse intra-line
+/// whitespace — those transformations would hide regressions the
+/// golden is meant to catch.
+///
+/// Duplicated verbatim from `tests/render_theme.rs::normalize`; see
+/// the module-level docs for why we don't share it yet.
+fn normalize(raw: &str) -> String {
+    let mut lines: Vec<String> = raw.lines().map(|l| l.trim_end().to_string()).collect();
+    let mut collapsed: Vec<String> = Vec::with_capacity(lines.len());
+    let mut prev_blank = false;
+    for line in lines.drain(..) {
+        let is_blank = line.is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        collapsed.push(line);
+        prev_blank = is_blank;
+    }
+    while collapsed.first().is_some_and(|s| s.is_empty()) {
+        collapsed.remove(0);
+    }
+    while collapsed.last().is_some_and(|s| s.is_empty()) {
+        collapsed.pop();
+    }
+    let mut out = collapsed.join("\n");
+    out.push('\n');
+    out
+}
+
+/// Resolve a path relative to the crate root (where `Cargo.toml`
+/// lives). Cargo sets `CARGO_MANIFEST_DIR` for integration tests, so
+/// this works regardless of the shell's `cwd` at test time.
+fn crate_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative)
+}


### PR DESCRIPTION
## Summary
- Adds `ferrocv render --format text` for ATS/email-body plaintext output (CONSTITUTION §3 first-class target).
- New built-in `text-minimal` native Typst theme; `--theme` is optional for text (defaults to `text-minimal`), still required for pdf.
- Default output path is format-aware: `dist/resume.txt` for text, `dist/resume.pdf` for pdf.

## Open question resolution
Issue #45 asks: does Typst's text export produce acceptable output, or do we need a custom Typst theme?

Typst 0.13 ships `typst-pdf` and `typst-html` exporter crates but **no `typst-text` exporter**. The three viable strategies were:

1. **Frame-walk extraction** — walk the compiled `PagedDocument`, collect `FrameItem::Text` items, sort by absolute (page, y, x), group into lines via a y-tolerance heuristic.
2. `typst-html` + tag stripping — couples to an experimental crate that may shift in 0.14.
3. PDF + `pdf-extract` at runtime — adds ~30 transitive deps and double-renders.

**Chose strategy 1.** It reuses the existing `FerrocvWorld` (preserving §6.1 no-network guarantees), keeps the render pipeline uniform per the issue's stated preference, and adds zero new runtime dependencies. Pairing it with a purpose-built single-column `text-minimal` theme keeps reading order predictable.

## Implementation notes
- `compile_text(theme, &Value) -> Result<String, RenderError>` mirrors the shape of `compile_theme`.
- The y-grouping heuristics (`LINE_TOLERANCE_PT = 1.0`, `PARAGRAPH_GAP_PT = 8.0`) are pragmatic Phase 2 choices — tunable as goldens evolve. A known follow-up: soft-wrapped lines currently appear paragraph-separated; tightening `PARAGRAPH_GAP_PT` (or theme-side spacing) can glue them back together. Left as-is per CONSTITUTION §5 (simple now, iterate later); the goldens lock in current behavior.
- `text-minimal` is technically a native theme per §4 but registered alongside the existing adapter for Phase 2; the §4 module split will land with Phase 4.

## Test plan
- [x] `make preflight` passes (fmt-check, clippy -D warnings, test, deny, audit, typos)
- [x] 6 new CLI scenario tests (happy path, implicit theme, default output path, schema-invalid exit 1, pdf-requires-theme regression guard, stdin input)
- [x] 2 new golden-file tests (Ada Lovelace full, Grace Hopper sparse) — committed under `tests/goldens/text-minimal.txt` and `tests/goldens/text-minimal-sparse.txt`
- [x] No regressions in the existing PDF render path
- [x] Manual smoke: `cargo run -- render tests/fixtures/render_full.json --format text` produces a recognizable resume
- [x] Manual smoke: `cargo run -- render tests/fixtures/render_full.json --format pdf` errors with "--theme is required for --format pdf" and exit 2

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plain-text resume output (new --format text) with a native "text-minimal" theme and format-specific default output path.
  * Theme is now optional for text output; theme remains required for PDF.

* **Documentation**
  * README updated with status, usage examples, and revised render option defaults and output behaviors.

* **Tests**
  * New golden and integration tests covering text rendering and CLI scenarios.

* **Chores**
  * Added MIT license for the text-minimal theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->