### PR TITLE
Add modern-cv theme adapter

### DIFF
--- a/assets/themes/modern-cv/LICENSE
+++ b/assets/themes/modern-cv/LICENSE
@@ -1,0 +1,189 @@
+MIT License
+
+Copyright (c) 2024 Paul Tsouchlos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Fonticons, Inc. (https://fontawesome.com)
+
+--------------------------------------------------------------------------------
+
+Font Awesome Free License
+
+Font Awesome Free is free, open source, and GPL friendly. You can use it for
+commercial projects, open source projects, or really almost whatever you want.
+Full Font Awesome Free license: https://fontawesome.com/license/free.
+
+--------------------------------------------------------------------------------
+
+# Icons: CC BY 4.0 License (https://creativecommons.org/licenses/by/4.0/)
+
+The Font Awesome Free download is licensed under a Creative Commons
+Attribution 4.0 International License and applies to all icons packaged
+as SVG and JS file types.
+
+--------------------------------------------------------------------------------
+
+# Fonts: SIL OFL 1.1 License
+
+In the Font Awesome Free download, the SIL OFL license applies to all icons
+packaged as web and desktop font files.
+
+Copyright (c) 2023 Fonticons, Inc. (https://fontawesome.com)
+with Reserved Font Name: "Font Awesome".
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting — in part or in whole — any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+# Code: MIT License (https://opensource.org/licenses/MIT)
+
+In the Font Awesome Free download, the MIT license applies to all non-font and
+non-icon files.
+
+Copyright 2023 Fonticons, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+# Attribution
+
+Attribution is required by MIT, SIL OFL, and CC BY licenses. Downloaded Font
+Awesome Free files already contain embedded comments with sufficient
+attribution, so you shouldn't need to do anything additional when using these
+files normally.
+
+We've kept attribution comments terse, so we ask that you do not actively work
+to remove them from files, especially code. They're a great way for folks to
+learn about Font Awesome.
+
+--------------------------------------------------------------------------------
+
+# Brand Icons
+
+All brand icons are trademarks of their respective owners. The use of these
+trademarks does not indicate endorsement of the trademark holder by Font
+Awesome, nor vice versa. **Please do not use brand logos for any purpose except
+to represent the company, product, or service to which they refer.**

--- a/assets/themes/modern-cv/VENDORING.md
+++ b/assets/themes/modern-cv/VENDORING.md
@@ -1,0 +1,374 @@
+# Vendoring record — modern-cv
+
+This directory contains a vendored, **patched** copy of the
+[`DeveloperPaul123/modern-cv`] Typst resume template (canonical slug:
+`ptsouchlos/modern-cv`), plus an authored glue entrypoint
+(`resume.typ`) that maps JSON Resume v1.0.0 documents onto modern-cv's
+helper-function call shape. The patches to `lib.typ` serve
+`CONSTITUTION.md` §6.1 (no network calls at render time); the glue file
+lives under §4 (adapter layer kept separable).
+
+[`DeveloperPaul123/modern-cv`]: https://github.com/DeveloperPaul123/modern-cv
+
+## Provenance
+
+| Field                | Value                                                                  |
+| -------------------- | ---------------------------------------------------------------------- |
+| Upstream (canonical) | https://github.com/ptsouchlos/modern-cv                                |
+| Upstream (legacy)    | https://github.com/DeveloperPaul123/modern-cv (redirects to canonical) |
+| Commit SHA           | `dcb863f722b22255b170de9e802ece97bf5f763f`                             |
+| Commit date          | 2025-09-09                                                             |
+| Release tag          | `0.9.0-patch`                                                          |
+| Package version      | 0.9.0                                                                  |
+| Upstream source path | `lib.typ` (repo root)                                                  |
+| Vendor date          | 2026-04-19                                                             |
+
+## License
+
+Upstream `LICENSE` is **MIT**, copyright Paul Tsouchlos, 2024.
+Upstream `typst.toml` also declares MIT; there is no discrepancy
+between the two. The MIT license is compatible with `ferrocv`'s
+MIT-OR-Apache-2.0 dual license under the standard permissive-license
+compatibility path.
+
+We copy the upstream `LICENSE` verbatim into
+[`LICENSE`](./LICENSE) in this directory so the full provenance chain
+is preserved in-tree. The upstream `LICENSE` also appends Font Awesome
+license notices; we keep those verbatim even though Patch A removes
+all Font Awesome usages — the text is short and preserving the
+upstream file lets us re-verify the copy mechanically on every
+re-vendor.
+
+## Patches applied
+
+Three patches were applied to the upstream `lib.typ` to make it
+compile under `ferrocv::render::FerrocvWorld` without reaching the
+network or crashing on a missing wall clock. All three are recorded
+below with before/after snippets.
+
+### A. Remove `fontawesome` Typst Universe import and every icon call site
+
+**Why:** `CONSTITUTION.md` §6.1 forbids network fetches at render
+time, and `FerrocvWorld` rejects any `FileId` carrying a
+`PackageSpec`. Upstream's first line pulled in the fontawesome
+package from Typst Universe, which would trigger a package-registry
+fetch on first compile.
+
+**Before** (upstream lines 1, 6, 16-28, 134, 419, 799):
+
+```typst
+#import "@preview/fontawesome:0.6.0": *
+
+// TODO(PT): Move to Fontawesome 7
+// for now, specify Fontawesome 6
+#fa-version("6")
+```
+
+```typst
+#let linkedin-icon = box(fa-icon("linkedin", fill: color-darknight))
+#let github-icon = box(fa-icon("github", fill: color-darknight))
+// ... (11 more icon consts follow the same pattern)
+#let address-icon = box(fa-icon("location-crosshairs", fill: color-darknight))
+```
+
+```typst
+#let github-link(github-path) = {
+  set box(height: 11pt)
+
+  align(right + horizon)[
+    #fa-icon("github", fill: color-darkgray) #link(
+      "https://github.com/" + github-path,
+      github-path,
+    )
+  ]
+}
+```
+
+```typst
+#if ("icon" in item) [
+  #box(fa-icon(item.icon, fill: color-darknight))
+]
+```
+
+**After:**
+
+```typst
+// NOTE (ferrocv vendor patch A): upstream imports the fontawesome Typst Universe
+// package and calls its version helper here. Both are removed. CONSTITUTION §6.1
+// forbids network fetches at render time, and the FerrocvWorld rejects any
+// Typst-package import. See VENDORING.md, Patch A.
+```
+
+```typst
+// const icons
+// NOTE (ferrocv vendor patch A): every upstream fa-icon call below is replaced
+// with empty content. Downstream code references these names, so we keep the
+// `#let` bindings and let them expand to nothing. Icons are purely decorative;
+// their absence leaves the surrounding layout intact. See VENDORING.md.
+#let linkedin-icon = []
+#let github-icon = []
+// ... (11 more icon consts, each `= []`)
+#let address-icon = []
+```
+
+```typst
+  align(right + horizon)[
+    // ferrocv vendor patch A: inline GitHub icon dropped; plain link remains.
+    #box[] #link(
+      "https://github.com/" + github-path,
+      github-path,
+    )
+  ]
+```
+
+```typst
+// ferrocv vendor patch A: per-item icon glyph dropped; `icon` key ignored.
+#if ("icon" in item) [
+  #box[]
+]
+```
+
+**Behavioral impact:** resumes still render; only the decorative
+icon glyphs are gone. The contact line preserves every text field
+(phone, email, URL, LinkedIn username, etc.) — only the small
+monochrome glyph that would have sat next to each item is removed.
+The per-item `icon` key in the `author.custom` array is silently
+ignored for the same reason. Layout reflow is nil because each
+icon was wrapped in a `box` whose contents are now empty.
+
+### B. Remove `linguify` Typst Universe import and inline every i18n lookup to English
+
+**Why:** same `CONSTITUTION.md` §6.1 rationale — the linguify package
+is a Typst Universe dependency. Additionally, linguify reads a
+sibling `lang.toml` file on every lookup; we do not vendor that file,
+which makes removing the package's call sites cleaner than stubbing
+the file.
+
+**Before** (upstream line 2 and ~8 call sites):
+
+```typst
+#import "@preview/linguify:0.4.2": *
+```
+
+```typst
+let lang_data = toml("lang.toml")
+
+let desc = if description == none {
+  (
+    lflib._linguify("resume", lang: language, from: lang_data).ok
+      + " " + author.firstname + " " + author.lastname
+  )
+} else { description }
+
+// ... and:
+title: lflib._linguify("resume", lang: language, from: lang_data).ok,
+
+// footer:
+name + " · " + linguify("resume", from: lang_data)
+
+// cover-letter variants call linguify("cover-letter"...), "attached",
+// "curriculum-vitae", "sincerely", "dear", and "letter-position-pretext".
+```
+
+**After:**
+
+```typst
+// NOTE (ferrocv vendor patch B): upstream also imports the linguify Typst Universe
+// package at line 2. Removed for the same reason; all i18n call sites are replaced
+// with hardcoded English strings. See VENDORING.md, Patch B.
+```
+
+```typst
+// NOTE (ferrocv vendor patch B): upstream read lang_data from a sibling TOML
+// file here. We don't vendor that file; removing the read is consistent with
+// Patch B's i18n removal. The `lang_data` parameter is still accepted by
+// `__resume_footer` and `__coverletter_footer` for ABI stability, but those
+// helpers no longer use it.
+let lang_data = (:)
+
+let desc = if description == none {
+  // ferrocv vendor patch B: upstream composed the description from an i18n lookup
+  // of the "resume" key; replaced with hardcoded English.
+  (
+    "Resume" + " " + author.firstname + " " + author.lastname
+  )
+} else { description }
+
+// ... and:
+title: "Resume",
+
+// footer:
+name + " · " + "Resume"
+```
+
+Every i18n key encountered was mapped 1:1 to plain English:
+
+| Upstream key              | English replacement |
+| ------------------------- | ------------------- |
+| `resume`                  | `Resume`            |
+| `cover-letter`            | `Cover Letter`      |
+| `attached`                | `Attached`          |
+| `curriculum-vitae`        | `Curriculum Vitae`  |
+| `sincerely`               | `Sincerely`         |
+| `dear`                    | `Dear`              |
+| `letter-position-pretext` | `Regarding`         |
+
+The `letter-position-pretext` key has no obvious English counterpart
+in the upstream repo (upstream's own `lang.toml` renders it as
+"Regarding" in en-US per the resolved string literal); we picked
+"Regarding" as the most natural reading.
+
+**Behavioral impact:** i18n is English-only. A user setting
+`language: "de"` on `resume(...)` still gets "Resume" in the footer
+and title slot rather than "Lebenslauf". The cover-letter helpers
+behave the same way, but we don't exercise those. A future caller who
+needs multilingual output can either vendor linguify locally (outside
+the render path) or file an issue requesting a proper i18n shim; per
+CONSTITUTION §5, that's a follow-up, not a blocker.
+
+### C. Replace `datetime.today()` defaults with a sentinel empty string
+
+**Why:** `FerrocvWorld::today()` deliberately returns `None` for
+reproducibility (see the comment on `World::today` in
+`src/render.rs`). Evaluating `datetime.today().display(...)` as a
+parameter default therefore panics the moment the function is called,
+which is worse than useless as a "default". Replacing the default
+with `""` lets a caller who forgets to pass `date:` get a blank
+footer slot instead of a cryptic crash.
+
+**Before** (upstream lines 202, 619, 867):
+
+```typst
+#let resume(
+  // ...
+  date: datetime.today().display("[month repr:long] [day], [year]"),
+  // ...
+) = { ... }
+```
+
+(same default shape repeats in `coverletter(...)` and `hiring-entity-info(...)`).
+
+**After:**
+
+```typst
+#let resume(
+  // ...
+  // NOTE (ferrocv vendor patch C): upstream default formatted the current date via
+  // Typst's today() API. FerrocvWorld returns None from today() for reproducibility,
+  // so evaluating that default would panic. Callers (like the ferrocv glue) are
+  // expected to pass an explicit `date:`; the sentinel `""` is a harmless fallback.
+  // See VENDORING.md, Patch C.
+  date: "",
+  // ...
+) = { ... }
+```
+
+**Behavioral impact:** calling `resume(...)` without an explicit
+`date:` argument now produces a blank footer-date slot instead of
+panicking. The ferrocv glue always passes `date: ""` explicitly, so
+the user-visible behavior is identical — this patch exists only to
+make `lib.typ` safe to import under `FerrocvWorld` without forcing
+every future caller to remember the `date:` argument.
+
+## What was NOT patched
+
+The following upstream behavior is unchanged and will follow upstream
+on the next re-vendor:
+
+- `resume(...)` body structure: paper size, margins, name/positions
+  block, contact-line layout, heading show rules, footer structure,
+  `author` dict schema.
+- Helper functions: `resume-entry`, `resume-item`, `resume-skill-*`,
+  `resume-certification`, `resume-gpa`, `justified-header`,
+  `secondary-justified-header`, `github-link`.
+- Default colors (`color-darknight`, `default-accent-color`, etc.)
+  and default spacing.
+- Cover-letter helpers (`coverletter`, `__coverletter_footer`,
+  `default-closing`, `hiring-entity-info`, `letter-heading`,
+  `coverletter-content`). These still compile post-patch — the
+  linguify calls inside them were rewritten — but the ferrocv glue
+  does not call them.
+
+## JSON Resume mapping notes
+
+The authored glue (`resume.typ`) makes these adapter decisions; they
+live in the glue, not in `lib.typ`, so re-vendoring upstream stays a
+mechanical copy.
+
+- **`basics.name` → `author.firstname` / `author.lastname`.** JSON
+  Resume carries the full name as a single string. modern-cv's
+  `author` dict expects two separate components because it styles
+  them differently in the big centered name (thin-weight firstname,
+  bold-weight lastname). We split on the first run of whitespace:
+  first token → `firstname`, remainder → `lastname`. Single-word
+  names end up entirely in `firstname` with `lastname = ""`.
+- **`basics.label` → `author.positions`.** JSON Resume has a single
+  `label` string; modern-cv's `positions` is an array that gets
+  joined with a middle-dot separator in the centered subtitle line.
+  We wrap `label` in a singleton list when it's set, or pass an
+  empty array otherwise.
+- **Font override to `"Libertinus Serif"`.** Modern-cv's upstream
+  defaults are `("Source Sans Pro", "Source Sans 3")` for body and
+  `"Roboto"` for headers. Neither is present in `typst-assets::fonts()`
+  (the font bundle ferrocv ships). Typst's `fallback: true` would
+  still render the document, but using a substitute font that
+  varies depending on exactly which fonts the bundle happens to
+  include — that breaks golden-test determinism. Overriding to a
+  bundled font (Libertinus Serif) keeps the golden reproducible
+  across hosts. **Tradeoff:** the rendered PDF looks distinctively
+  different from a stock modern-cv rendered outside ferrocv with
+  Source Sans Pro installed. A future caller who wants the original
+  look can file an issue for a font-override knob; CONSTITUTION §5
+  defers that until a real caller asks.
+- **`profile-picture: none` override.** Modern-cv's `resume(...)`
+  declares `profile-picture: image` as the default — that is, the
+  Typst `image` builtin *function itself*, not an image value. The
+  function body then checks `if profile-picture != none`, which is
+  always true for a function, and tries to pass the function into
+  `block(..., profile-picture)` as a body argument. Typst 0.13
+  rejects that as "unexpected argument". The glue passes
+  `profile-picture: none` explicitly so the branch takes the
+  no-image layout path. A future caller who wants to supply a real
+  profile photo can add a knob; CONSTITUTION §5 defers that.
+- **Certificates drop `issuer` and `url`.** modern-cv's
+  `resume-certification` is a two-positional-arg function
+  (`certification`, `date`). JSON Resume's `certificates[i].issuer`
+  and `.url` have no natural slot in that shape; we silently drop
+  both today. Iterate when a caller complains.
+- **Cover-letter helpers are present but unused.** `lib.typ` still
+  exposes `coverletter`, `hiring-entity-info`, `letter-heading`,
+  etc. post-patch, but the glue's entrypoint only calls `resume(...)`.
+  If a future theme wants cover-letter output it will need its own
+  glue (and its own golden).
+
+## Updating
+
+To re-vendor from a newer upstream:
+
+1. `curl -O https://raw.githubusercontent.com/DeveloperPaul123/modern-cv/<new-SHA>/lib.typ`
+2. Copy the fetched file over `assets/themes/modern-cv/lib.typ`,
+   overwriting the patched copy.
+3. Re-apply Patches A, B, and C. This grep enumerates the re-apply
+   surface in one pass:
+
+    ```sh
+    grep -nE "fa-icon\(|fa-version\(|linguify\(|lflib\.|toml\(\"lang|datetime\.today" \
+      assets/themes/modern-cv/lib.typ
+    ```
+
+   After patching, the same grep (plus `grep -n "@preview/" ...`)
+   must return nothing.
+4. Refetch the upstream `LICENSE` and update it if the year or
+   copyright holder changed.
+5. Update the Provenance table above with the new SHA, commit date,
+   release tag, and package version.
+6. Adjust `resume.typ` if `resume(...)` or any helper signature
+   changed upstream. Read the re-patched `lib.typ` first; the glue
+   assumes the signature shape documented in this file.
+7. Regenerate goldens once the golden tests land:
+
+    ```sh
+    UPDATE_GOLDEN=1 cargo test --test render_theme
+    ```
+
+   Inspect the golden diff before committing.

