### PR TITLE
Add themes list subcommand for registry discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,19 @@ Pages.
 (both default to `text-minimal`). When `--output` is omitted, the
 output lands at `dist/resume.pdf` for PDF, `dist/resume.txt` for text,
 and `dist/resume.html` for HTML; parent directories are created as
-needed. Both subcommands read from stdin if no path is given.
+needed. `validate` and `render` read from stdin if no path is given.
 
-Exit codes (same for both subcommands):
+`themes list` prints registered theme names to stdout, one per line,
+sorted lexicographically, with no decoration — a stable
+machine-readable contract.
+
+Exit codes (shared across subcommands):
 
 - `0` — success
-- `1` — JSON parsed but failed schema validation (diagnostics on stderr)
-- `2` — IO error, JSON parse error, unknown theme/format, or render error
+- `1` — JSON parsed but failed schema validation (`validate` / `render`;
+  diagnostics on stderr)
+- `2` — usage error, IO error, JSON parse error, unknown theme/format,
+  render error, or unrecoverable stdout write failure
 
 No network is touched — the schema, theme, and fonts are all compiled
 into the binary.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ ferrocv render resume.json --format text
 # export is upstream-experimental; output shape may shift across
 # ferrocv releases when Typst is bumped.
 ferrocv render resume.json --format html
+
+# List bundled themes (machine-readable, one name per line)
+ferrocv themes list
 ```
 
 The quickest way to try it end-to-end is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@
 //!   IO error, malformed JSON, unknown theme, unknown format, or
 //!   Typst render error
 
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -175,13 +176,25 @@ pub fn run() -> Result<ExitCode> {
 ///
 /// This is the machine-readable contract: no headers, no decoration,
 /// no extra whitespace. Shell pipelines depend on stability here.
+///
+/// Writes go through a locked `stdout` handle with explicit error
+/// handling rather than `println!` — a broken pipe (e.g.
+/// `ferrocv themes list | head`) is a normal IO error here, not a
+/// panic. Per the module-level exit-code contract, unrecoverable
+/// stdout write failures exit with code 2.
 fn run_themes_list() -> Result<ExitCode> {
     let mut names: Vec<&'static str> = THEMES.iter().map(|t| t.name).collect();
     // `sort_unstable` is fine — theme names are unique, so stability
     // on equal keys is moot.
     names.sort_unstable();
+
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
     for name in names {
-        println!("{name}");
+        if let Err(err) = writeln!(stdout, "{name}") {
+            eprintln!("error: failed to write theme list to stdout: {err}");
+            return Ok(ExitCode::from(2));
+        }
     }
     Ok(ExitCode::SUCCESS)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,29 @@ enum Commands {
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
     },
+    /// List themes bundled with this build.
+    ///
+    /// `themes list` prints theme names one per line, sorted
+    /// lexicographically, to stdout with no decoration — a stable
+    /// machine-readable contract.
+    ///
+    /// The nested-verb form (`themes list` rather than bare `themes`)
+    /// leaves room for a sibling `themes install <spec>` subcommand
+    /// when issue #41 adds remote-fetchable themes.
+    Themes {
+        #[command(subcommand)]
+        command: ThemesCommands,
+    },
+}
+
+/// Subcommands of `ferrocv themes`.
+///
+/// Nested-verb structure reserves space for a future
+/// `themes install <spec>` sibling (see issue #41).
+#[derive(Debug, Subcommand)]
+enum ThemesCommands {
+    /// List registered theme names, one per line, sorted.
+    List,
 }
 
 /// Output formats supported by `ferrocv render`.
@@ -141,7 +164,26 @@ pub fn run() -> Result<ExitCode> {
             format,
             output,
         } => run_render(path.as_deref(), theme.as_deref(), format, output.as_deref()),
+        Commands::Themes { command } => match command {
+            ThemesCommands::List => run_themes_list(),
+        },
     }
+}
+
+/// Print the names of every theme registered with this build, one per
+/// line, sorted lexicographically ascending, to stdout.
+///
+/// This is the machine-readable contract: no headers, no decoration,
+/// no extra whitespace. Shell pipelines depend on stability here.
+fn run_themes_list() -> Result<ExitCode> {
+    let mut names: Vec<&'static str> = THEMES.iter().map(|t| t.name).collect();
+    // `sort_unstable` is fine — theme names are unique, so stability
+    // on equal keys is moot.
+    names.sort_unstable();
+    for name in names {
+        println!("{name}");
+    }
+    Ok(ExitCode::SUCCESS)
 }
 
 fn run_validate(path: Option<&Path>) -> Result<ExitCode> {

--- a/tests/themes_cli.rs
+++ b/tests/themes_cli.rs
@@ -1,0 +1,31 @@
+//! Scenario-style black-box tests for the `ferrocv themes` subcommand.
+//!
+//! These tests spawn the real built binary via `assert_cmd` and assert
+//! on observable behavior only: exit code, stdout, stderr.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #1, every CLI-visible
+//! behavior gets a scenario test. The exit-code contract under test:
+//! 0 = success. The exact-stdout assertion is deliberate — it locks
+//! in the machine-readable output contract so any accidental
+//! decoration (headers, blank lines, extra whitespace) fails loudly.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
+}
+
+#[test]
+fn themes_list_prints_sorted_names() {
+    ferrocv()
+        .arg("themes")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::eq(
+            "fantastic-cv\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
+        ))
+        .stderr(predicate::str::is_empty());
+}


### PR DESCRIPTION
## Summary

- Adds a `ferrocv themes list` subcommand that prints registered theme names to stdout, one per line, sorted — a stable machine-readable contract.
- Uses the nested-verb form (`themes list`, not bare `themes`) to leave room for a sibling `themes install` when #41 lands.
- No registry schema change — the optional `description` field flagged in the issue is deferred per CONSTITUTION §5 ("simple now; iterate later").

## Test plan

- [x] `cargo test --test themes_cli` — new scenario test (exact-match stdout assertion) passes.
- [x] `cargo test` — full suite green, no regressions.
- [x] `make preflight` — fmt-check, clippy, test, deny, audit, typos all pass.
- [x] Manual `ferrocv themes list` prints `fantastic-cv`, `modern-cv`, `text-minimal`, `typst-jsonresume-cv` and exits 0.
- [x] Manual `ferrocv themes` (no `list`) prints clap usage and exits non-zero — confirms the nested-verb structure.
- [x] `ferrocv --help` shows `themes` alongside `validate` and `render`.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include documentation of the new `themes list` CLI subcommand and usage examples.

* **New Features**
  * Added `ferrocv themes list` subcommand. Users can now directly list all available themes from the command line in alphabetical order, making it significantly easier to discover and reference the bundled theme options without consulting external documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->