### PR TITLE
Default --theme to text-minimal and add vendoring checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ schema and replaces the rendering pipeline with something more robust:
 # Validate a resume against the JSON Resume schema
 ferrocv validate resume.json
 
-# Render to PDF using the typst-jsonresume-cv theme
+# Render to PDF (defaults to the native `text-minimal` theme;
+# `--theme` is optional)
+ferrocv render resume.json
+
+# Pick a visually richer PDF theme
 ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
 
-# Render to plain text (defaults to the native `text-minimal` theme;
-# `--theme` is optional for text)
+# Render to plain text (also defaults to `text-minimal`)
 ferrocv render resume.json --format text
 
 # Render to HTML (also defaults to `text-minimal`). Note: Typst's HTML
@@ -65,12 +68,12 @@ forkable starter template that renders its own `resume.json` to PDF
 on every push via GitHub Actions and publishes the result to GitHub
 Pages.
 
-`render` defaults to `--format pdf`. `--theme` is required for
-`--format pdf` and optional for `--format text` and `--format html`
-(both default to `text-minimal`). When `--output` is omitted, the
-output lands at `dist/resume.pdf` for PDF, `dist/resume.txt` for text,
-and `dist/resume.html` for HTML; parent directories are created as
-needed. `validate` and `render` read from stdin if no path is given.
+`render` defaults to `--format pdf`. `--theme` is optional for every
+format and defaults to the native `text-minimal` theme. When
+`--output` is omitted, the output lands at `dist/resume.pdf` for PDF,
+`dist/resume.txt` for text, and `dist/resume.html` for HTML; parent
+directories are created as needed. `validate` and `render` read from
+stdin if no path is given.
 
 `themes list` prints registered theme names to stdout, one per line,
 sorted lexicographically, with no decoration — a stable