--- a/assets/themes/modern-cv/lib.typ
+++ b/assets/themes/modern-cv/lib.typ
@@ -1,0 +1,955 @@
+// NOTE (ferrocv vendor patch A): upstream imports the fontawesome Typst Universe
+// package and calls its version helper here. Both are removed. CONSTITUTION §6.1
+// forbids network fetches at render time, and the FerrocvWorld rejects any
+// Typst-package import. See VENDORING.md, Patch A.
+// NOTE (ferrocv vendor patch B): upstream also imports the linguify Typst Universe
+// package at line 2. Removed for the same reason; all i18n call sites are replaced
+// with hardcoded English strings. See VENDORING.md, Patch B.
+
+// const color
+#let color-darknight = rgb("#131A28")
+#let color-darkgray = rgb("#333333")
+#let color-gray = rgb("#5d5d5d")
+#let default-accent-color = rgb("#262F99")
+#let default-location-color = rgb("#333333")
+
+// const icons
+// NOTE (ferrocv vendor patch A): every upstream fa-icon call below is replaced
+// with empty content. Downstream code references these names, so we keep the
+// `#let` bindings and let them expand to nothing. Icons are purely decorative;
+// their absence leaves the surrounding layout intact. See VENDORING.md.
+#let linkedin-icon = []
+#let github-icon = []
+#let gitlab-icon = []
+#let bitbucket-icon = []
+#let twitter-icon = []
+#let google-scholar-icon = []
+#let orcid-icon = []
+#let phone-icon = []
+#let email-icon = []
+#let birth-icon = []
+#let homepage-icon = []
+#let website-icon = []
+#let address-icon = []
+
+/// Helpers
+
+// Common helper functions
+#let __format_author_name(author, language) = {
+  if language == "zh" or language == "ja" {
+    str(author.lastname) + str(author.firstname)
+  } else {
+    str(author.firstname) + " " + str(author.lastname)
+  }
+}
+
+#let __apply_smallcaps(content, use-smallcaps) = {
+  if use-smallcaps {
+    smallcaps(content)
+  } else {
+    content
+  }
+}
+
+// layout utility
+#let __justify_align(left_body, right_body) = {
+  block[
+    #left_body
+    #box(width: 1fr)[
+      #align(right)[
+        #right_body
+      ]
+    ]
+  ]
+}
+
+#let __justify_align_3(left_body, mid_body, right_body) = {
+  block[
+    #box(width: 1fr)[
+      #align(left)[
+        #left_body
+      ]
+    ]
+    #box(width: 1fr)[
+      #align(center)[
+        #mid_body
+      ]
+    ]
+    #box(width: 1fr)[
+      #align(right)[
+        #right_body
+      ]
+    ]
+  ]
+}
+
+#let __coverletter_footer(
+  author,
+  language,
+  date,
+  lang_data,
+  use-smallcaps: true,
+) = {
+  set text(fill: gray, size: 8pt)
+  __justify_align_3[
+    #__apply_smallcaps(date, use-smallcaps)
+  ][
+    #__apply_smallcaps(
+      {
+        let name = __format_author_name(author, language)
+        // ferrocv vendor patch B: upstream called linguify with key "cover-letter"
+        // here; replaced with hardcoded English. See VENDORING.md.
+        name + " · " + "Cover Letter"
+      },
+      use-smallcaps,
+    )
+  ][
+    #context {
+      counter(page).display()
+    }
+  ]
+}
+
+#let __resume_footer(author, language, lang_data, date, use-smallcaps: true) = {
+  set text(fill: gray, size: 8pt)
+  __justify_align_3[
+    #__apply_smallcaps(date, use-smallcaps)
+  ][
+    #__apply_smallcaps(
+      {
+        let name = __format_author_name(author, language)
+        // ferrocv vendor patch B: upstream called linguify with key "resume" here;
+        // replaced with hardcoded English. See VENDORING.md.
+        name + " · " + "Resume"
+      },
+      use-smallcaps,
+    )
+  ][
+    #context {
+      counter(page).display()
+    }
+  ]
+}
+
+/// Show a link with an icon, specifically for Github projects
+/// *Example*
+/// #example(`resume.github-link("DeveloperPaul123/awesome-resume")`)
+/// - github-path (string): The path to the Github project (e.g. "DeveloperPaul123/awesome-resume")
+/// -> none
+#let github-link(github-path) = {
+  set box(height: 11pt)
+
+  align(right + horizon)[
+    // ferrocv vendor patch A: inline GitHub icon dropped; plain link remains.
+    #box[] #link(
+      "https://github.com/" + github-path,
+      github-path,
+    )
+  ]
+}
+
+/// Right section for the justified headers
+/// - body (content): The body of the right header
+#let secondary-right-header(body) = {
+  set text(size: 11pt, weight: "medium")
+  body
+}
+
+/// Right section of a tertiaty headers.
+/// - body (content): The body of the right header
+#let tertiary-right-header(body) = {
+  set text(weight: "light", size: 9pt)
+  body
+}
+
+/// Justified header that takes a primary section and a secondary section. The primary section is on the left and the secondary section is on the right.
+/// - primary (content): The primary section of the header
+/// - secondary (content): The secondary section of the header
+#let justified-header(primary, secondary) = {
+  set block(above: 0.7em, below: 0.7em)
+  pad[
+    #__justify_align[
+      == #primary
+    ][
+      #secondary-right-header[#secondary]
+    ]
+  ]
+}
+
+/// Justified header that takes a primary section and a secondary section. The primary section is on the left and the secondary section is on the right. This is a smaller header compared to the `justified-header`.
+/// - primary (content): The primary section of the header
+/// - secondary (content): The secondary section of the header
+#let secondary-justified-header(primary, secondary) = {
+  __justify_align[
+    === #primary
+  ][
+    #tertiary-right-header[#secondary]
+  ]
+}
+/// --- End of Helpers
+
+/// ---- Resume Template ----
+
+/// Resume template that is inspired by the Awesome CV Latex template by posquit0. This template can loosely be considered a port of the original Latex template.
+///
+/// The original template: https://github.com/posquit0/Awesome-CV
+///
+/// - author (dictionary): Structure that takes in all the author's information
+/// - profile-picture (image): The profile picture of the author. This will be cropped to a circle and should be square in nature.
+/// - date (string): The date the resume was created
+/// - accent-color (color): The accent color of the resume
+/// - colored-headers (boolean): Whether the headers should be colored or not
+/// - language (string): The language of the resume, defaults to "en". See lang.toml for available languages
+/// - use-smallcaps (boolean): Whether to use small caps formatting throughout the template
+/// - show-address-icon (boolean): Whether to show the address icon
+/// - description (str | none): The PDF description
+/// - keywords (array | str): The PDF keywords
+/// - body (content): The body of the resume
+/// -> none
+#let resume(
+  author: (:),
+  profile-picture: image,
+  // NOTE (ferrocv vendor patch C): upstream default formatted the current date via
+  // Typst's today() API. FerrocvWorld returns None from today() for reproducibility,
+  // so evaluating that default would panic. Callers (like the ferrocv glue) are
+  // expected to pass an explicit `date:`; the sentinel `""` is a harmless fallback.
+  // See VENDORING.md, Patch C.
+  date: "",
+  accent-color: default-accent-color,
+  colored-headers: true,
+  show-footer: true,
+  language: "en",
+  font: ("Source Sans Pro", "Source Sans 3"),
+  header-font: "Roboto",
+  paper-size: "a4",
+  use-smallcaps: true,
+  show-address-icon: false,
+  description: none,
+  keywords: (),
+  body,
+) = {
+  if type(accent-color) == str {
+    accent-color = rgb(accent-color)
+  }
+
+  // NOTE (ferrocv vendor patch B): upstream read lang_data from a sibling TOML
+  // file here. We don't vendor that file; removing the read is consistent with
+  // Patch B's i18n removal. The `lang_data` parameter is still accepted by
+  // `__resume_footer` and `__coverletter_footer` for ABI stability, but those
+  // helpers no longer use it.
+  let lang_data = (:)
+
+  let desc = if description == none {
+    // ferrocv vendor patch B: upstream composed the description from an i18n lookup
+    // of the "resume" key; replaced with hardcoded English.
+    (
+      "Resume"
+        + " "
+        + author.firstname
+        + " "
+        + author.lastname
+    )
+  } else {
+    description
+  }
+
+  show: body => context {
+    set document(
+      author: author.firstname + " " + author.lastname,
+      // ferrocv vendor patch B: upstream read the title from the i18n "resume" key.
+      title: "Resume",
+      description: desc,
+      keywords: keywords,
+    )
+    body
+  }
+
+  set text(
+    font: font,
+    lang: language,
+    size: 11pt,
+    fill: color-darkgray,
+    fallback: true,
+  )
+
+  set page(
+    paper: paper-size,
+    margin: (left: 15mm, right: 15mm, top: 10mm, bottom: 10mm),
+    footer: if show-footer [#__resume_footer(
+      author,
+      language,
+      lang_data,
+      date,
+      use-smallcaps: use-smallcaps,
+    )] else [],
+    footer-descent: 0pt,
+  )
+
+  // set paragraph spacing
+  set par(spacing: 0.75em, justify: true)
+
+  set heading(numbering: none, outlined: false)
+
+  show heading.where(level: 1): it => [
+    #set text(size: 16pt, weight: "regular")
+    #set align(left)
+    #set block(above: 1em)
+    #let color = if colored-headers {
+      accent-color
+    } else {
+      color-darkgray
+    }
+    #text[#strong[#text(color)[#it.body]]]
+    #box(width: 1fr, line(length: 100%))
+  ]
+
+  show heading.where(level: 2): it => {
+    set text(color-darkgray, size: 12pt, style: "normal", weight: "bold")
+    it.body
+  }
+
+  show heading.where(level: 3): it => {
+    set text(size: 10pt, weight: "regular")
+    __apply_smallcaps(it.body, use-smallcaps)
+  }
+
+  let name = {
+    align(center)[
+      #pad(bottom: 5pt)[
+        #block[
+          #set text(size: 32pt, style: "normal", font: header-font)
+          #if language == "zh" or language == "ja" [
+            #text(accent-color, weight: "bold")[#author.lastname]#text(
+              weight: "thin",
+            )[#author.firstname]
+          ] else [
+            #text(accent-color, weight: "thin")[#author.firstname]
+            #text(weight: "bold")[#author.lastname]
+          ]
+        ]
+      ]
+    ]
+  }
+
+  let positions = {
+    set text(accent-color, size: 9pt, weight: "regular")
+    align(center)[
+      #__apply_smallcaps(
+        author.positions.join(text[#"  "#sym.dot.c#"  "]),
+        use-smallcaps,
+      )
+    ]
+  }
+
+  let address = {
+    set text(size: 9pt, weight: "regular")
+    align(center)[
+      #if ("address" in author) [
+        #if show-address-icon [
+          #address-icon
+          #box[#text(author.address)]
+        ] else [
+          #text(author.address)
+        ]
+      ]
+    ]
+  }
+
+  let contacts = {
+    set box(height: 9pt)
+
+    let separator = box(width: 5pt)
+
+    align(center)[
+      #set text(size: 9pt, weight: "regular", style: "normal")
+      #block[
+        #align(horizon)[
+          #if ("birth" in author) [
+            #birth-icon
+            #box[#text(author.birth)]
+            #separator
+          ]
+          #if ("phone" in author) [
+            #phone-icon
+            #box[#link("tel:" + author.phone)[#author.phone]]
+            #separator
+          ]
+          #if ("email" in author) [
+            #email-icon
+            #box[#link("mailto:" + author.email)[#author.email]]
+          ]
+          #if ("homepage" in author) [
+            #separator
+            #homepage-icon
+            #box[#link(author.homepage)[#author.homepage]]
+          ]
+          #if ("github" in author) [
+            #separator
+            #github-icon
+            #box[#link("https://github.com/" + author.github)[#author.github]]
+          ]
+          #if ("gitlab" in author) [
+            #separator
+            #gitlab-icon
+            #box[#link("https://gitlab.com/" + author.gitlab)[#author.gitlab]]
+          ]
+          #if ("bitbucket" in author) [
+            #separator
+            #bitbucket-icon
+            #box[#link(
+              "https://bitbucket.org/" + author.bitbucket,
+            )[#author.bitbucket]]
+          ]
+          #if ("linkedin" in author) [
+            #separator
+            #linkedin-icon
+            #box[
+              #link(
+                "https://www.linkedin.com/in/" + author.linkedin,
+              )[#author.firstname #author.lastname]
+            ]
+          ]
+          #if ("twitter" in author) [
+            #separator
+            #twitter-icon
+            #box[#link(
+              "https://twitter.com/" + author.twitter,
+            )[\@#author.twitter]]
+          ]
+          #if ("scholar" in author) [
+            #let fullname = str(author.firstname + " " + author.lastname)
+            #separator
+            #google-scholar-icon
+            #box[#link(
+              "https://scholar.google.com/citations?user=" + author.scholar,
+            )[#fullname]]
+          ]
+          #if ("orcid" in author) [
+            #separator
+            #orcid-icon
+            #box[#link("https://orcid.org/" + author.orcid)[#author.orcid]]
+          ]
+          #if ("website" in author) [
+            #separator
+            #website-icon
+            #box[#link(author.website)[#author.website]]
+          ]
+          #if ("custom" in author and type(author.custom) == array) [
+            #for item in author.custom [
+              #if ("text" in item) [
+                #separator
+                // ferrocv vendor patch A: per-item icon glyph dropped; `icon` key ignored.
+                #if ("icon" in item) [
+                  #box[]
+                ]
+                #box[
+                  #if ("link" in item) [
+                    #link(item.link)[#item.text]
+                  ] else [
+                    #item.text
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+
+  if profile-picture != none {
+    grid(
+      columns: (100% - 4cm, 4cm),
+      rows: 100pt,
+      gutter: 10pt,
+      [
+        #name
+        #positions
+        #address
+        #contacts
+      ],
+      align(left + horizon)[
+        #block(
+          clip: true,
+          stroke: 0pt,
+          radius: 2cm,
+          width: 4cm,
+          height: 4cm,
+          profile-picture,
+        )
+      ],
+    )
+  } else {
+    name
+    positions
+    address
+    contacts
+  }
+
+  body
+}
+
+/// The base item for resume entries.
+/// This formats the item for the resume entries. Typically your body would be a bullet list of items. Could be your responsibilities at a company or your academic achievements in an educational background section.
+/// - body (content): The body of the resume entry
+#let resume-item(body) = {
+  set text(size: 10pt, style: "normal", weight: "light", fill: color-darknight)
+  set block(above: 0.75em, below: 1.25em)
+  set par(leading: 0.65em)
+  block(above: 0.5em)[
+    #body
+  ]
+}
+
+/// The base item for resume entries. This formats the item for the resume entries. Typically your body would be a bullet list of items. Could be your responsibilities at a company or your academic achievements in an educational background section.
+/// - title (string): The title of the resume entry
+/// - location (string): The location of the resume entry
+/// - date (string): The date of the resume entry, this can be a range (e.g. "Jan 2020 - Dec 2020")
+/// - description (content): The body of the resume entry
+/// - title-link (string): The link to use for the title (can be none)
+/// - accent-color (color): Override the accent color of the resume-entry
+/// - location-color (color): Override the default color of the "location" for a resume entry.
+#let resume-entry(
+  title: none,
+  location: "",
+  date: "",
+  description: "",
+  title-link: none,
+  accent-color: default-accent-color,
+  location-color: default-location-color,
+) = {
+  let title-content
+  if type(title-link) == str {
+    title-content = link(title-link)[#title]
+  } else {
+    title-content = title
+  }
+  block(above: 1em, below: 0.65em)[
+    #pad[
+      #justified-header(title-content, location)
+      #if description != "" or date != "" [
+        #secondary-justified-header(description, date)
+      ]
+    ]
+  ]
+}
+
+/// Show cumulative GPA.
+/// *Example:*
+/// #example(`resume.resume-gpa("3.5", "4.0")`)
+#let resume-gpa(numerator, denominator) = {
+  set text(size: 12pt, style: "italic", weight: "light")
+  text[Cumulative GPA: #box[#strong[#numerator] / #denominator]]
+}
+
+/// Show a certification in the resume.
+/// *Example:*
+/// #example(`resume.resume-certification("AWS Certified Solutions Architect - Associate", "Jan 2020")`)
+/// - certification (content): The certification
+/// - date (content): The date the certification was achieved
+#let resume-certification(certification, date) = {
+  justified-header(certification, date)
+}
+
+/// Styling for resume skill categories.
+/// - category (string): The category
+#let resume-skill-category(category) = {
+  align(left)[
+    #set text(hyphenate: false)
+    == #category
+  ]
+}
+
+/// Styling for resume skill values/items
+/// - values (array): The skills to display
+#let resume-skill-values(values) = {
+  align(left)[
+    #set text(size: 11pt, style: "normal", weight: "light")
+    // This is a list so join by comma (,)
+    #values.join(", ")
+  ]
+}
+
+/// Show a list of skills in the resume under a given category.
+/// - category (string): The category of the skills
+/// - items (list): The list of skills. This can be a list of strings but you can also emphasize certain skills by using the `strong` function.
+#let resume-skill-item(category, items) = {
+  set block(below: 0.65em)
+  set pad(top: 2pt)
+
+  pad[
+    #grid(
+      columns: (3fr, 8fr),
+      gutter: 10pt,
+      resume-skill-category(category), resume-skill-values(items),
+    )
+  ]
+}
+
+/// Show a grid of skill lists with each row corresponding to a category of skills, followed by the skills themselves. The dictionary given to this function should have the skill categories as the dictionary keys and the values should be an array of values for the corresponding key.
+/// - categories-with-values (dictionary): key value pairs of skill categories and it's corresponding values (skills)
+#let resume-skill-grid(categories-with-values: (:)) = {
+  set block(below: 1.25em)
+  set pad(top: 2pt)
+
+  pad[
+    #grid(
+      columns: (auto, auto),
+      gutter: 10pt,
+      ..categories-with-values
+        .pairs()
+        .map(((key, value)) => (
+          resume-skill-category(key),
+          resume-skill-values(value),
+        ))
+        .flatten()
+    )
+  ]
+}
+
+/// ---- End of Resume Template ----
+
+/// ---- Coverletter ----
+
+#let default-closing(lang-data) = {
+  align(bottom)[
+    #text(weight: "light", style: "italic")[
+      // ferrocv vendor patch B: linguify calls replaced with hardcoded English.
+      #"Attached"#sym.colon #"Curriculum Vitae"]
+  ]
+}
+
+/// Cover letter template that is inspired by the Awesome CV Latex template by posquit0. This template can loosely be considered a port of the original Latex template.
+/// This coverletter template is designed to be used with the resume template.
+/// - author (dictionary): Structure that takes in all the author's information. The following fields are required: firstname, lastname, positions. The following fields are used if available: email, phone, github, linkedin, orcid, address, website, custom. The `custom` field is an array of additional entries with the following fields: text (string, required), icon (string, optional Font Awesome icon name), link (string, optional).
+/// - profile-picture (image): The profile picture of the author. This will be cropped to a circle and should be square in nature.
+/// - date (datetime): The date the cover letter was created. This will default to the current date.
+/// - accent-color (color): The accent color of the cover letter
+/// - language (string): The language of the cover letter, defaults to "en". See lang.toml for available languages
+/// - font (array): The font families of the cover letter
+/// - header-font (array): The font families of the cover letter header
+/// - show-footer (boolean): Whether to show the footer or not
+/// - closing (content): The closing of the cover letter. This defaults to "Attached Curriculum Vitae". You can set this to `none` to show the default closing or remove it completely.
+/// - use-smallcaps (boolean): Whether to use small caps formatting throughout the template
+/// - show-address-icon (boolean): Whether to show the address icon
+/// - description (str | none): The PDF description
+/// - keywords (array | str): The PDF keywords
+/// - body (content): The body of the cover letter
+#let coverletter(
+  author: (:),
+  profile-picture: image,
+  // ferrocv vendor patch C: same rationale as for `resume(...)`. Upstream default
+  // formatted today()'s date; replaced with sentinel "". See VENDORING.md.
+  date: "",
+  accent-color: default-accent-color,
+  language: "en",
+  font: ("Source Sans Pro", "Source Sans 3"),
+  header-font: "Roboto",
+  show-footer: true,
+  closing: none,
+  paper-size: "a4",
+  use-smallcaps: true,
+  show-address-icon: false,
+  description: none,
+  keywords: (),
+  body,
+) = {
+  if type(accent-color) == str {
+    accent-color = rgb(accent-color)
+  }
+
+  // ferrocv vendor patch B: upstream read lang_data from a sibling TOML file;
+  // replaced with an empty dict. See VENDORING.md.
+  let lang_data = (:)
+
+  if closing == none {
+    closing = default-closing(lang_data)
+  }
+
+  let desc = if description == none {
+    // ferrocv vendor patch B: upstream composed the description from an i18n
+    // lookup of the "cover-letter" key; replaced with hardcoded English.
+    (
+      "Cover Letter"
+        + " "
+        + author.firstname
+        + " "
+        + author.lastname
+    )
+  } else {
+    description
+  }
+
+  show: body => context {
+    set document(
+      author: author.firstname + " " + author.lastname,
+      // ferrocv vendor patch B: upstream read the title from the i18n "cover-letter" key.
+      title: "Cover Letter",
+      description: desc,
+      keywords: keywords,
+    )
+    body
+  }
+
+  set text(
+    font: font,
+    lang: language,
+    size: 11pt,
+    fill: color-darkgray,
+    fallback: true,
+  )
+
+  set page(
+    paper: paper-size,
+    margin: (left: 15mm, right: 15mm, top: 10mm, bottom: 10mm),
+    footer: if show-footer [#__coverletter_footer(
+      author,
+      language,
+      date,
+      lang_data,
+      use-smallcaps: use-smallcaps,
+    )] else [],
+    footer-descent: 2mm,
+  )
+
+  // set paragraph spacing
+  set par(spacing: 0.75em, justify: true)
+
+  set heading(numbering: none, outlined: false)
+
+  show heading: it => [
+    #set block(above: 1em, below: 1em)
+    #set text(size: 16pt, weight: "regular")
+
+    #align(left)[
+      #text[#strong[#text(accent-color)[#it.body]]]
+      #box(width: 1fr, line(length: 100%))
+    ]
+  ]
+
+  let name = {
+    align(right)[
+      #pad(bottom: 5pt)[
+        #block[
+          #set text(size: 32pt, style: "normal", font: header-font)
+          #if language == "zh" or language == "ja" [
+            #text(accent-color, weight: "bold")[#author.lastname]#text(
+              weight: "bold",
+            )[#author.firstname]
+          ] else [
+            #text(accent-color, weight: "thin")[#author.firstname]
+            #text(weight: "bold")[#author.lastname]
+          ]
+
+        ]
+      ]
+    ]
+  }
+
+  let positions = {
+    set text(accent-color, size: 9pt, weight: "regular")
+    align(right)[
+      #__apply_smallcaps(
+        author.positions.join(text[#"  "#sym.dot.c#"  "]),
+        use-smallcaps,
+      )
+    ]
+  }
+
+  let address = {
+    set text(size: 9pt, weight: "bold", fill: color-gray)
+    align(right)[
+      #if ("address" in author) [
+        #if show-address-icon [
+          #address-icon
+          #box[#text(author.address)]
+        ] else [
+          #text(author.address)
+        ]
+      ]
+    ]
+  }
+
+  let contacts = {
+    set box(height: 9pt)
+
+    let separator = [ #box(sym.bar.v) ]
+    let author_list = ()
+
+    if ("phone" in author) {
+      author_list.push[
+        #phone-icon
+        #box[#link("tel:" + author.phone)[#author.phone]]
+      ]
+    }
+    if ("email" in author) {
+      author_list.push[
+        #email-icon
+        #box[#link("mailto:" + author.email)[#author.email]]
+      ]
+    }
+    if ("github" in author) {
+      author_list.push[
+        #github-icon
+        #box[#link("https://github.com/" + author.github)[#author.github]]
+      ]
+    }
+    if ("linkedin" in author) {
+      author_list.push[
+        #linkedin-icon
+        #box[
+          #link(
+            "https://www.linkedin.com/in/" + author.linkedin,
+          )[#author.firstname #author.lastname]
+        ]
+      ]
+    }
+    if ("orcid" in author) {
+      author_list.push[
+        #orcid-icon
+        #box[#link("https://orcid.org/" + author.orcid)[#author.orcid]]
+      ]
+    }
+    if ("website" in author) {
+      author_list.push[
+        #website-icon
+        #box[#link(author.website)[#author.website]]
+      ]
+    }
+
+    if ("custom" in author and type(author.custom) == array) {
+      for item in author.custom {
+        if ("text" in item) {
+          author_list.push[
+            // ferrocv vendor patch A: per-item icon glyph dropped; `icon` key ignored.
+            #if ("icon" in item) [
+              #box[]
+            ]
+            #box[
+              #if ("link" in item) [
+                #link(item.link)[#item.text]
+              ] else [
+                #item.text
+              ]
+            ]
+          ]
+        }
+      }
+    }
+
+
+    align(right)[
+      #set text(size: 8pt, weight: "light", style: "normal")
+      #author_list.join(separator)
+    ]
+  }
+
+  let letter-heading = {
+    grid(
+      columns: (1fr, 2fr),
+      rows: 100pt,
+      align(left + horizon)[
+        #block(
+          clip: true,
+          stroke: 0pt,
+          radius: 2cm,
+          width: 4cm,
+          height: auto,
+          profile-picture,
+        )
+      ],
+      [
+        #name
+        #positions
+        #address
+        #contacts
+      ],
+    )
+  }
+
+  let signature = {
+    align(bottom)[
+      #pad(bottom: 2em)[
+        // ferrocv vendor patch B: upstream linguify "sincerely" lookup → "Sincerely".
+        #text(weight: "light")[#"Sincerely"#if (
+            language != "de"
+          ) [#sym.comma]] \
+        #text(weight: "bold")[#author.firstname #author.lastname] \ \
+      ]
+    ]
+  }
+
+  // actual content
+  letter-heading
+  body
+  linebreak()
+  signature
+  closing
+}
+
+/// Cover letter heading that takes in the information for the hiring company and formats it properly.
+/// - entity-info (content): The information of the hiring entity including the company name, the target (who's attention to), street address, and city
+/// - date (date): The date the letter was written (defaults to the current date)
+// ferrocv vendor patch C: upstream default formatted today()'s date; replaced with "".
+#let hiring-entity-info(
+  entity-info: (:),
+  date: "",
+  use-smallcaps: true,
+) = {
+  set par(leading: 1em)
+  pad(top: 1.5em, bottom: 1.5em)[
+    #__justify_align[
+      #text(weight: "bold", size: 12pt)[#entity-info.target]
+    ][
+      #text(weight: "light", style: "italic", size: 9pt)[#date]
+    ]
+
+    #pad(top: 0.65em, bottom: 0.65em)[
+      #text(weight: "regular", fill: color-gray, size: 9pt)[
+        #__apply_smallcaps(entity-info.name, use-smallcaps) \
+        #entity-info.street-address \
+        #entity-info.city \
+      ]
+    ]
+  ]
+}
+
+/// Letter heading for a given job position and addressee.
+/// - job-position (string): The job position you are applying for
+/// - addressee (string): The person you are addressing the letter to
+/// - dear (string): optional field for redefining the "dear" variable
+#let letter-heading(job-position: "", addressee: "", dear: "") = {
+  // ferrocv vendor patch B: upstream read lang_data from a lang.toml sibling and
+  // performed i18n lookups here. All such lookups are replaced with hardcoded
+  // English. The "letter-position-pretext" key has no obvious English counterpart
+  // upstream (it's the text that precedes the job title); a reasonable plain
+  // English rendering is "Regarding". See VENDORING.md, Patch B.
+
+  // TODO: Make this adaptable to content
+  underline(evade: false, stroke: 0.5pt, offset: 0.3em)[
+    #text(weight: "bold", size: 12pt)[#"Regarding" #job-position]
+  ]
+  pad(top: 1em, bottom: 1em)[
+    #text(weight: "light", fill: color-gray)[
+      #if dear == "" [
+        // ferrocv vendor patch B: upstream linguify "dear" lookup → "Dear".
+        #"Dear"
+      ] else [
+        #dear
+      ]
+      #addressee,
+    ]
+  ]
+}
+
+/// Cover letter content paragraph. This is the main content of the cover letter.
+/// - content (content): The content of the cover letter
+#let coverletter-content(content) = {
+  pad(top: 1em, bottom: 1em)[
+    #set par(first-line-indent: 3em)
+    #set text(weight: "light")
+    #content
+  ]
+}
+
+/// ---- End of Coverletter ----

