### PR TITLE
Refresh docs for v0.3.0 and tighten constitution §6.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,51 @@ in this repository.
 documents to PDF, HTML, and plain text via [Typst](https://typst.app/),
 embedded in-process via the `typst` crate.
 
-**Status: pre-implementation.** See `TODO.md` for the design summary,
-phased roadmap, and open questions. `README.md` is the user-facing
-entrypoint.
+PDF, plain-text, and HTML rendering all work today (released as v0.3.0).
+The phased roadmap now lives in [GitHub
+issues](https://github.com/cacack/ferrocv/issues); `TODO.md` holds only
+unresolved design questions. `README.md` is the user-facing entrypoint.
+
+## Commands
+
+`Makefile` is the source of truth for CI-parity checks — command
+strings there are kept in lockstep with `.github/workflows/ci.yml`.
+
+- `make preflight` — full CI check suite (fmt-check, clippy, test,
+  deny, audit, typos). Run before pushing.
+- `make test` / `make clippy` / `make fmt` — individual targets.
+- `make install-tools` — first-time install of the non-stock tools
+  (`cargo-deny`, `cargo-audit`, `typos-cli`).
+- A single test: `cargo test --test <file> <name>` (integration tests
+  live under `tests/`, e.g. `cargo test --test render_cli`).
+
+## Architecture
+
+- **Embedded Typst (CONSTITUTION §2).** Rendering is
+  `typst::compile(&world)` in-process, then `typst-pdf`, `typst-html`,
+  or a frame-walk text extractor. No subprocess, no shell-out, ever.
+  `src/render.rs` owns the `FerrocvWorld` and the three exporters;
+  `FerrocvWorld` refuses `@preview/...` package imports to uphold §6.1
+  (no network at render time).
+- **Theme registry (`src/theme.rs`).** A static `&[&Theme]` slice of
+  Typst source bundles `include_bytes!`'d at compile time. Two kinds
+  live here per CONSTITUTION §4:
+  - *Adapters* wrap upstream Typst Universe templates vendored under
+    `assets/themes/<name>/` — each with its own `VENDORING.md` recording
+    upstream SHA and any patches (e.g. `modern-cv` was patched to drop
+    `@preview/fontawesome` and `@preview/linguify`).
+  - *Native themes* (currently just `text-minimal`) author Typst
+    directly against the JSON Resume schema; this is what
+    `--format text` and `--format html` default to.
+- **Schema embedding.** `assets/schema/jsonresume-v1.0.0.json` is
+  vendored and baked into the binary via `include_str!` in `src/lib.rs`.
+  `jsonschema` is built without default features to avoid pulling
+  `reqwest` (§6.1).
+- **Tests.** Scenario tests spawn the built binary via `assert_cmd`
+  (`tests/validate_cli.rs`, `tests/render_cli.rs`). Theme regressions
+  are caught by golden text files in `tests/goldens/` — the fixtures
+  `render_full.json` and `render_sparse.json` both get rendered through
+  every theme and diffed against committed text extractions.
 
 ## Principles
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -81,11 +81,14 @@ history. Users must be able to run this tool and know exactly where
 their data goes. The following are hard commitments; weakening any of
 them requires a constitutional amendment, not a feature PR.
 
-- **No network calls at render time.** `ferrocv render` and
-  `ferrocv validate` run fully offline. The only network-touching
-  operation is explicit, user-initiated theme fetching (e.g. pulling
-  a Typst Universe package), which is cached locally and never
-  triggered silently during a render.
+- **No network calls at runtime, full stop.** `ferrocv render` and
+  `ferrocv validate` are fully offline. Themes ship vendored in-tree
+  (`assets/themes/`) and are baked into the binary; the JSON Resume
+  schema is vendored the same way. The embedded Typst `World`
+  actively rejects any `@preview/...` package import rather than
+  fetching it. If a future feature needs a network-touching operation
+  (e.g. a package manager for out-of-tree themes), that is a
+  constitutional amendment, not a feature PR.
 - **No telemetry, ever.** No usage pings, no crash reports, no opt-in
   "help us improve" toggle, no analytics SDK. Not now, not later.
 - **Resume data never leaves the process.** We read `resume.json`, we

--- a/assets/themes/typst-jsonresume-cv/VENDORING.md
+++ b/assets/themes/typst-jsonresume-cv/VENDORING.md
@@ -209,5 +209,8 @@ To re-vendor from a newer upstream:
 3. Re-apply the two patches above. A quick grep for `@preview/` and
    `../../output/` in the copied files catches both.
 4. Update the commit SHA and vendor date in this file.
-5. Run the render tests (`cargo test --test render`) and, once the
-   golden test lands from issue #12, its golden fixture.
+5. Regenerate goldens and inspect the diff before committing:
+
+    ```sh
+    UPDATE_GOLDEN=1 cargo test --test render_theme
+    ```


### PR DESCRIPTION
## Summary

Documentation audit against v0.3.0 reality. Two commits, intentionally split:

- **`docs: refresh CLAUDE.md for v0.3.0 and fix re-vendor step`** — `CLAUDE.md` still claimed "pre-implementation" while the repo is at v0.3.0 with PDF/HTML/text rendering shipping; added Commands and Architecture sections. The `typst-jsonresume-cv` vendoring doc's step 5 still gated on "once the golden test lands from issue #12" — the golden has shipped, so the step is aligned with the other two `VENDORING.md` files' `UPDATE_GOLDEN=1 cargo test --test render_theme` invocation.
- **`docs(constitution): strengthen §6.1 no-network commitment`** — a constitutional amendment. The original §6.1 bullet carved out a "user-initiated theme fetching" operation that was never built and is not on the roadmap; `FerrocvWorld` actively *rejects* `@preview/...` imports. The amendment tightens the clause to match the lived "zero network calls, full stop" reality. No principle is being weakened.

The amendment gets its own commit per `CONSTITUTION.md`'s own Amendments section ("In the commit message, state what changed and why").

## Test plan

- [x] `make preflight` passes locally
- [ ] CI green
- [ ] Reviewer confirms the §6.1 re-wording faithfully strengthens (not weakens) the original intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