--- a/assets/themes/VENDORING_CHECKLIST.md
+++ b/assets/themes/VENDORING_CHECKLIST.md
@@ -1,0 +1,108 @@
+# Vendoring checklist
+
+Runbook for vendoring a new theme adapter, or re-vendoring an existing
+one after an upstream or Typst bump. Each per-theme `VENDORING.md` links
+back here; this file codifies the hygiene steps we keep rediscovering
+the hard way.
+
+Scope: **adapters only** (themes under `assets/themes/` that wrap an
+upstream Typst Universe template). Native themes like `text-minimal`
+author Typst directly and do not need this checklist.
+
+Work top-to-bottom. Each item is a two-minute check, not a policy
+debate — if the grep comes back clean, tick the box and move on.
+
+## 1. No `@preview/...` imports
+
+Upstream Typst Universe templates routinely import other Typst Universe
+packages (`fontawesome`, `linguify`, `scienceicons`, etc.). The
+`FerrocvWorld` rejects any `FileId` carrying a `PackageSpec` at render
+time — CONSTITUTION §6.1 forbids network fetches — so **any theme that
+imports an `@preview/...` package is dead on arrival**.
+
+```sh
+grep -n "@preview/" assets/themes/<theme>/*.typ
+```
+
+- [ ] Returns no matches.
+- [ ] If matches exist: remove the import *and* rewrite every call site.
+      Record each one in the theme's `VENDORING.md` under "Patches
+      applied" with a before/after snippet. See
+      [`modern-cv/VENDORING.md`](./modern-cv/VENDORING.md) Patches A and
+      B for worked examples (fontawesome + linguify).
+
+## 2. Empty-URL safety audit
+
+Typst `link("")` is a fatal error in 0.14.x (`error: URL must not be
+empty`). JSON Resume v1.0.0 makes every `url` field optional, so
+real-world resumes trigger this constantly. The fantastic-cv empty-URL
+bug ([#59]) was a full regression on a Typst bump because we had not
+audited this proactively.
+
+[#59]: https://github.com/cacack/ferrocv/issues/59
+
+```sh
+grep -n "link(" assets/themes/<theme>/*.typ
+```
+
+- [ ] For every call site, trace the argument back to its source. If it
+      can ever be an empty string, the call site must be guarded.
+- [ ] Acceptable guard patterns (pick whichever is closest to upstream
+      — **do not normalize across themes**, each theme's pattern
+      minimizes re-vendoring diff):
+  - **Inline ternary** (fantastic-cv): `if url.len() == 0 { text } else
+    { link(url)[text] }`.
+  - **Presence check** (modern-cv): `if ("email" in author) [ ...
+    link(...) ]`.
+  - **Empty-string guard in a helper** (typst-jsonresume-cv): wrap the
+    `link()` inside `if value != "" { ... }`.
+- [ ] Record the audit outcome in the theme's `VENDORING.md` under
+      "Empty-URL safety audit" — call sites, guard pattern, and the
+      regression test that exercises the sparse path
+      (`render_accepts_sparse_schema_valid_resume` in
+      `tests/render_cli.rs`).
+
+## 3. License consistency
+
+Upstream repos sometimes disagree with themselves: the `LICENSE` file
+says one thing, `typst.toml`'s `license` field says another. Vendoring
+the `LICENSE` file verbatim is correct, but the discrepancy must be
+noted so a future re-vendorer doesn't silently "fix" it.
+
+- [ ] Compare upstream `LICENSE` and `typst.toml`'s `license` field.
+- [ ] Vendor the actual `LICENSE` file's text into
+      `assets/themes/<theme>/LICENSE`.
+- [ ] If the two disagree, record it in the "License" section of the
+      theme's `VENDORING.md`. See
+      [`fantastic-cv/VENDORING.md`](./fantastic-cv/VENDORING.md) lines
+      28-53 for a worked example (MIT in `typst.toml`, Unlicense in
+      `LICENSE`).
+- [ ] Verify the upstream license is compatible with ferrocv's
+      MIT-OR-Apache-2.0 dual license.
+
+## 4. Regenerate goldens and inspect visually
+
+Any vendoring change — initial vendor, re-vendor, Typst bump, or a
+patch re-application — can shift pixels. The golden text extractions
+catch that.
+
+```sh
+UPDATE_GOLDEN=1 cargo test --test render_theme
+```
+
+- [ ] Run the command above, then `git diff tests/goldens/` and read
+      every line of the diff. Semantically sensible changes get
+      committed; anything unexpected is a bug.
+- [ ] Render at least one PDF manually and open it. The golden diffs
+      cover text content but not layout; a broken layout shows up
+      visually long before it breaks a test.
+- [ ] `make preflight` must be green after the update.
+
+## Final sanity pass
+
+- [ ] The per-theme `VENDORING.md` provenance table (upstream URL,
+      commit SHA, commit date, package version, vendor date) is
+      current.
+- [ ] The theme's `VENDORING.md` links back to this checklist in its
+      "See also" line.
+- [ ] `make preflight` is green.

--- a/assets/themes/fantastic-cv/VENDORING.md
+++ b/assets/themes/fantastic-cv/VENDORING.md
@@ -10,6 +10,10 @@ satisfies the constitutional no-network constraint (see
 
 [`austinyu/fantastic-cv`]: https://github.com/austinyu/fantastic-cv
 
+See also: [`../VENDORING_CHECKLIST.md`](../VENDORING_CHECKLIST.md) —
+the shared runbook for initial vendoring, re-vendoring, and Typst
+bumps.
+
 ## Provenance
 
 | Field                | Value                                                  |

--- a/assets/themes/modern-cv/VENDORING.md
+++ b/assets/themes/modern-cv/VENDORING.md
@@ -10,6 +10,10 @@ lives under §4 (adapter layer kept separable).
 
 [`DeveloperPaul123/modern-cv`]: https://github.com/DeveloperPaul123/modern-cv
 
+See also: [`../VENDORING_CHECKLIST.md`](../VENDORING_CHECKLIST.md) —
+the shared runbook for initial vendoring, re-vendoring, and Typst
+bumps.
+
 ## Provenance
 
 | Field                | Value                                                                  |

--- a/assets/themes/typst-jsonresume-cv/VENDORING.md
+++ b/assets/themes/typst-jsonresume-cv/VENDORING.md
@@ -7,6 +7,10 @@ Resume bytes from the path `ferrocv`'s Typst `World` serves them under.
 
 [`fruggiero/typst-jsonresume-cv`]: https://github.com/fruggiero/typst-jsonresume-cv
 
+See also: [`../VENDORING_CHECKLIST.md`](../VENDORING_CHECKLIST.md) —
+the shared runbook for initial vendoring, re-vendoring, and Typst
+bumps.
+
 ## Provenance
 
 | Field       | Value                                                                 |
@@ -198,6 +202,59 @@ before handing it to Typst) at that point.
 - Section builders (`work`, `edu`, `projects`,
   `cumulativeCertSkillsInterests`) — untouched.
 - Multilingual `section_titles` dictionary — untouched.
+
+## Empty-URL safety audit
+
+**Audit date:** 2026-04-20. **Outcome:** safe by construction; no
+patch required.
+
+Typst `link("")` is a fatal error in 0.14.x, and JSON Resume v1.0.0
+makes every `url` field optional, so every vendored adapter gets an
+empty-URL audit on vendor and on re-vendor. See
+[`../VENDORING_CHECKLIST.md`](../VENDORING_CHECKLIST.md) §2 for the
+shared procedure; this section records the outcome for this theme.
+
+```sh
+$ grep -n "link(" assets/themes/typst-jsonresume-cv/*.typ
+assets/themes/typst-jsonresume-cv/base.typ:152:        link(link-type + value)[#(prefix + value)]
+```
+
+One and only one `link(...)` call site, inside the `contact-item`
+helper defined at `base.typ:149`:
+
+```typst
+let contact-item(value, prefix: "", link-type: "") = {
+  if value != "" {
+    if link-type != "" {
+      link(link-type + value)[#(prefix + value)]
+    } else {
+      value
+    }
+  }
+}
+```
+
+The outer `if value != ""` guard means `link()` is never invoked with
+an empty string. The glue `resume.typ` populates every caller via
+`.at("email", default: "")`, `.at("phone", default: "")`,
+`.at("github", default: "")`, etc. — empty-string defaults flow
+cleanly through the guard. The top-level `basics.url` field is
+handled via a separate `website != none` check upstream and never
+reaches `contact-item`.
+
+`resume.typ` itself has zero `link(` call sites (grep-verified), so
+the audit surface is exactly the one call above.
+
+**Regression test:** `render_accepts_sparse_schema_valid_resume` in
+`tests/render_cli.rs` renders `tests/fixtures/render_sparse.json`
+(only `basics.name` plus one `work` entry, no URLs) through this
+theme to PDF and asserts the output is a valid PDF. Any future patch
+that weakens the `if value != ""` guard will fail that test.
+
+**Re-vendor obligation:** re-run the grep above after every upstream
+bump. If a new `link(` call site appears, trace its argument back to
+its source; if the source can ever be an empty string, apply an
+empty-URL guard before committing.
 
 ## Updating
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,9 +10,8 @@
 //!   - `validate`: document is valid
 //!   - `render`: PDF, text, or HTML written to `--output`
 //! - `1` — document parsed as JSON but failed schema validation
-//! - `2` — usage error (e.g. `--theme` missing for `--format pdf`),
-//!   IO error, malformed JSON, unknown theme, unknown format, or
-//!   Typst render error
+//! - `2` — usage error, IO error, malformed JSON, unknown theme,
+//!   unknown format, or Typst render error
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -48,10 +47,9 @@ enum Commands {
     /// Render a JSON Resume document to PDF, plain text, or HTML via
     /// the named theme.
     ///
-    /// `--theme` is required for `--format pdf` (no sensible default
-    /// adapter to pick). For `--format text` and `--format html` it
-    /// defaults to the native `text-minimal` theme so those outputs
-    /// work out of the box.
+    /// `--theme` is optional for all formats; PDF, text, and HTML all
+    /// default to the native `text-minimal` theme so first-use works
+    /// out of the box.
     ///
     /// HTML output uses Typst's experimental HTML export; output shape
     /// may shift across ferrocv releases when Typst is bumped. The CLI
@@ -60,14 +58,14 @@ enum Commands {
     /// Exit codes:
     /// - 0 — rendered successfully; output written to --output
     /// - 1 — JSON parsed but failed schema validation
-    /// - 2 — usage error (missing required `--theme` for pdf), IO
-    ///   error, parse error, unknown theme, or render error
+    /// - 2 — usage error, IO error, parse error, unknown theme, or
+    ///   render error
     Render {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
         /// Theme name. See the registered themes in `ferrocv::THEMES`.
-        /// Optional for `--format text` and `--format html` (both
-        /// default to `text-minimal`); required for `--format pdf`.
+        /// Optional for all formats; defaults to the native
+        /// `text-minimal` theme.
         #[arg(long)]
         theme: Option<String>,
         /// Output format: `pdf`, `text`, or `html`. Defaults to `pdf`.
@@ -122,21 +120,14 @@ enum Format {
 /// Resolve which theme name to use given the format and the optional
 /// `--theme` argument.
 ///
-/// Returns `Err` when the user must explicitly pick a theme but did not
-/// (currently only `--format pdf`). Returning `&'static str` for the
-/// error keeps allocation off the hot path; the caller prints it
-/// verbatim.
-fn resolve_theme_name(format: Format, requested: Option<&str>) -> Result<&str, &'static str> {
-    match (format, requested) {
-        (_, Some(name)) => Ok(name),
-        // Text and HTML both default to the native `text-minimal`
-        // theme. A dedicated `html-minimal` semantic theme is a
-        // deliberate follow-up — see `research/44-html-viability.md`
-        // §7 for the rationale (text-minimal produces valid HTML that
-        // is good enough for a first release).
-        (Format::Text, None) | (Format::Html, None) => Ok("text-minimal"),
-        (Format::Pdf, None) => Err("error: --theme is required for --format pdf"),
-    }
+/// Every format defaults to the native `text-minimal` theme when
+/// `--theme` is omitted, so first-use works out of the box without the
+/// user knowing any theme names. An explicit `--theme` always wins. A
+/// dedicated `html-minimal` semantic theme is a deliberate follow-up —
+/// see `research/44-html-viability.md` §7 for the rationale
+/// (text-minimal produces valid HTML that is good enough today).
+fn resolve_theme_name(_format: Format, requested: Option<&str>) -> &str {
+    requested.unwrap_or("text-minimal")
 }
 
 /// Default output path for a given format.
@@ -245,15 +236,10 @@ fn run_render(
     format: Format,
     output: Option<&Path>,
 ) -> Result<ExitCode> {
-    // Step 1: resolve theme name first. A missing `--theme` for pdf is
-    // a usage error and we want to fail before doing IO work.
-    let theme_name = match resolve_theme_name(format, theme_name) {
-        Ok(name) => name,
-        Err(msg) => {
-            eprintln!("{msg}");
-            return Ok(ExitCode::from(2));
-        }
-    };
+    // Step 1: resolve theme name first. Every format now has a default
+    // (`text-minimal`), so this is infallible — an explicit `--theme`
+    // overrides, otherwise the native default applies.
+    let theme_name = resolve_theme_name(format, theme_name);
 
     // Step 2: read input. IO failures bubble up via anyhow and main
     // maps them to exit code 2 (same as validate).

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -327,11 +327,13 @@ fn render_text_rejects_invalid_resume_with_exit_one() {
 }
 
 #[test]
-fn render_pdf_requires_theme_flag() {
+fn render_pdf_uses_text_minimal_when_theme_omitted() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let out = tmp.path().join("out.pdf");
 
-    // No `--theme`; explicit `--format pdf` (also the default).
+    // No `--theme`; explicit `--format pdf` (also the default). Since
+    // #52, PDF defaults to the native `text-minimal` theme like text
+    // and HTML do.
     ferrocv()
         .arg("render")
         .arg(fixture("render_full"))
@@ -340,12 +342,43 @@ fn render_pdf_requires_theme_flag() {
         .arg("--output")
         .arg(&out)
         .assert()
-        .code(2)
-        .stderr(predicate::str::contains("--theme is required"));
+        .success()
+        .stderr(predicate::str::is_empty());
 
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    assert_eq!(
+        read_prefix(&out, 5),
+        b"%PDF-",
+        "output must start with the PDF magic bytes",
+    );
+    let size = std::fs::metadata(&out).expect("stat").len();
+    assert!(size > 1024, "PDF should be > 1 KiB, was {size} bytes");
+}
+
+#[test]
+fn render_pdf_default_output_path_is_dist_resume_pdf() {
+    // No `--output`, no `--theme`, no `--format` (pdf is the default).
+    // `current_dir` is set to a tempdir so the default `dist/resume.pdf`
+    // lands under the temp tree rather than polluting the workspace.
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    ferrocv()
+        .current_dir(tmp.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .assert()
+        .success();
+
+    let expected = tmp.path().join("dist/resume.pdf");
     assert!(
-        !out.exists(),
-        "no output file should be written when --theme is missing",
+        expected.exists(),
+        "default PDF output must land at <cwd>/dist/resume.pdf; expected {}",
+        expected.display()
+    );
+    assert_eq!(
+        read_prefix(&expected, 5),
+        b"%PDF-",
+        "default PDF output must start with the PDF magic bytes",
     );
 }
 


### PR DESCRIPTION
## Summary

- **#52** — Make `--theme` optional for `--format pdf` by defaulting to the `text-minimal` native theme, matching the existing text/html behavior. Gating condition (native theme exists as anchor) is met. `resolve_theme_name` simplified to infallible `-> &str`; `render_pdf_requires_theme_flag` test replaced with two default-behavior tests mirroring the text/html pattern; README quickstart and CLI doc comments updated.
- **#60** — Audit `typst-jsonresume-cv` for empty-URL safety (confirmed safe by construction: single `link()` call in `base.typ:152` guarded by `if value != ""`; glue populates callers with empty-string defaults). Added shared `assets/themes/VENDORING_CHECKLIST.md` runbook and cross-linked from each per-theme `VENDORING.md`.

Two independent commits kept for clear changelog separation (release-please reads commit types).

## Test plan

- [x] `make preflight` green
- [x] `cargo test --test render_cli` — new `render_pdf_uses_text_minimal_when_theme_omitted` and `render_pdf_default_output_path_is_dist_resume_pdf` pass; deleted test no longer referenced
- [x] `ferrocv render --help` surfaces `text-minimal` as the default; no stale "required for pdf" copy
- [x] `ferrocv render resume.json` (no `--theme`) produces a valid PDF
- [x] Explicit `--theme typst-jsonresume-cv` override still works
- [x] Existing `render_accepts_sparse_schema_valid_resume` continues to guard empty-URL regression for `typst-jsonresume-cv`

Closes #52
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--theme` parameter is now optional for all rendering formats (pdf, text, html), with all defaulting to `text-minimal`.

* **Documentation**
  * Updated CLI documentation and added theme vendoring guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->