--- a/assets/themes/modern-cv/resume.typ
+++ b/assets/themes/modern-cv/resume.typ
@@ -1,0 +1,248 @@
+// ferrocv glue entrypoint for the vendored `modern-cv` theme.
+//
+// This file is authored by ferrocv (NOT vendored). It imports the patched
+// upstream `lib.typ` and adapts JSON Resume v1.0.0 data into modern-cv's
+// helper-function call shape (`resume`, `resume-entry`, `resume-item`,
+// `resume-skill-item`, `resume-certification`). The vendored `lib.typ`
+// carries three §6.1 / reproducibility patches; see VENDORING.md.
+//
+// CONSTITUTION §1: JSON Resume is the canonical input; every field is
+// optional per the v1.0.0 schema. Every read uses `.at(..., default: ...)`.
+// CONSTITUTION §5: no section-toggle knobs; every section with data renders.
+
+#import "lib.typ": resume, resume-entry, resume-item, resume-skill-item, resume-certification
+
+// The FerrocvWorld serves the JSON Resume bytes at the virtual path
+// "/resume.json". Same convention as every other ferrocv theme.
+#let r = json("/resume.json")
+
+// Small helper: format a JSON Resume startDate/endDate pair. modern-cv's
+// `resume-entry` takes a single `date:` string, so we compose one.
+#let __fmt_range(start, end) = {
+  if start != "" and end != "" { start + " – " + end }
+  else if start != "" { start + " – Present" }
+  else if end != "" { end }
+  else { "" }
+}
+
+// Optional-field shim for `basics` — absent, null, or partially-filled
+// sub-objects must all render without a dict-lookup panic.
+#let basics = r.at("basics", default: (:))
+#let location = basics.at("location", default: (:))
+#let city = location.at("city", default: "")
+#let region = location.at("region", default: "")
+#let address = if city != "" and region != "" {
+  city + ", " + region
+} else if city != "" {
+  city
+} else {
+  region
+}
+
+// ferrocv glue: JSON Resume `basics.name` is a single string; modern-cv's
+// `author` dict expects `firstname`/`lastname`. Split on the first run of
+// whitespace: first token → firstname, remainder → lastname.
+#let full_name = basics.at("name", default: "")
+#let name_parts = if full_name != "" { full_name.split(regex("\\s+")) } else { () }
+#let firstname = if name_parts.len() > 0 { name_parts.at(0) } else { "" }
+#let lastname = if name_parts.len() > 1 { name_parts.slice(1).join(" ") } else { "" }
+
+// ferrocv glue: JSON Resume `basics.label` is a single string; modern-cv's
+// `author.positions` expects an array. Wrap in a singleton list when set.
+#let label = basics.at("label", default: "")
+
+#let author_dict = (
+  firstname: firstname,
+  lastname: lastname,
+  positions: if label != "" { (label,) } else { () },
+  address: address,
+  phone: basics.at("phone", default: ""),
+  email: basics.at("email", default: ""),
+  personal-site: basics.at("url", default: ""),
+)
+
+// Apply modern-cv's `resume(...)` show rule.
+//
+// Font override: modern-cv's upstream defaults (Source Sans Pro / Roboto)
+// are NOT bundled in `typst-assets::fonts()`. Libertinus Serif IS bundled;
+// overriding makes the golden reproducible across hosts. VENDORING.md has
+// the full rationale.
+//
+// date: "" keeps the footer's date slot blank (see VENDORING.md, Patch C).
+//
+// profile-picture: none — upstream's default is the `image` *function*
+// itself (not an image value), which upstream then branches on via
+// `if profile-picture != none`. Passing `none` explicitly avoids the
+// "profile-picture function passed as block body" failure that Typst
+// 0.13 rejects. (Upstream's own example passes an image path; the
+// function-as-default only works if the caller always overrides it.)
+//
+// CONSTITUTION §5: no other overrides. Iterate when a caller asks.
+#show: resume.with(
+  author: author_dict,
+  profile-picture: none,
+  date: "",
+  font: "Libertinus Serif",
+  header-font: "Libertinus Serif",
+)
+
+// Section: work → `= Experience`. JSON Resume `work[i].summary` → the
+// `description` slot (the secondary right-header); `highlights` become
+// a bullet list wrapped in `resume-item`.
+#if "work" in r and r.work != none and r.work.len() > 0 {
+  [= Experience]
+  for w in r.work {
+    resume-entry(
+      title: w.at("name", default: ""),
+      location: w.at("location", default: ""),
+      date: __fmt_range(w.at("startDate", default: ""), w.at("endDate", default: "")),
+      description: w.at("position", default: ""),
+      title-link: w.at("url", default: none),
+    )
+    let summary = w.at("summary", default: "")
+    let highlights = w.at("highlights", default: ())
+    if summary != "" or highlights.len() > 0 {
+      resume-item[
+        #if summary != "" [#summary]
+
+        #for h in highlights [
+          - #h
+        ]
+      ]
+    }
+  }
+}
+
+// Section: education → `= Education`. JSON Resume has no `location` on
+// education entries; default to empty. Description composes studyType
+// and area, trimming stray separator if either is missing.
+#if "education" in r and r.education != none and r.education.len() > 0 {
+  [= Education]
+  for e in r.education {
+    let study_type = e.at("studyType", default: "")
+    let area = e.at("area", default: "")
+    let desc = if study_type != "" and area != "" { study_type + ", " + area }
+      else if study_type != "" { study_type }
+      else { area }
+    resume-entry(
+      title: e.at("institution", default: ""),
+      location: e.at("location", default: ""),
+      date: __fmt_range(e.at("startDate", default: ""), e.at("endDate", default: "")),
+      description: desc,
+      title-link: e.at("url", default: none),
+    )
+    let courses = e.at("courses", default: ())
+    if courses.len() > 0 {
+      resume-item[
+        Courses: #courses.join(", ")
+      ]
+    }
+  }
+}
+
+// Section: projects → `= Projects`. JSON Resume has no single-string
+// "location" on projects; use roles (or keywords as a fallback) in that
+// slot — mirrors the fantastic-cv glue's choice.
+#if "projects" in r and r.projects != none and r.projects.len() > 0 {
+  [= Projects]
+  for p in r.projects {
+    let roles = p.at("roles", default: p.at("keywords", default: ()))
+    resume-entry(
+      title: p.at("name", default: ""),
+      location: roles.join(", "),
+      date: __fmt_range(p.at("startDate", default: ""), p.at("endDate", default: "")),
+      description: p.at("description", default: ""),
+      title-link: p.at("url", default: none),
+    )
+    let highlights = p.at("highlights", default: ())
+    if highlights.len() > 0 {
+      resume-item[
+        #for h in highlights [
+          - #h
+        ]
+      ]
+    }
+  }
+}
+
+// Section: volunteer → `= Volunteer`.
+#if "volunteer" in r and r.volunteer != none and r.volunteer.len() > 0 {
+  [= Volunteer]
+  for v in r.volunteer {
+    resume-entry(
+      title: v.at("organization", default: ""),
+      location: "",
+      date: __fmt_range(v.at("startDate", default: ""), v.at("endDate", default: "")),
+      description: v.at("position", default: ""),
+      title-link: v.at("url", default: none),
+    )
+    let summary = v.at("summary", default: "")
+    let highlights = v.at("highlights", default: ())
+    if summary != "" or highlights.len() > 0 {
+      resume-item[
+        #if summary != "" [#summary]
+
+        #for h in highlights [
+          - #h
+        ]
+      ]
+    }
+  }
+}
+
+// Section: awards → `= Awards`. JSON Resume `awards[i].awarder` occupies
+// modern-cv's `location` slot; `.date` is already a plain string.
+#if "awards" in r and r.awards != none and r.awards.len() > 0 {
+  [= Awards]
+  for a in r.awards {
+    resume-entry(
+      title: a.at("title", default: ""),
+      location: a.at("awarder", default: ""),
+      date: a.at("date", default: ""),
+      description: a.at("summary", default: ""),
+      title-link: a.at("url", default: none),
+    )
+  }
+}
+
+// Section: certificates → `= Certifications`.
+// ferrocv glue: modern-cv's `resume-certification` is a two-arg function
+// (`certification`, `date`). JSON Resume's `issuer` and `url` are dropped
+// here; iterate when a caller asks (CONSTITUTION §5).
+#if "certificates" in r and r.certificates != none and r.certificates.len() > 0 {
+  [= Certifications]
+  for c in r.certificates {
+    resume-certification(
+      c.at("name", default: ""),
+      c.at("date", default: ""),
+    )
+  }
+}
+
+// Section: publications → `= Publications`. JSON Resume `releaseDate`
+// maps to modern-cv's `date:`, `publisher` to `location:`.
+#if "publications" in r and r.publications != none and r.publications.len() > 0 {
+  [= Publications]
+  for pub in r.publications {
+    resume-entry(
+      title: pub.at("name", default: ""),
+      location: pub.at("publisher", default: ""),
+      date: pub.at("releaseDate", default: ""),
+      description: pub.at("summary", default: ""),
+      title-link: pub.at("url", default: none),
+    )
+  }
+}
+
+// Section: skills → `= Skills`. Each JSON Resume skill entry becomes one
+// `resume-skill-item(<name>, <keywords>)` row. modern-cv's signature is
+// two positional args (`category`, `items`).
+#if "skills" in r and r.skills != none and r.skills.len() > 0 {
+  [= Skills]
+  for s in r.skills {
+    resume-skill-item(
+      s.at("name", default: ""),
+      s.at("keywords", default: ()),
+    )
+  }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,11 +31,12 @@
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 2 ships with three themes total. A linear scan over `THEMES`
-//! is O(n) for n ≤ 3. CONSTITUTION §5 ("simple now, iterate later")
-//! calls for the narrower solution here; generalizing to a hashed
-//! lookup or a builder pattern should wait for a second caller that
-//! actually needs it.
+//! Phase 2 ships four themes total: three adapters
+//! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`) and one native
+//! theme (`text-minimal`). A linear scan over `THEMES` is O(n) for
+//! small n; CONSTITUTION §5 ("simple now, iterate later") calls for
+//! the narrower solution here. Generalizing to a hashed lookup or a
+//! builder pattern should wait for a caller that actually needs it.
 
 /// A themed Typst source bundle that [`crate::render::compile_theme`]
 /// can compile against a JSON Resume document.
