### PR TITLE
Add HTML output via --format html

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,7 @@ dependencies = [
  "tempfile",
  "typst",
  "typst-assets",
+ "typst-html",
  "typst-pdf",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ serde_json = "1"
 typst = "0.14.2"
 # PDF exporter, released in lockstep with `typst`.
 typst-pdf = "0.14.2"
+# HTML exporter, released in lockstep with typst.
+typst-html = "0.14.2"
 # Bundled font set (DejaVu, Linux Libertine, etc.) compiled into the
 # binary. The `fonts` feature is what carries the actual font bytes.
 # Bundling is what gives us cross-host reproducibility (CONSTITUTION

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 
 ## Status
 
-**Early.** PDF and plain-text output work today (PDF via the
-`typst-jsonresume-cv` theme adapter, text via the native `text-minimal`
-theme). HTML output, additional themes, and native-theme tooling are
-tracked as [GitHub issues](https://github.com/cacack/ferrocv/issues)
-(HTML lives at #44) and organized into phase milestones. The
-non-negotiable design principles live in
+**Early.** PDF, plain-text, and HTML output all work today (PDF via
+any of the registered theme adapters, text and HTML via the native
+`text-minimal` theme by default). Additional themes and native-theme
+tooling are tracked as
+[GitHub issues](https://github.com/cacack/ferrocv/issues) and
+organized into phase milestones. HTML uses Typst's upstream-experimental
+HTML export — output shape may shift when Typst is bumped; the CLI
+surface itself is stable. The non-negotiable design principles live in
 [`CONSTITUTION.md`](./CONSTITUTION.md).
 
 ## Why
@@ -47,6 +49,11 @@ ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
 # Render to plain text (defaults to the native `text-minimal` theme;
 # `--theme` is optional for text)
 ferrocv render resume.json --format text
+
+# Render to HTML (also defaults to `text-minimal`). Note: Typst's HTML
+# export is upstream-experimental; output shape may shift across
+# ferrocv releases when Typst is bumped.
+ferrocv render resume.json --format html
 ```
 
 The quickest way to try it end-to-end is
@@ -55,12 +62,12 @@ forkable starter template that renders its own `resume.json` to PDF
 on every push via GitHub Actions and publishes the result to GitHub
 Pages.
 
-`render` defaults to `--format pdf`; HTML output is tracked at #44.
-`--theme` is required for `--format pdf` and optional for
-`--format text` (defaults to `text-minimal`). When `--output` is
-omitted, the output lands at `dist/resume.pdf` for PDF and
-`dist/resume.txt` for text; parent directories are created as needed.
-Both subcommands read from stdin if no path is given.
+`render` defaults to `--format pdf`. `--theme` is required for
+`--format pdf` and optional for `--format text` and `--format html`
+(both default to `text-minimal`). When `--output` is omitted, the
+output lands at `dist/resume.pdf` for PDF, `dist/resume.txt` for text,
+and `dist/resume.html` for HTML; parent directories are created as
+needed. Both subcommands read from stdin if no path is given.
 
 Exit codes (same for both subcommands):
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@
 //! Exit codes (contractual, shared across subcommands):
 //! - `0` — operation succeeded
 //!   - `validate`: document is valid
-//!   - `render`: PDF or text written to `--output`
+//!   - `render`: PDF, text, or HTML written to `--output`
 //! - `1` — document parsed as JSON but failed schema validation
 //! - `2` — usage error (e.g. `--theme` missing for `--format pdf`),
 //!   IO error, malformed JSON, unknown theme, unknown format, or
@@ -21,7 +21,9 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use serde_json::Value;
 
-use crate::{THEMES, ValidationError, compile_text, compile_theme, find_theme, validate_value};
+use crate::{
+    THEMES, ValidationError, compile_html, compile_text, compile_theme, find_theme, validate_value,
+};
 
 /// Render JSON Resume documents via embedded Typst.
 #[derive(Debug, Parser)]
@@ -42,12 +44,17 @@ enum Commands {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
     },
-    /// Render a JSON Resume document to PDF or plain text via the
-    /// named theme.
+    /// Render a JSON Resume document to PDF, plain text, or HTML via
+    /// the named theme.
     ///
     /// `--theme` is required for `--format pdf` (no sensible default
-    /// adapter to pick). For `--format text` it defaults to the native
-    /// `text-minimal` theme so plain-text output works out of the box.
+    /// adapter to pick). For `--format text` and `--format html` it
+    /// defaults to the native `text-minimal` theme so those outputs
+    /// work out of the box.
+    ///
+    /// HTML output uses Typst's experimental HTML export; output shape
+    /// may shift across ferrocv releases when Typst is bumped. The CLI
+    /// surface itself is stable. See `research/44-html-viability.md`.
     ///
     /// Exit codes:
     /// - 0 — rendered successfully; output written to --output
@@ -58,16 +65,19 @@ enum Commands {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
         /// Theme name. See the registered themes in `ferrocv::THEMES`.
-        /// Optional for `--format text` (defaults to `text-minimal`);
-        /// required for `--format pdf`.
+        /// Optional for `--format text` and `--format html` (both
+        /// default to `text-minimal`); required for `--format pdf`.
         #[arg(long)]
         theme: Option<String>,
-        /// Output format. Defaults to `pdf`.
+        /// Output format: `pdf`, `text`, or `html`. Defaults to `pdf`.
+        /// HTML output is experimental upstream; its shape may shift
+        /// when Typst is bumped.
         #[arg(long, default_value = "pdf")]
         format: Format,
         /// Output file path. Parent directories are created as needed.
-        /// Defaults to `dist/resume.pdf` for `--format pdf` and
-        /// `dist/resume.txt` for `--format text`.
+        /// Defaults to `dist/resume.pdf` for `--format pdf`,
+        /// `dist/resume.txt` for `--format text`, and
+        /// `dist/resume.html` for `--format html`.
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
     },
@@ -75,13 +85,14 @@ enum Commands {
 
 /// Output formats supported by `ferrocv render`.
 ///
-/// Phase 2 ships PDF and plain text. HTML is tracked separately
-/// (issue #44).
+/// Phase 2 ships PDF, plain text, and HTML. HTML uses Typst's
+/// upstream-experimental HTML export; its output shape may shift
+/// across `ferrocv` releases when Typst is bumped.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Format {
     Pdf,
     Text,
-    // TODO Phase 2 (#44): Html
+    Html,
 }
 
 /// Resolve which theme name to use given the format and the optional
@@ -94,7 +105,12 @@ enum Format {
 fn resolve_theme_name(format: Format, requested: Option<&str>) -> Result<&str, &'static str> {
     match (format, requested) {
         (_, Some(name)) => Ok(name),
-        (Format::Text, None) => Ok("text-minimal"),
+        // Text and HTML both default to the native `text-minimal`
+        // theme. A dedicated `html-minimal` semantic theme is a
+        // deliberate follow-up — see `research/44-html-viability.md`
+        // §7 for the rationale (text-minimal produces valid HTML that
+        // is good enough for a first release).
+        (Format::Text, None) | (Format::Html, None) => Ok("text-minimal"),
         (Format::Pdf, None) => Err("error: --theme is required for --format pdf"),
     }
 }
@@ -107,6 +123,7 @@ fn default_output_path(format: Format) -> PathBuf {
     match format {
         Format::Pdf => PathBuf::from("dist/resume.pdf"),
         Format::Text => PathBuf::from("dist/resume.txt"),
+        Format::Html => PathBuf::from("dist/resume.html"),
     }
 }
 
@@ -217,9 +234,9 @@ fn run_render(
         }
     };
 
-    // Step 6: format dispatch. PDF returns bytes; text returns a
-    // String which we convert to UTF-8 bytes for the shared write
-    // path below.
+    // Step 6: format dispatch. PDF returns bytes; text and HTML both
+    // return a String which we convert to UTF-8 bytes for the shared
+    // write path below.
     let bytes: Vec<u8> = match format {
         Format::Pdf => match compile_theme(theme, &value) {
             Ok(bytes) => bytes,
@@ -230,6 +247,13 @@ fn run_render(
         },
         Format::Text => match compile_text(theme, &value) {
             Ok(text) => text.into_bytes(),
+            Err(err) => {
+                eprintln!("{err}");
+                return Ok(ExitCode::from(2));
+            }
+        },
+        Format::Html => match compile_html(theme, &value) {
+            Ok(html) => html.into_bytes(),
             Err(err) => {
                 eprintln!("{err}");
                 return Ok(ExitCode::from(2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ pub mod render;
 pub mod theme;
 pub mod validate;
 
-pub use render::{RenderDiagnostic, RenderError, compile_pdf, compile_text, compile_theme};
+pub use render::{
+    RenderDiagnostic, RenderError, compile_html, compile_pdf, compile_text, compile_theme,
+};
 pub use theme::{THEMES, Theme, find_theme};
 pub use validate::{ValidationError, validate_value};
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,7 @@
-//! In-process Typst compilation to PDF and plain text.
+//! In-process Typst compilation to PDF, plain text, and HTML.
 //!
 //! Wraps the embedded `typst` crate behind a small library surface.
-//! Three public entry points:
+//! Four public entry points:
 //!
 //! - [`compile_pdf`] — compile a single Typst source string against a
 //!   JSON Resume value. Intended for smoke tests, one-off rendering,
@@ -13,34 +13,65 @@
 //! - [`compile_text`] — compile a [`crate::theme::Theme`] against a
 //!   JSON Resume value and extract a UTF-8 plain-text rendering by
 //!   walking the compiled frame tree. This is the foundation for
-//!   `ferrocv render --format text` (issue #45). Typst 0.13 has no
+//!   `ferrocv render --format text` (issue #45). Typst has no
 //!   dedicated text exporter, so we read glyph runs directly off
 //!   the [`PagedDocument`] rather than round-tripping through PDF
 //!   or HTML.
+//! - [`compile_html`] — compile a [`crate::theme::Theme`] against a
+//!   JSON Resume value and serialize to a single-file HTML document
+//!   via the `typst-html` exporter. This is the path the CLI
+//!   `render --format html` subcommand takes (issue #44).
 //!
-//! All three run the real Typst compiler in-process (no subprocess,
-//! no shell-out) and return either PDF bytes or extracted text.
+//! All four run the real Typst compiler in-process (no subprocess,
+//! no shell-out) and return either PDF bytes, extracted text, or an
+//! HTML string.
 //!
 //! # Constitutional commitments
 //!
 //! - **§2 — Embed Typst, never subprocess it.** The whole compilation
 //!   path is `typst::compile(&world)` followed by either
-//!   `typst_pdf::pdf(...)` (PDF) or a frame-walk extractor (text),
-//!   all linked statically. No `std::process::Command`, no shelling
-//!   out to the `typst` CLI, ever.
+//!   `typst_pdf::pdf(...)` (PDF), a frame-walk extractor (text), or
+//!   `typst_html::html(...)` (HTML), all linked statically. No
+//!   `std::process::Command`, no shelling out to the `typst` CLI,
+//!   ever.
 //! - **§6.1 — No network calls at render time.** The [`FerrocvWorld`]
 //!   does not implement a package resolver. Any `FileId` carrying a
 //!   `PackageSpec` (i.e. `@preview/...` imports) returns
 //!   [`FileError::Package(PackageError::NotFound(_))`]. There is no
 //!   code path by which Typst can reach the network from inside
-//!   `compile_pdf`, `compile_theme`, or `compile_text`. A test in
-//!   `tests/render.rs` enforces this.
+//!   `compile_pdf`, `compile_theme`, `compile_text`, or
+//!   `compile_html`. HTML compilation reuses the same World and the
+//!   same `source`/`file` implementations, so the guarantee applies
+//!   uniformly. Tests in `tests/render.rs` enforce this for both PDF
+//!   and HTML paths.
 //! - **§6.4 — Themes run under Typst's native sandbox, nothing more.**
 //!   We do not add filesystem-wide access, shell-escape, or any
 //!   custom capabilities. The World exposes exactly the virtual
 //!   files the caller registers plus the always-present
 //!   `/resume.json` slot wired to the caller-supplied JSON Resume
-//!   bytes.
+//!   bytes. HTML compilation gains no new capabilities; it only
+//!   selects a different compile target inside the same sandbox.
+//!
+//! # Experimental upstream status
+//!
+//! Typst's HTML export is labelled "experimental" by upstream. The
+//! reference docs banner reads verbatim:
+//!
+//! > "Typst's HTML export is currently under active development. The
+//! > feature is still very incomplete and only available for
+//! > experimentation behind a feature flag. Do not use this feature
+//! > for production use cases."
+//!
+//! We ship it anyway because the *CLI surface* we expose
+//! (`--format html`) is stable and internal to `ferrocv`; the churn
+//! is in Typst's HTML emitter's *output shape*, which our tests
+//! absorb by using loose substring + well-formedness assertions
+//! rather than byte-exact golden files. See
+//! `research/44-html-viability.md` for the full analysis.
+//!
+//! The Typst library flag `Feature::Html` is a library-builder
+//! option, not a Cargo feature of `ferrocv`. End users never see or
+//! enable it. See [`shared_library`].
 //!
 //! # Fonts
 //!
@@ -74,7 +105,8 @@ use typst::layout::{Frame, FrameItem, PagedDocument};
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
-use typst::{Library, LibraryExt, World};
+use typst::{Feature, Library, LibraryExt, World};
+use typst_html::HtmlDocument;
 use typst_pdf::PdfOptions;
 
 use crate::theme::Theme;
@@ -245,6 +277,41 @@ pub fn compile_text(theme: &Theme, data: &Value) -> Result<String, RenderError> 
     render_world_to_text(&world)
 }
 
+/// Compile a [`Theme`] bundle to a single-file HTML document against
+/// a JSON Resume value.
+///
+/// Mirrors [`compile_theme`] and [`compile_text`] but produces an HTML
+/// string via the `typst-html` exporter, using the same
+/// [`FerrocvWorld`] and the same Typst compilation path. HTML
+/// compilation therefore inherits the same constitutional guarantees —
+/// no subprocess (§2), no network (§6.1), no extended sandbox
+/// capabilities (§6.4).
+///
+/// The returned string is a complete HTML document, starting with
+/// `<!DOCTYPE html>`. Typst emits a single self-contained file — no
+/// external CSS, fonts, or images — so there is no post-processing
+/// step. See `research/44-html-viability.md` §5 for the evidence.
+///
+/// # Experimental upstream status
+///
+/// Typst labels its HTML export "experimental" and explicitly warns
+/// against production use. `ferrocv`'s `--format html` CLI surface is
+/// stable; the *output shape* emitted by this function may shift
+/// across Typst minor bumps. See the module-level
+/// "Experimental upstream status" section.
+///
+/// # Errors
+///
+/// Returns the same [`RenderError`] type as the PDF path; Typst
+/// compilation diagnostics flow through the shared
+/// `diagnostics_to_error` helper unchanged. HTML-specific rejections
+/// (e.g. `link("")` being fatal in HTML mode where PDF tolerated it
+/// for some theme sources) surface as plain compile errors here.
+pub fn compile_html(theme: &Theme, data: &Value) -> Result<String, RenderError> {
+    let world = FerrocvWorld::from_theme(theme, data);
+    render_world_to_html(&world)
+}
+
 /// Shared compile + PDF-serialize path used by both entry points.
 fn render_world(world: &FerrocvWorld) -> Result<Vec<u8>, RenderError> {
     // `typst::compile` returns Warned { output, warnings }. Drop
@@ -274,6 +341,23 @@ fn render_world_to_text(world: &FerrocvWorld) -> Result<String, RenderError> {
     } = typst::compile::<PagedDocument>(world);
     let document = output.map_err(diagnostics_to_error)?;
     Ok(extract_text(&document))
+}
+
+/// Shared compile + HTML-serialize path used by [`compile_html`].
+///
+/// Mirrors [`render_world`]'s shape: drive the same Typst compiler
+/// (but targeting [`HtmlDocument`] instead of [`PagedDocument`]),
+/// surface diagnostics through the same path, then serialize via
+/// `typst_html::html`. The [`Feature::Html`] library flag must be
+/// enabled for `typst::compile::<HtmlDocument>` to succeed; see
+/// [`shared_library`].
+fn render_world_to_html(world: &FerrocvWorld) -> Result<String, RenderError> {
+    let Warned {
+        output,
+        warnings: _,
+    } = typst::compile::<HtmlDocument>(world);
+    let document = output.map_err(diagnostics_to_error)?;
+    typst_html::html(&document).map_err(diagnostics_to_error)
 }
 
 /// Maximum vertical distance (in PostScript points) between two text
@@ -600,9 +684,27 @@ impl FerrocvWorld {
 }
 
 /// Cached library; built once per process.
+///
+/// `Feature::Html` is always enabled on the shared library. It is a
+/// Typst-internal library-builder option — **not** a user-facing
+/// Cargo feature of `ferrocv`, so CONSTITUTION §3 (HTML must not be
+/// permanently gated behind a feature flag) is upheld. End users
+/// never see or enable this flag; HTML output is selected purely via
+/// `--format html`.
+///
+/// The flag gates Typst's `html.*` namespace in the global scope and
+/// is required for `typst::compile::<HtmlDocument>` to succeed. PDF
+/// and text compilation ignore it entirely, so there is zero
+/// overhead for non-HTML callers. We enable it unconditionally rather
+/// than gating dynamically because the shared-cache lifecycle would
+/// otherwise have to juggle two `Library` instances — premature
+/// complexity for a feature the flag costs nothing to carry.
 fn shared_library() -> &'static LazyHash<Library> {
     static LIBRARY: OnceLock<LazyHash<Library>> = OnceLock::new();
-    LIBRARY.get_or_init(|| LazyHash::new(Library::default()))
+    LIBRARY.get_or_init(|| {
+        let features: typst::Features = [Feature::Html].into_iter().collect();
+        LazyHash::new(Library::builder().with_features(features).build())
+    })
 }
 
 /// Cached `(FontBook, fonts)` pair; built once per process.

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -16,7 +16,7 @@
 //! 4. Package fetch is rejected — proves no network resolver is wired
 //!    up. This test is the in-code enforcement of CONSTITUTION §6.1.
 
-use ferrocv::{RenderError, compile_pdf};
+use ferrocv::{RenderError, Theme, compile_html, compile_pdf};
 use serde_json::{Value, json};
 
 /// PDF magic bytes; every valid PDF stream must start with `%PDF-`.
@@ -103,6 +103,32 @@ fn preview_package_import_is_rejected_no_network() {
     let source = r#"#import "@preview/cetz:0.2.0": *"#;
     let err = compile_pdf(source, &Value::Object(Default::default()))
         .expect_err("preview-package import must be rejected (no network resolver)");
+    let rendered = format!("{err}").to_lowercase();
+    assert!(
+        rendered.contains("preview")
+            || rendered.contains("cetz")
+            || rendered.contains("package")
+            || rendered.contains("not found"),
+        "diagnostic must mention the rejected package or 'not found'; got:\n{rendered}",
+    );
+}
+
+#[test]
+fn preview_package_import_is_rejected_in_html_compilation() {
+    // HTML counterpart to `preview_package_import_is_rejected_no_network`.
+    // CONSTITUTION §6.1 applies uniformly across all render targets —
+    // the HTML path must reject `@preview/...` imports for the same
+    // reason (no package resolver, no network fetch). Since
+    // `compile_html` takes a Theme (not a raw source), we wrap a
+    // minimal source as a one-file theme inline.
+    const ENTRY: &str = "/main.typ";
+    let theme = Theme {
+        name: "no-network-html-probe",
+        files: &[(ENTRY, br#"#import "@preview/cetz:0.2.0": *"# as &[u8])],
+        entrypoint: ENTRY,
+    };
+    let err = compile_html(&theme, &Value::Object(Default::default()))
+        .expect_err("preview-package import must be rejected in HTML compilation too");
     let rendered = format!("{err}").to_lowercase();
     assert!(
         rendered.contains("preview")

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -205,7 +205,7 @@ fn render_rejects_unknown_format_with_exit_two() {
 
     // clap's ValueEnum mismatch exits 2 before we reach any of our code.
     // `xml` stands in for "any format we don't ship"; `html` was the
-    // previous canary but is reserved for #44 and may land soon.
+    // pre-#44 canary, now a valid format, so `xml` is the replacement.
     ferrocv()
         .arg("render")
         .arg(fixture("render_full"))
@@ -395,4 +395,199 @@ fn render_accepts_resume_on_stdin() {
 
     assert!(out.exists());
     assert_eq!(read_prefix(&out, 5), b"%PDF-");
+}
+
+// --- HTML format scenarios ---------------------------------------------
+//
+// Mirror the PDF and text scenarios above for `--format html`. HTML is
+// Typst's upstream-experimental export, so assertions stay loose —
+// exact byte shape is guaranteed to churn across Typst minors. The
+// full-document well-formedness check (DOCTYPE presence, no external
+// references, etc.) lives in `tests/render_html.rs`.
+
+#[test]
+fn render_writes_html_to_output_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("text-minimal")
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("HTML output must be UTF-8");
+    assert!(
+        body.starts_with("<!DOCTYPE html>"),
+        "HTML output must begin with the DOCTYPE declaration; got first 80 bytes: {:?}",
+        body.chars().take(80).collect::<String>(),
+    );
+    assert!(
+        body.contains("Ada Lovelace"),
+        "HTML output must contain the rendered name; got {} bytes",
+        body.len(),
+    );
+}
+
+#[test]
+fn render_html_uses_text_minimal_when_theme_omitted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("HTML output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "HTML output must contain the rendered name"
+    );
+}
+
+#[test]
+fn render_html_default_output_path_is_dist_resume_html() {
+    // No `--output`, no `--theme`. `current_dir` is set to a tempdir so
+    // the default `dist/resume.html` lands under the temp tree rather
+    // than polluting the workspace.
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    ferrocv()
+        .current_dir(tmp.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--format")
+        .arg("html")
+        .assert()
+        .success();
+
+    let expected = tmp.path().join("dist/resume.html");
+    assert!(
+        expected.exists(),
+        "default HTML output must land at <cwd>/dist/resume.html; expected {}",
+        expected.display()
+    );
+}
+
+#[test]
+fn render_html_rejects_invalid_resume_with_exit_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("invalid_wrong_type_email"))
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("/basics/email"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written when validation fails",
+    );
+}
+
+#[test]
+fn render_html_accepts_resume_on_stdin() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+    let input =
+        std::fs::read_to_string(fixture("render_full")).expect("fixture `render_full.json`");
+
+    ferrocv()
+        .arg("render")
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .write_stdin(input)
+        .assert()
+        .success();
+
+    assert!(out.exists());
+    let body = std::fs::read_to_string(&out).expect("HTML output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "HTML output must contain the rendered name"
+    );
+}
+
+/// Adapter HTML happy-path: `fantastic-cv` was fixed for HTML
+/// compatibility in #59 (empty-URL guard); verify the fix extends to
+/// the CLI render path. Assertions are minimal — we only check the
+/// compile succeeds and produces an HTML file. Shape of that output
+/// is upstream-experimental and not something we want to pin.
+#[test]
+fn render_html_fantastic_cv_happy_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("fantastic-cv")
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let size = std::fs::metadata(&out).expect("stat").len();
+    assert!(
+        size > 0,
+        "HTML output should be non-empty, was {size} bytes"
+    );
+}
+
+/// Adapter HTML happy-path: `modern-cv` (added in #58) compiles to
+/// HTML cleanly. Same minimal-assertion posture as the fantastic-cv
+/// case — we only assert compile success and non-empty output.
+#[test]
+fn render_html_modern_cv_happy_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("modern-cv")
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let size = std::fs::metadata(&out).expect("stat").len();
+    assert!(
+        size > 0,
+        "HTML output should be non-empty, was {size} bytes"
+    );
 }

--- a/tests/render_html.rs
+++ b/tests/render_html.rs
@@ -1,0 +1,156 @@
+//! Loose-assertion well-formedness tests for HTML output.
+//!
+//! Enforces CONSTITUTION testing doctrine §2 ("every theme has a
+//! golden-file test") for the HTML path, but with a deliberate
+//! relaxation: **no byte-exact golden files**. Typst's HTML export
+//! is explicitly labelled experimental upstream and its output shape
+//! is guaranteed to shift across Typst minor bumps. A byte-exact
+//! golden would produce noise PRs on every Typst version bump
+//! without catching any real regression.
+//!
+//! Instead, we assert on:
+//! - Structural well-formedness (starts with `<!DOCTYPE html>`,
+//!   ends with `</html>`, contains a `<body>...</body>` pair in
+//!   the right order).
+//! - Content presence (the fixture's name string makes it through).
+//! - External-reference negation (no `src=`, no `href=` except
+//!   anchor links, no `<link rel`, no `@font-face`, no `url(`) —
+//!   guards against a future Typst bump silently turning on
+//!   external assets, which would break CONSTITUTION §6.1's
+//!   "single-file output" promise.
+//!
+//! Runs the real embedded Typst compiler via
+//! [`ferrocv::compile_html`] (doctrine §4: no mocking Typst).
+//!
+//! See `research/44-html-viability.md` §2 for the rationale behind
+//! the loose-assertion choice.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+#[test]
+fn html_compiles_full_fixture_to_well_formed_html() {
+    let data = read_fixture("tests/fixtures/render_full.json");
+    let theme = ferrocv::find_theme("text-minimal").expect("text-minimal must be registered");
+
+    let html = ferrocv::compile_html(theme, &data)
+        .expect("text-minimal must compile render_full.json to HTML");
+
+    // Structural well-formedness.
+    assert!(
+        html.starts_with("<!DOCTYPE html>"),
+        "HTML must begin with <!DOCTYPE html>; got first 80 chars:\n{}",
+        html.chars().take(80).collect::<String>(),
+    );
+    assert!(
+        html.trim_end().ends_with("</html>"),
+        "HTML must end with </html> (after trimming); got last 80 chars:\n{}",
+        html.chars()
+            .rev()
+            .take(80)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect::<String>(),
+    );
+
+    // `<body>` and `</body>` must both exist, and the opening tag
+    // must appear before the closing tag. Substring search rather
+    // than HTML parsing — loose by design.
+    let body_open = html
+        .find("<body>")
+        .expect("HTML must contain a <body> opening tag");
+    let body_close = html
+        .find("</body>")
+        .expect("HTML must contain a </body> closing tag");
+    assert!(
+        body_open < body_close,
+        "<body> must appear before </body>; got body_open={body_open}, body_close={body_close}",
+    );
+
+    // Content presence: the rendered name must survive into the HTML.
+    assert!(
+        html.contains("Ada Lovelace"),
+        "HTML must contain the fixture's name 'Ada Lovelace'; got {} bytes",
+        html.len(),
+    );
+
+    // External-reference negation. A regression that silently turns
+    // on external CSS, fonts, or images would break the single-file
+    // guarantee (see CONSTITUTION §6.1 and research/44-html-viability.md
+    // §5). Fragment-only `href="#..."` anchors are allowed.
+    assert!(
+        !html.contains("src=\""),
+        "HTML must not contain any `src=\"...\"` references; found one in:\n{}",
+        preview(&html, "src=\""),
+    );
+    for bad in ["<link rel", "@font-face", "url("] {
+        assert!(
+            !html.contains(bad),
+            "HTML must not contain `{bad}`; found one in:\n{}",
+            preview(&html, bad),
+        );
+    }
+    // Scan every `href="..."` and reject any that is not a fragment
+    // anchor. Iterative search keeps the assertion honest without
+    // pulling in an HTML parser.
+    let mut rest = html.as_str();
+    while let Some(idx) = rest.find("href=\"") {
+        let after = &rest[idx + 6..];
+        // The first char after `href="` must be `#` for the link to
+        // count as a fragment-only anchor.
+        let first_char = after.chars().next();
+        assert!(
+            matches!(first_char, Some('#')),
+            "HTML href must be a fragment anchor (`#...`) only; found href starting with {first_char:?} in:\n{}",
+            preview(rest, "href=\""),
+        );
+        rest = &after[1..];
+    }
+}
+
+#[test]
+fn html_compiles_sparse_fixture_without_errors() {
+    let data = read_fixture("tests/fixtures/render_sparse.json");
+    let theme = ferrocv::find_theme("text-minimal").expect("text-minimal must be registered");
+
+    let html = ferrocv::compile_html(theme, &data)
+        .expect("text-minimal must compile render_sparse.json to HTML");
+
+    assert!(
+        html.contains("Grace Hopper"),
+        "HTML must contain the sparse fixture's name 'Grace Hopper'; got {} bytes",
+        html.len(),
+    );
+}
+
+/// Resolve a path relative to the crate root (where `Cargo.toml`
+/// lives). Duplicated from `tests/render_text.rs::crate_path` per
+/// CONSTITUTION §5 (share on the third caller, not the second).
+fn crate_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+/// Read and parse a JSON Resume fixture from the test tree.
+fn read_fixture(relative: &str) -> Value {
+    let path = crate_path(relative);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("parse fixture {}: {e}", path.display()))
+}
+
+/// Return a short preview of `haystack` around the first occurrence
+/// of `needle`, for assertion error messages. Bounded to 120 chars
+/// so failing tests don't dump the entire HTML document.
+fn preview(haystack: &str, needle: &str) -> String {
+    match haystack.find(needle) {
+        Some(idx) => {
+            let start = idx.saturating_sub(40);
+            let end = (idx + needle.len() + 40).min(haystack.len());
+            haystack[start..end].to_string()
+        }
+        None => "<not found>".to_string(),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ferrocv render --format html` end-to-end — closes #44.
- Single-file HTML output via `typst-html 0.14.2`; `Feature::Html` enabled on the shared Typst library.
- `--format html` defaults to the native `text-minimal` theme (same default-theme pattern as `--format text`); all three adapters (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`) also compile to HTML.
- Typst's HTML export is labelled experimental upstream; the `--format html` CLI surface is stable but the emitted shape may shift when Typst is bumped. See `research/44-html-viability.md`.
- Tests use loose substring + well-formedness assertions rather than byte-exact goldens — shape churn is guaranteed upstream so byte goldens would produce noise PRs. External-reference negation guards the single-file guarantee (§6.1).
- HTML network-isolation test mirrors the existing PDF test (`@preview/...` imports rejected at the World layer).

A dedicated semantic `html-minimal` native theme (real `<h2>`, `<section>`, `<a href>`) is a deliberate follow-up — filed as a separate issue.

## Test plan

- [x] `cargo build` clean, zero warnings
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-features --workspace` — 57 tests pass
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
- [x] Manual smoke across all four themes: `<!DOCTYPE html>` prefix, no `src=`/`href=` (except fragment anchors)/`@font-face`/`url(`
- [x] fantastic-cv HTML happy path (post-#59 fix) exercised by `render_html_fantastic_cv_happy_path`
- [x] modern-cv HTML happy path exercised by `render_html_modern_cv_happy_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