@@ -74,6 +75,13 @@ const TYPST_JSONRESUME_CV_PREFIX: &str = "/themes/typst-jsonresume-cv";
 /// fields stay in lockstep. If this prefix changes, every file path
 /// in [`FANTASTIC_CV`] updates in one place.
 const FANTASTIC_CV_PREFIX: &str = "/themes/fantastic-cv";
+
+/// Virtual-path prefix for this theme's files inside the World.
+///
+/// Centralized as a private `const` so the `files` and `entrypoint`
+/// fields stay in lockstep. If this prefix changes, every file path
+/// in [`MODERN_CV`] updates in one place.
+const MODERN_CV_PREFIX: &str = "/themes/modern-cv";
 
 /// Adapter for [`fruggiero/typst-jsonresume-cv`]'s `basic-resume`
 /// theme, vendored under `assets/themes/typst-jsonresume-cv/`.
@@ -144,6 +152,40 @@ const _: () = {
     assert!(!FANTASTIC_CV_PREFIX.is_empty());
 };
 
+/// Adapter for [`DeveloperPaul123/modern-cv`] (canonical:
+/// `ptsouchlos/modern-cv`), vendored under `assets/themes/modern-cv/`.
+///
+/// Unlike [`FANTASTIC_CV`] (which is a pure glue-only vendor — the
+/// upstream source is byte-for-byte unchanged), this adapter ships a
+/// **patched** `lib.typ`: the upstream pulls `@preview/fontawesome`
+/// and `@preview/linguify` at compile time, which CONSTITUTION §6.1
+/// forbids. All icon and i18n call sites were rewritten; see
+/// `assets/themes/modern-cv/VENDORING.md` for the patch record.
+/// The entrypoint is our authored glue `resume.typ`, which imports
+/// the patched `lib.typ` from the same virtual directory.
+///
+/// [`DeveloperPaul123/modern-cv`]: https://github.com/DeveloperPaul123/modern-cv
+pub const MODERN_CV: Theme = Theme {
+    name: "modern-cv",
+    files: &[
+        (
+            // Must agree with MODERN_CV_PREFIX + "/lib.typ".
+            concat!("/themes/modern-cv", "/lib.typ"),
+            include_bytes!("../assets/themes/modern-cv/lib.typ"),
+        ),
+        (
+            concat!("/themes/modern-cv", "/resume.typ"),
+            include_bytes!("../assets/themes/modern-cv/resume.typ"),
+        ),
+    ],
+    entrypoint: concat!("/themes/modern-cv", "/resume.typ"),
+};
+
+// Compile-time sanity check: same shape as for TYPST_JSONRESUME_CV.
+const _: () = {
+    assert!(!MODERN_CV_PREFIX.is_empty());
+};
+
 /// Virtual path of the `text-minimal` theme's entrypoint.
 ///
 /// Single per-file constant used by both the [`Theme::files`] key and
@@ -197,19 +239,20 @@ pub const TEXT_MINIMAL: Theme = Theme {
 
 /// All themes registered with this build of `ferrocv`.
 ///
-/// Phase 2 ships two adapters (`typst-jsonresume-cv`, `fantastic-cv`)
-/// and one native theme (`text-minimal`). See the module doc for why
-/// this is a `&[&Theme]` rather than a `HashMap` or a builder
-/// pattern — a linear scan over a handful of entries is fine, and
-/// CONSTITUTION §5 calls for the narrower solution until a caller
+/// Phase 2 ships three adapters (`typst-jsonresume-cv`, `fantastic-cv`,
+/// `modern-cv`) and one native theme (`text-minimal`). See the module
+/// doc for why this is a `&[&Theme]` rather than a `HashMap` or a
+/// builder pattern — a linear scan over a handful of entries is fine,
+/// and CONSTITUTION §5 calls for the narrower solution until a caller
 /// actually needs more. See the module doc as well for the §4
 /// deferral on splitting native themes into their own module.
-pub const THEMES: &[&Theme] = &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV, &TEXT_MINIMAL];
+pub const THEMES: &[&Theme] =
+    &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV, &MODERN_CV, &TEXT_MINIMAL];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.
 ///
-/// Linear scan over [`THEMES`]; O(n) for n themes. Acceptable for
-/// the current n ≤ 3 regime (CONSTITUTION §5).
+/// Linear scan over [`THEMES`]; O(n) for n themes. Acceptable for the
+/// current handful of entries (CONSTITUTION §5).
 pub fn find_theme(name: &str) -> Option<&'static Theme> {
     THEMES.iter().copied().find(|t| t.name == name)
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -246,8 +246,12 @@ pub const TEXT_MINIMAL: Theme = Theme {
 /// and CONSTITUTION §5 calls for the narrower solution until a caller
 /// actually needs more. See the module doc as well for the §4
 /// deferral on splitting native themes into their own module.
-pub const THEMES: &[&Theme] =
-    &[&TYPST_JSONRESUME_CV, &FANTASTIC_CV, &MODERN_CV, &TEXT_MINIMAL];
+pub const THEMES: &[&Theme] = &[
+    &TYPST_JSONRESUME_CV,
+    &FANTASTIC_CV,
+    &MODERN_CV,
+    &TEXT_MINIMAL,
+];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.
 ///

--- a/tests/goldens/modern-cv-sparse.txt
+++ b/tests/goldens/modern-cv-sparse.txt
@@ -1,0 +1,11 @@
+Grace   Hopper
+
+Computer Scientist
+
+Experience
+
+US Navy
+Rear Admiral   1944-07-01 – Present
+• Worked on the Mark I computer at Harvard.
+• Developed the first compiler for a computer programming language.
+   Grace Hopper · Resume   1

--- a/tests/goldens/modern-cv.txt
+++ b/tests/goldens/modern-cv.txt
@@ -1,0 +1,32 @@
+Ada   Lovelace
+
+Computing Pioneer London, England
+
++44-20-0000-0000     ada@example.com
+
+Experience
+
+Analytical Engines Ltd
+Programmer   1843-01-01 – 1852-11-27
+Translated and annotated Menabrea's paper on the Analytical Engine; wrote the first published algorithm intended for machine execution.• Published the first algorithm designed for a machine (Bernoulli numbers)
+• Introduced the concept of a general-purpose computing device
+Education
+
+University of London
+Self-directed, Mathematics   1833-01-01 – 1843-01-01
+Projects
+
+Notes on the Analytical Engine
+
+Expanded translation of Menabrea's sketch, including the first published algorithm for a computing machine.
+
+1842-01-01 –
+1843-07-01
+• Note G — the Bernoulli-number algorithm
+Certifications
+Honorary Fellowship in Computing History   1843-09-01
+Skills
+
+Programming Analytical Engine, Algorithms
+Mathematics Calculus, Symbolic logic
+   Ada Lovelace · Resume   1

--- a/tests/render_theme.rs
+++ b/tests/render_theme.rs
@@ -110,6 +110,27 @@ fn fantastic_cv_renders_grace_hopper_sparse_to_expected_text() {
     );
 }
 
+// modern-cv adapter goldens.
+#[test]
+fn modern_cv_renders_ada_lovelace_to_expected_text() {
+    run_golden(
+        "modern-cv",
+        "tests/fixtures/render_full.json",
+        "tests/goldens/modern-cv.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn modern_cv_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "modern-cv",
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/modern-cv-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
 /// Shared golden-file workflow: compile the named adapter against the
 /// named fixture, extract and normalize the PDF text, and compare
 /// against (or rewrite, under `UPDATE_GOLDEN`) the committed golden.


### PR DESCRIPTION
## Summary

- Adds `modern-cv` as the third selectable theme adapter in `ferrocv`, closing Phase 3's second adapter (issue #38). After this merges, `ferrocv render resume.json --theme modern-cv` produces a valid PDF end-to-end.
- Vendors [`DeveloperPaul123/modern-cv`](https://github.com/DeveloperPaul123/modern-cv) (canonical: `ptsouchlos/modern-cv`) at pinned commit `dcb863f` (tag `0.9.0-patch`) with **three patches** for CONSTITUTION §6.1 compliance — unlike `fantastic-cv`'s pure glue-only vendor, this one required touching the upstream source.
- Adds golden-file tests for both the full (Ada Lovelace) and sparse (Grace Hopper) fixtures per CONSTITUTION §2. The sparse fixture stresses every optional-field default in the glue.

## Patches applied to vendored `lib.typ`

Each is recorded with before/after snippets in `assets/themes/modern-cv/VENDORING.md`:

- **Patch A — fontawesome removal.** Upstream `#import "@preview/fontawesome:0.6.0": *` plus all `fa-icon(...)` call sites (13 named-icon `#let` bindings + 3 inline uses) removed. Icons expand to empty content; decorative only, no layout reflow.
- **Patch B — linguify removal.** Upstream `#import "@preview/linguify:0.4.2": *` and every `linguify(...)` / `lflib._linguify(...)` call replaced with hardcoded English literals (~10 sites). The `toml("lang.toml")` read is also gone; `lang.toml` is not vendored.
- **Patch C — `datetime.today()` default replacement.** `resume(...)`, `coverletter(...)`, and `hiring-entity-info(...)` default `date:` parameters neutered from `datetime.today().display(...)` to `""` because `FerrocvWorld::today()` returns `None`.

## Notable decisions

- **Glue-first mapping.** `assets/themes/modern-cv/resume.typ` handles every JSON Resume → modern-cv shape friction: `basics.name` split on whitespace into `author.firstname`/`author.lastname`; `basics.label` wrapped into a `positions` singleton; certificate entries drop `issuer`/`url` (modern-cv's `resume-certification` is two-arg — iterate when a caller complains).
- **Font override.** modern-cv's upstream defaults (`"Source Sans Pro"`, `"Roboto"`) aren't bundled in `typst-assets`; glue overrides to `"Libertinus Serif"` (bundled) so the golden stays deterministic across hosts. Documented in VENDORING.md — the rendered PDF will look visually different from a standalone modern-cv user.
- **Upstream latent bug worked around.** `resume(...)`'s `profile-picture: image` default evaluates to the `image` function itself, which Typst 0.13 rejects when passed as a `block(...)` body. The glue explicitly passes `profile-picture: none`; no patch to `lib.typ` needed. Documented in VENDORING.md.
- **Registry stays simple.** Four themes (three adapters + one native) is still below any threshold that would justify a hashed lookup or builder pattern (CONSTITUTION §5). Module doc updated to reflect the new count; the `n ≤ N` phrasing is retired in favor of the more generic "handful of entries" language.

## Test plan

- [x] `make preflight` passes locally (fmt, clippy `-D warnings`, all tests, cargo-deny, cargo-audit, typos)
- [x] Both new golden tests pass deterministically (ran without `UPDATE_GOLDEN` after a fresh `UPDATE_GOLDEN=1` bootstrap)
- [x] Existing `typst-jsonresume-cv`, `fantastic-cv`, and `text-minimal` goldens byte-identical (no cross-theme regression)
- [x] Smoke render against both `tests/fixtures/render_full.json` (23,714 bytes) and `tests/fixtures/render_sparse.json` (16,655 bytes) produces valid PDFs
- [x] All four forbidden-pattern greps on patched `lib.typ` return nothing: `@preview/`, `fa-icon(|fa-version(|linguify(|lflib.`, `toml("lang`, `datetime.today`
- [x] Rebased on latest `origin/main` (post-`feat/45-text-output` merge); `src/theme.rs` conflicts resolved in favor of the combined "3 adapters + 1 native" shape

## Audit note

`cargo audit` continues to report three pre-existing **unmaintained** advisories on transitive deps pulled in via Typst (`bincode 1.3.3`, `paste 1.0.15`, `yaml-rust 0.4.5`). Not introduced by this PR; already allowlisted.

## Documentation

Deferred to a dedicated docs PR (same precedent as PR #55 for `fantastic-cv`). README's Status paragraph already drifts — it mentions only `typst-jsonresume-cv` and `text-minimal`. A follow-up can refresh the theme list once.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
