### PR TITLE
Add native html-minimal semantic-HTML theme and route --format html to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 ## Status
 
 **Early.** PDF, plain-text, and HTML output all work today (PDF via
-any of the registered theme adapters, text and HTML via the native
-`text-minimal` theme by default). Additional themes and native-theme
+any registered PDF-capable theme, plain text via the native
+`text-minimal` default, and HTML via the native `html-minimal`
+semantic theme). Additional themes and native-theme
 tooling are tracked as
 [GitHub issues](https://github.com/cacack/ferrocv/issues) and
 organized into phase milestones. HTML uses Typst's upstream-experimental

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
 # Render to plain text (also defaults to `text-minimal`)
 ferrocv render resume.json --format text
 
-# Render to HTML (also defaults to `text-minimal`). Note: Typst's HTML
-# export is upstream-experimental; output shape may shift across
-# ferrocv releases when Typst is bumped.
+# Render to HTML (defaults to the native `html-minimal` semantic theme).
+# Note: Typst's HTML export is upstream-experimental; output shape may
+# shift across ferrocv releases when Typst is bumped.
 ferrocv render resume.json --format html
 
 # List bundled themes (machine-readable, one name per line)
@@ -69,7 +69,8 @@ on every push via GitHub Actions (using the `setup-ferrocv` composite
 action below) and publishes the result to GitHub Pages.
 
 `render` defaults to `--format pdf`. `--theme` is optional for every
-format and defaults to the native `text-minimal` theme. When
+format: PDF and text default to the native `text-minimal` theme, while
+HTML defaults to the native `html-minimal` semantic theme. When
 `--output` is omitted, the output lands at `dist/resume.pdf` for PDF,
 `dist/resume.txt` for text, and `dist/resume.html` for HTML; parent
 directories are created as needed. `validate` and `render` read from

--- a/assets/themes/html-minimal/LICENSE
+++ b/assets/themes/html-minimal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Clonch and ferrocv contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/themes/html-minimal/resume.typ
+++ b/assets/themes/html-minimal/resume.typ
@@ -1,0 +1,497 @@
+// html-minimal — a native ferrocv theme authored directly against
+// JSON Resume v1.0.0 for the `--format html` target.
+//
+// Design constraints (see CLAUDE.md, CONSTITUTION.md §3, §4, §6.1):
+// - HTML-only. No `set page(...)` / `set par(...)` — Typst 0.14 warns
+//   when paged-layout rules are used in HTML mode, and this theme
+//   never renders to PDF. Text output still goes through the
+//   sibling `text-minimal` theme which remains optimized for the
+//   frame-walk extractor.
+// - Semantic-HTML first. `<h2>` section headings, `<section>` per
+//   JSON Resume area, `<header>` for the contact block, `<a href>`
+//   for every URL (including `mailto:` and `tel:`), `<ul>`/`<li>`
+//   for highlight lists. The browser provides visual affordances
+//   via HTML semantics — no inline CSS, no decorative glyphs.
+// - Single-file output. No package imports (the embedded
+//   `FerrocvWorld` rejects them anyway), no images, no external
+//   stylesheets, no web fonts, no inline style attributes, no
+//   sourced sub-resources. Resume data never leaves the process.
+// - Defensive optional-field reads — JSON Resume v1.0.0 has zero
+//   required fields; every accessor must tolerate missing keys.
+//   The helper block is duplicated from `text-minimal` rather than
+//   shared; CONSTITUTION §5 says share on the third caller.
+//
+// Typed-HTML API reference: https://typst.app/docs/reference/html/
+
+#let resume = json("/resume.json")
+
+// --- Optional-field helpers ----------------------------------------
+//
+// `opt(d, k)` returns `d.at(k)` if `d` is a dictionary and `k` is
+// present, otherwise `none`. Lets per-section code stay readable
+// without sprinkling `if "x" in d { ... }` everywhere.
+#let opt(d, k) = if type(d) == dictionary and k in d { d.at(k) } else { none }
+
+// `nz(s)` collapses both absent and empty-string values to `none` so
+// sections can uniformly check `if value != none`.
+#let nz(s) = if s == none or s == "" { none } else { s }
+
+// Join a list of optional strings with `sep`, dropping `none`/empty.
+// Used for location ("city, region, country") where any subset of
+// components may be missing.
+#let join_present(parts, sep) = {
+  let kept = parts.filter(p => p != none and p != "")
+  kept.join(sep)
+}
+
+// Format a date range. Either bound may be missing; an absent
+// `endDate` becomes "Present". Returns `none` if both are absent so
+// the caller can skip the line entirely.
+#let date_range(item) = {
+  let start = nz(opt(item, "startDate"))
+  let end = nz(opt(item, "endDate"))
+  if start == none and end == none {
+    none
+  } else if start != none and end != none {
+    start + " - " + end
+  } else if start != none {
+    start + " - Present"
+  } else {
+    end
+  }
+}
+
+// --- Document ------------------------------------------------------
+//
+// Single `<main>` wrapping the whole resume. Each JSON Resume area
+// becomes its own `<section>` with an `<h2>` heading. Contact block
+// is a `<header>` sibling of the sections.
+#html.main[
+  // --- Header ------------------------------------------------------
+  #let basics = opt(resume, "basics")
+  #if basics != none {
+    let name = nz(opt(basics, "name"))
+    let label = nz(opt(basics, "label"))
+    let email = nz(opt(basics, "email"))
+    let phone = nz(opt(basics, "phone"))
+    let url = nz(opt(basics, "url"))
+    let location = opt(basics, "location")
+    let location_line = if location != none {
+      let city = nz(opt(location, "city"))
+      let region = nz(opt(location, "region"))
+      let country = nz(opt(location, "countryCode"))
+      let joined = join_present((city, region, country), ", ")
+      if joined == "" { none } else { joined }
+    } else { none }
+
+    html.header[
+      #if name != none {
+        html.h1[#name]
+      }
+      #if label != none {
+        html.p[#label]
+      }
+      #if email != none {
+        html.p[#html.a(href: "mailto:" + email)[#email]]
+      }
+      #if phone != none {
+        let tel_href = "tel:" + phone.replace(" ", "").replace("-", "")
+        html.p[#html.a(href: tel_href)[#phone]]
+      }
+      #if url != none {
+        html.p[#html.a(href: url)[#url]]
+      }
+      #if location_line != none {
+        html.p[#location_line]
+      }
+      // basics.profiles — emit each as a contact-style paragraph.
+      // Treated as header continuation rather than a separate section
+      // so the rendering matches how social profiles read on a real
+      // resume.
+      #let profiles = opt(basics, "profiles")
+      #if profiles != none and type(profiles) == array and profiles.len() > 0 {
+        html.ul[
+          #for profile in profiles {
+            let network = nz(opt(profile, "network"))
+            let username = nz(opt(profile, "username"))
+            let purl = nz(opt(profile, "url"))
+            let label_part = if network != none and username != none {
+              network + ": " + username
+            } else if network != none {
+              network
+            } else if username != none {
+              username
+            } else { none }
+            if label_part != none and purl != none {
+              html.li[#label_part - #html.a(href: purl)[#purl]]
+            } else if label_part != none {
+              html.li[#label_part]
+            } else if purl != none {
+              html.li[#html.a(href: purl)[#purl]]
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Summary -----------------------------------------------------
+  #let summary = if basics != none { nz(opt(basics, "summary")) } else { none }
+  #if summary != none {
+    html.section[
+      #html.h2[Summary]
+      #html.p[#summary]
+    ]
+  }
+
+  // --- Work --------------------------------------------------------
+  #let work = opt(resume, "work")
+  #if work != none and type(work) == array and work.len() > 0 {
+    html.section[
+      #html.h2[Work]
+      #for entry in work {
+        let name = nz(opt(entry, "name"))
+        let position = nz(opt(entry, "position"))
+        let wurl = nz(opt(entry, "url"))
+        let header_text = if name != none and position != none {
+          position + " - " + name
+        } else if name != none {
+          name
+        } else if position != none {
+          position
+        } else { none }
+        html.article[
+          #if header_text != none {
+            html.h3[#header_text]
+          }
+          #if wurl != none {
+            html.p[#html.a(href: wurl)[#wurl]]
+          }
+          #let dates = date_range(entry)
+          #if dates != none {
+            html.p[#dates]
+          }
+          #let work_summary = nz(opt(entry, "summary"))
+          #if work_summary != none {
+            html.p[#work_summary]
+          }
+          #let highlights = opt(entry, "highlights")
+          #if highlights != none and type(highlights) == array {
+            let kept = highlights.filter(h => h != none and h != "")
+            if kept.len() > 0 {
+              html.ul[
+                #for h in kept {
+                  html.li[#h]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Volunteer ---------------------------------------------------
+  #let volunteer = opt(resume, "volunteer")
+  #if volunteer != none and type(volunteer) == array and volunteer.len() > 0 {
+    html.section[
+      #html.h2[Volunteer]
+      #for entry in volunteer {
+        let organization = nz(opt(entry, "organization"))
+        let position = nz(opt(entry, "position"))
+        let vurl = nz(opt(entry, "url"))
+        let header_text = if organization != none and position != none {
+          position + " - " + organization
+        } else if organization != none {
+          organization
+        } else if position != none {
+          position
+        } else { none }
+        html.article[
+          #if header_text != none {
+            html.h3[#header_text]
+          }
+          #if vurl != none {
+            html.p[#html.a(href: vurl)[#vurl]]
+          }
+          #let dates = date_range(entry)
+          #if dates != none {
+            html.p[#dates]
+          }
+          #let v_summary = nz(opt(entry, "summary"))
+          #if v_summary != none {
+            html.p[#v_summary]
+          }
+          #let highlights = opt(entry, "highlights")
+          #if highlights != none and type(highlights) == array {
+            let kept = highlights.filter(h => h != none and h != "")
+            if kept.len() > 0 {
+              html.ul[
+                #for h in kept {
+                  html.li[#h]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Education ---------------------------------------------------
+  #let education = opt(resume, "education")
+  #if education != none and type(education) == array and education.len() > 0 {
+    html.section[
+      #html.h2[Education]
+      #for entry in education {
+        let institution = nz(opt(entry, "institution"))
+        let eurl = nz(opt(entry, "url"))
+        html.article[
+          #if institution != none {
+            html.h3[#institution]
+          }
+          #if eurl != none {
+            html.p[#html.a(href: eurl)[#eurl]]
+          }
+          #let study_type = nz(opt(entry, "studyType"))
+          #let area = nz(opt(entry, "area"))
+          #let study_line = join_present((study_type, area), ", ")
+          #if study_line != "" {
+            html.p[#study_line]
+          }
+          #let dates = date_range(entry)
+          #if dates != none {
+            html.p[#dates]
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Awards ------------------------------------------------------
+  #let awards = opt(resume, "awards")
+  #if awards != none and type(awards) == array and awards.len() > 0 {
+    html.section[
+      #html.h2[Awards]
+      #for entry in awards {
+        let title = nz(opt(entry, "title"))
+        html.article[
+          #if title != none {
+            html.h3[#title]
+          }
+          #let awarder = nz(opt(entry, "awarder"))
+          #let date = nz(opt(entry, "date"))
+          #let meta = join_present((awarder, date), " - ")
+          #if meta != "" {
+            html.p[#meta]
+          }
+          #let a_summary = nz(opt(entry, "summary"))
+          #if a_summary != none {
+            html.p[#a_summary]
+          }
+          #let highlights = opt(entry, "highlights")
+          #if highlights != none and type(highlights) == array {
+            let kept = highlights.filter(h => h != none and h != "")
+            if kept.len() > 0 {
+              html.ul[
+                #for h in kept {
+                  html.li[#h]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Certificates ------------------------------------------------
+  #let certificates = opt(resume, "certificates")
+  #if certificates != none and type(certificates) == array and certificates.len() > 0 {
+    html.section[
+      #html.h2[Certificates]
+      #for entry in certificates {
+        let name = nz(opt(entry, "name"))
+        html.article[
+          #if name != none {
+            html.h3[#name]
+          }
+          #let issuer = nz(opt(entry, "issuer"))
+          #let date = nz(opt(entry, "date"))
+          #let meta = join_present((issuer, date), " - ")
+          #if meta != "" {
+            html.p[#meta]
+          }
+          #let curl = nz(opt(entry, "url"))
+          #if curl != none {
+            html.p[#html.a(href: curl)[#curl]]
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Publications ------------------------------------------------
+  #let publications = opt(resume, "publications")
+  #if publications != none and type(publications) == array and publications.len() > 0 {
+    html.section[
+      #html.h2[Publications]
+      #for entry in publications {
+        let name = nz(opt(entry, "name"))
+        html.article[
+          #if name != none {
+            html.h3[#name]
+          }
+          #let publisher = nz(opt(entry, "publisher"))
+          #let release = nz(opt(entry, "releaseDate"))
+          #let meta = join_present((publisher, release), " - ")
+          #if meta != "" {
+            html.p[#meta]
+          }
+          #let purl = nz(opt(entry, "url"))
+          #if purl != none {
+            html.p[#html.a(href: purl)[#purl]]
+          }
+          #let p_summary = nz(opt(entry, "summary"))
+          #if p_summary != none {
+            html.p[#p_summary]
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- Skills ------------------------------------------------------
+  #let skills = opt(resume, "skills")
+  #if skills != none and type(skills) == array and skills.len() > 0 {
+    html.section[
+      #html.h2[Skills]
+      #html.ul[
+        #for skill in skills {
+          let name = nz(opt(skill, "name"))
+          let level = nz(opt(skill, "level"))
+          let keywords = opt(skill, "keywords")
+          let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+            keywords.filter(k => k != none and k != "").join(", ")
+          } else { none }
+          let label_part = if name != none and level != none {
+            name + " (" + level + ")"
+          } else if name != none {
+            name
+          } else if level != none {
+            level
+          } else { none }
+          let line = if label_part != none and keywords_str != none and keywords_str != "" {
+            label_part + ": " + keywords_str
+          } else if label_part != none {
+            label_part
+          } else if keywords_str != none {
+            keywords_str
+          } else { none }
+          if line != none {
+            html.li[#line]
+          }
+        }
+      ]
+    ]
+  }
+
+  // --- Languages ---------------------------------------------------
+  #let languages = opt(resume, "languages")
+  #if languages != none and type(languages) == array and languages.len() > 0 {
+    html.section[
+      #html.h2[Languages]
+      #html.ul[
+        #for entry in languages {
+          let language = nz(opt(entry, "language"))
+          let fluency = nz(opt(entry, "fluency"))
+          let line = if language != none and fluency != none {
+            language + " (" + fluency + ")"
+          } else if language != none {
+            language
+          } else if fluency != none {
+            fluency
+          } else { none }
+          if line != none {
+            html.li[#line]
+          }
+        }
+      ]
+    ]
+  }
+
+  // --- Interests ---------------------------------------------------
+  #let interests = opt(resume, "interests")
+  #if interests != none and type(interests) == array and interests.len() > 0 {
+    html.section[
+      #html.h2[Interests]
+      #html.ul[
+        #for entry in interests {
+          let name = nz(opt(entry, "name"))
+          let keywords = opt(entry, "keywords")
+          let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+            keywords.filter(k => k != none and k != "").join(", ")
+          } else { none }
+          let line = if name != none and keywords_str != none and keywords_str != "" {
+            name + ": " + keywords_str
+          } else if name != none {
+            name
+          } else if keywords_str != none {
+            keywords_str
+          } else { none }
+          if line != none {
+            html.li[#line]
+          }
+        }
+      ]
+    ]
+  }
+
+  // --- Projects ----------------------------------------------------
+  #let projects = opt(resume, "projects")
+  #if projects != none and type(projects) == array and projects.len() > 0 {
+    html.section[
+      #html.h2[Projects]
+      #for entry in projects {
+        let name = nz(opt(entry, "name"))
+        let purl = nz(opt(entry, "url"))
+        html.article[
+          #if name != none {
+            html.h3[#name]
+          }
+          #let description = nz(opt(entry, "description"))
+          #if description != none {
+            html.p[#description]
+          }
+          #if purl != none {
+            html.p[#html.a(href: purl)[#purl]]
+          }
+          #let dates = date_range(entry)
+          #if dates != none {
+            html.p[#dates]
+          }
+        ]
+      }
+    ]
+  }
+
+  // --- References --------------------------------------------------
+  #let references = opt(resume, "references")
+  #if references != none and type(references) == array and references.len() > 0 {
+    html.section[
+      #html.h2[References]
+      #for entry in references {
+        let name = nz(opt(entry, "name"))
+        html.article[
+          #if name != none {
+            html.h3[#name]
+          }
+          #let reference = nz(opt(entry, "reference"))
+          #if reference != none {
+            html.p[#reference]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,9 +47,8 @@ enum Commands {
     /// Render a JSON Resume document to PDF, plain text, or HTML via
     /// the named theme.
     ///
-    /// `--theme` is optional for all formats; PDF, text, and HTML all
-    /// default to the native `text-minimal` theme so first-use works
-    /// out of the box.
+    /// `--theme` is optional for all formats. PDF and text default to
+    /// `text-minimal`; HTML defaults to `html-minimal`.
     ///
     /// HTML output uses Typst's experimental HTML export; output shape
     /// may shift across ferrocv releases when Typst is bumped. The CLI
@@ -120,14 +119,19 @@ enum Format {
 /// Resolve which theme name to use given the format and the optional
 /// `--theme` argument.
 ///
-/// Every format defaults to the native `text-minimal` theme when
-/// `--theme` is omitted, so first-use works out of the box without the
-/// user knowing any theme names. An explicit `--theme` always wins. A
-/// dedicated `html-minimal` semantic theme is a deliberate follow-up —
-/// see `research/44-html-viability.md` §7 for the rationale
-/// (text-minimal produces valid HTML that is good enough today).
-fn resolve_theme_name(_format: Format, requested: Option<&str>) -> &str {
-    requested.unwrap_or("text-minimal")
+/// PDF and text default to the native `text-minimal` theme. HTML
+/// defaults to the semantic-HTML native theme `html-minimal`. An
+/// explicit `--theme` always wins. See CONSTITUTION §3 for why each
+/// format gets its own native default rather than a single shared
+/// anchor.
+fn resolve_theme_name(format: Format, requested: Option<&str>) -> &str {
+    match requested {
+        Some(name) => name,
+        None => match format {
+            Format::Html => "html-minimal",
+            Format::Pdf | Format::Text => "text-minimal",
+        },
+    }
 }
 
 /// Default output path for a given format.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,8 +63,8 @@ enum Commands {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
         /// Theme name. See the registered themes in `ferrocv::THEMES`.
-        /// Optional for all formats; defaults to the native
-        /// `text-minimal` theme.
+        /// Optional for all formats. PDF and text default to
+        /// `text-minimal`; HTML defaults to `html-minimal`.
         #[arg(long)]
         theme: Option<String>,
         /// Output format: `pdf`, `text`, or `html`. Defaults to `pdf`.
@@ -241,8 +241,9 @@ fn run_render(
     output: Option<&Path>,
 ) -> Result<ExitCode> {
     // Step 1: resolve theme name first. Every format now has a default
-    // (`text-minimal`), so this is infallible — an explicit `--theme`
-    // overrides, otherwise the native default applies.
+    // (`text-minimal` for PDF/text, `html-minimal` for HTML), so this
+    // is infallible — an explicit `--theme` overrides, otherwise the
+    // native default applies.
     let theme_name = resolve_theme_name(format, theme_name);
 
     // Step 2: read input. IO failures bubble up via anyhow and main

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -26,10 +26,13 @@
 //! Per CONSTITUTION §4 the two layers are kept separable: adapter
 //! code does not leak into native themes, and native themes do not
 //! depend on adapter internals. §4 also promises that native themes
-//! will eventually live in a dedicated module. For Phase 2, with one
-//! native theme to ship, that split would be premature abstraction
-//! (CONSTITUTION §5: "simple now, iterate later"); the split is
-//! deferred until a second native theme materializes.
+//! will eventually live in a dedicated module. For Phase 2, with two
+//! small native themes colocated here (`text-minimal` and
+//! `html-minimal`), splitting into a dedicated module would add
+//! scaffolding without saving anything — the themes share no Rust
+//! code, only a registration pattern. Extract when shared
+//! native-theme infrastructure actually warrants it (CONSTITUTION §5:
+//! "simple now, iterate later").
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
@@ -228,9 +231,10 @@ const TEXT_MINIMAL_RESUME_PATH: &str = "/themes/text-minimal/resume.typ";
 /// package.
 ///
 /// CONSTITUTION §4 promises a separate native-themes module
-/// eventually. For Phase 2, with one native theme registered,
-/// splitting is premature abstraction (§5: "simple now, iterate
-/// later"); the split is deferred until a second native theme exists.
+/// eventually. For Phase 2, `text-minimal` and `html-minimal`
+/// colocate here without sharing Rust code; splitting would add
+/// scaffolding without paying for itself (§5: "simple now, iterate
+/// later"). See the module-level doc for the full rationale.
 pub const TEXT_MINIMAL: Theme = Theme {
     name: "text-minimal",
     files: &[(

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -17,9 +17,11 @@
 //!   they give `ferrocv` visual variety without re-implementing a
 //!   full resume renderer.
 //! - **Native themes** implement a `render(data) -> content` contract
-//!   directly against parsed JSON Resume data. The `text-minimal`
-//!   theme below is the first native theme — it exists to feed clean
-//!   plain-text output to [`crate::render::compile_text`].
+//!   directly against parsed JSON Resume data. `text-minimal` feeds
+//!   clean plain-text output to [`crate::render::compile_text`];
+//!   `html-minimal` targets Typst's typed-HTML API
+//!   ([`crate::render::compile_html`]) with semantic `<section>` /
+//!   `<h2>` markup.
 //!
 //! Per CONSTITUTION §4 the two layers are kept separable: adapter
 //! code does not leak into native themes, and native themes do not
@@ -31,12 +33,13 @@
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 2 ships four themes total: three adapters
-//! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`) and one native
-//! theme (`text-minimal`). A linear scan over `THEMES` is O(n) for
-//! small n; CONSTITUTION §5 ("simple now, iterate later") calls for
-//! the narrower solution here. Generalizing to a hashed lookup or a
-//! builder pattern should wait for a caller that actually needs it.
+//! Phase 2 ships five themes total: three adapters
+//! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`) and two native
+//! themes (`text-minimal`, `html-minimal`). A linear scan over
+//! `THEMES` is O(n) for small n; CONSTITUTION §5 ("simple now,
+//! iterate later") calls for the narrower solution here. Generalizing
+//! to a hashed lookup or a builder pattern should wait for a caller
+//! that actually needs it.
 
 /// A themed Typst source bundle that [`crate::render::compile_theme`]
 /// can compile against a JSON Resume document.
@@ -237,20 +240,59 @@ pub const TEXT_MINIMAL: Theme = Theme {
     entrypoint: TEXT_MINIMAL_RESUME_PATH,
 };
 
+/// Virtual path of the `html-minimal` theme's entrypoint.
+///
+/// Single per-file constant used by both the [`Theme::files`] key and
+/// the [`Theme::entrypoint`] field below, so the two cannot drift out
+/// of sync. Mirrors the [`TEXT_MINIMAL_RESUME_PATH`] pattern.
+const HTML_MINIMAL_RESUME_PATH: &str = "/themes/html-minimal/resume.typ";
+
+/// `html-minimal` — a **native theme** (per CONSTITUTION §4) authored
+/// directly against the JSON Resume v1.0.0 schema and targeted at
+/// Typst's typed-HTML API (`html.elem`, `html.body`, …) through
+/// [`crate::render::compile_html`].
+///
+/// Where [`TEXT_MINIMAL`] optimizes for frame-walk text extraction
+/// (see its doc-comment for the single-column / no-dingbat rationale),
+/// `html-minimal` optimizes for **semantic HTML** output: resume
+/// sections are wrapped in `<section>` with `<h2>` headings, contact
+/// details land in a `<ul>`, and work/education entries use `<article>`
+/// so downstream ATS and web consumers can parse structure without
+/// regexing the text. It is deliberately *not* plain-text-extractable —
+/// that is `text-minimal`'s job, and CONSTITUTION §3 calls for each
+/// format to get its own sensible default rather than forcing a single
+/// theme to straddle both.
+///
+/// The MIT-licensed source under `assets/themes/html-minimal/` is
+/// also redistributable under the `ferrocv` crate's MIT-or-Apache-2.0
+/// dual license; the file-level `LICENSE` is duplicated so the theme
+/// remains self-contained if it is ever extracted into its own
+/// package.
+pub const HTML_MINIMAL: Theme = Theme {
+    name: "html-minimal",
+    files: &[(
+        HTML_MINIMAL_RESUME_PATH,
+        include_bytes!("../assets/themes/html-minimal/resume.typ"),
+    )],
+    entrypoint: HTML_MINIMAL_RESUME_PATH,
+};
+
 /// All themes registered with this build of `ferrocv`.
 ///
 /// Phase 2 ships three adapters (`typst-jsonresume-cv`, `fantastic-cv`,
-/// `modern-cv`) and one native theme (`text-minimal`). See the module
-/// doc for why this is a `&[&Theme]` rather than a `HashMap` or a
-/// builder pattern — a linear scan over a handful of entries is fine,
-/// and CONSTITUTION §5 calls for the narrower solution until a caller
-/// actually needs more. See the module doc as well for the §4
-/// deferral on splitting native themes into their own module.
+/// `modern-cv`) and two native themes (`text-minimal`, `html-minimal`).
+/// See the module doc for why this is a `&[&Theme]` rather than a
+/// `HashMap` or a builder pattern — a linear scan over a handful of
+/// entries is fine, and CONSTITUTION §5 calls for the narrower
+/// solution until a caller actually needs more. See the module doc as
+/// well for the §4 deferral on splitting native themes into their own
+/// module.
 pub const THEMES: &[&Theme] = &[
     &TYPST_JSONRESUME_CV,
     &FANTASTIC_CV,
     &MODERN_CV,
     &TEXT_MINIMAL,
+    &HTML_MINIMAL,
 ];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -471,10 +471,16 @@ fn render_writes_html_to_output_path() {
 }
 
 #[test]
-fn render_html_uses_text_minimal_when_theme_omitted() {
+fn render_html_uses_html_minimal_when_theme_omitted() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let out = tmp.path().join("out.html");
 
+    // Since #64, `--format html` without an explicit `--theme`
+    // defaults to the native `html-minimal` theme (not `text-minimal`
+    // like PDF and text). The semantic-element assertion below is
+    // what distinguishes the two: `text-minimal` emits no `<h2>` or
+    // `<section>` tags in its HTML export, so this assertion would
+    // fail if the default-theme wiring regressed.
     ferrocv()
         .arg("render")
         .arg(fixture("render_full"))
@@ -491,6 +497,13 @@ fn render_html_uses_text_minimal_when_theme_omitted() {
     assert!(
         body.contains("Ada Lovelace"),
         "HTML output must contain the rendered name"
+    );
+    assert!(
+        body.contains("<h2") || body.contains("<section"),
+        "default-theme HTML must include a semantic element (<h2 or <section); \
+         got {} bytes starting:\n{}",
+        body.len(),
+        body.chars().take(200).collect::<String>(),
     );
 }
 
@@ -547,8 +560,13 @@ fn render_html_accepts_resume_on_stdin() {
     let input =
         std::fs::read_to_string(fixture("render_full")).expect("fixture `render_full.json`");
 
+    // `--theme text-minimal` is explicit here so this test exercises
+    // only the stdin-ingest path; if HTML defaults are ever rerouted
+    // again, this test stays stable.
     ferrocv()
         .arg("render")
+        .arg("--theme")
+        .arg("text-minimal")
         .arg("--format")
         .arg("html")
         .arg("--output")
@@ -622,5 +640,41 @@ fn render_html_modern_cv_happy_path() {
     assert!(
         size > 0,
         "HTML output should be non-empty, was {size} bytes"
+    );
+}
+
+/// Native HTML happy-path: `html-minimal` (added in #64) is the
+/// default for `--format html`, but explicitly selecting it via
+/// `--theme` should also work. The `<h2` check distinguishes this
+/// theme from `text-minimal`, which emits no semantic headings.
+#[test]
+fn render_html_html_minimal_happy_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.html");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("html-minimal")
+        .arg("--format")
+        .arg("html")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let size = std::fs::metadata(&out).expect("stat").len();
+    assert!(
+        size > 0,
+        "HTML output should be non-empty, was {size} bytes"
+    );
+    let body = std::fs::read_to_string(&out).expect("HTML output must be UTF-8");
+    assert!(
+        body.contains("<h2"),
+        "html-minimal must emit at least one <h2 element; got {} bytes",
+        body.len(),
     );
 }

--- a/tests/render_html.rs
+++ b/tests/render_html.rs
@@ -158,11 +158,17 @@ fn html_minimal_compiles_full_fixture_with_semantic_elements() {
 
     // URL fields must render as real anchors, not bare text. The
     // fixture carries both `mailto:` (basics.email) and `https://`
-    // (profiles, projects) URLs, so at least one of each scheme
-    // should survive into the output.
+    // (profiles, projects) URLs, so both schemes should survive —
+    // asserting them separately catches a regression in either class
+    // that an `||` would mask.
     assert!(
-        html.contains("<a href=\"http") || html.contains("<a href=\"mailto:"),
-        "html-minimal must render URL fields as anchors (http/mailto); got {} bytes",
+        html.contains("<a href=\"mailto:"),
+        "html-minimal must render email fields as mailto anchors; got {} bytes",
+        html.len(),
+    );
+    assert!(
+        html.contains("<a href=\"http"),
+        "html-minimal must render URL fields as http(s) anchors; got {} bytes",
         html.len(),
     );
 

--- a/tests/render_html.rs
+++ b/tests/render_html.rs
@@ -13,11 +13,14 @@
 //!   ends with `</html>`, contains a `<body>...</body>` pair in
 //!   the right order).
 //! - Content presence (the fixture's name string makes it through).
-//! - External-reference negation (no `src=`, no `href=` except
-//!   anchor links, no `<link rel`, no `@font-face`, no `url(`) —
-//!   guards against a future Typst bump silently turning on
-//!   external assets, which would break CONSTITUTION §6.1's
-//!   "single-file output" promise.
+//! - External-asset negation (no `src=`, no `<link rel`, no
+//!   `@font-face`, no `url(`) — guards against a future Typst bump
+//!   silently turning on external assets, which would break
+//!   CONSTITUTION §6.1's "single-file output" promise. `href` values
+//!   (fragment anchors, `mailto:`, `tel:`, `http(s)://`) are *not*
+//!   external assets — they are inert link targets that the user's
+//!   agent decides whether to follow — so we deliberately do not
+//!   restrict their scheme.
 //!
 //! Runs the real embedded Typst compiler via
 //! [`ferrocv::compile_html`] (doctrine §4: no mocking Typst).
@@ -77,10 +80,12 @@ fn html_compiles_full_fixture_to_well_formed_html() {
         html.len(),
     );
 
-    // External-reference negation. A regression that silently turns
-    // on external CSS, fonts, or images would break the single-file
+    // External-asset negation. A regression that silently turns on
+    // external CSS, fonts, or images would break the single-file
     // guarantee (see CONSTITUTION §6.1 and research/44-html-viability.md
-    // §5). Fragment-only `href="#..."` anchors are allowed.
+    // §5). `href` values are intentionally *not* restricted — a
+    // `mailto:` or `https://` anchor is an inert link target, not an
+    // external asset fetched at render or display time.
     assert!(
         !html.contains("src=\""),
         "HTML must not contain any `src=\"...\"` references; found one in:\n{}",
@@ -93,22 +98,102 @@ fn html_compiles_full_fixture_to_well_formed_html() {
             preview(&html, bad),
         );
     }
-    // Scan every `href="..."` and reject any that is not a fragment
-    // anchor. Iterative search keeps the assertion honest without
-    // pulling in an HTML parser.
-    let mut rest = html.as_str();
-    while let Some(idx) = rest.find("href=\"") {
-        let after = &rest[idx + 6..];
-        // The first char after `href="` must be `#` for the link to
-        // count as a fragment-only anchor.
-        let first_char = after.chars().next();
+}
+
+#[test]
+fn html_minimal_compiles_full_fixture_with_semantic_elements() {
+    let data = read_fixture("tests/fixtures/render_full.json");
+    let theme = ferrocv::find_theme("html-minimal").expect("html-minimal must be registered");
+
+    let html = ferrocv::compile_html(theme, &data)
+        .expect("html-minimal must compile render_full.json to HTML");
+
+    // Structural well-formedness (same posture as the text-minimal
+    // test above — substring search rather than HTML parsing).
+    assert!(
+        html.starts_with("<!DOCTYPE html>"),
+        "HTML must begin with <!DOCTYPE html>; got first 80 chars:\n{}",
+        html.chars().take(80).collect::<String>(),
+    );
+    assert!(
+        html.trim_end().ends_with("</html>"),
+        "HTML must end with </html> (after trimming); got last 80 chars:\n{}",
+        html.chars()
+            .rev()
+            .take(80)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect::<String>(),
+    );
+
+    let body_open = html
+        .find("<body>")
+        .expect("HTML must contain a <body> opening tag");
+    let body_close = html
+        .find("</body>")
+        .expect("HTML must contain a </body> closing tag");
+    assert!(
+        body_open < body_close,
+        "<body> must appear before </body>; got body_open={body_open}, body_close={body_close}",
+    );
+
+    // Content presence.
+    assert!(
+        html.contains("Ada Lovelace"),
+        "HTML must contain the fixture's name 'Ada Lovelace'; got {} bytes",
+        html.len(),
+    );
+
+    // Semantic elements — the reason html-minimal exists. Tag-prefix
+    // matching (`<h2`, `<section`, etc., no closing `>`) tolerates
+    // optional attributes across Typst minor versions.
+    for tag in ["<h2", "<section", "<header", "<main"] {
         assert!(
-            matches!(first_char, Some('#')),
-            "HTML href must be a fragment anchor (`#...`) only; found href starting with {first_char:?} in:\n{}",
-            preview(rest, "href=\""),
+            html.contains(tag),
+            "html-minimal must emit at least one `{tag}` element; got {} bytes",
+            html.len(),
         );
-        rest = &after[1..];
     }
+
+    // URL fields must render as real anchors, not bare text. The
+    // fixture carries both `mailto:` (basics.email) and `https://`
+    // (profiles, projects) URLs, so at least one of each scheme
+    // should survive into the output.
+    assert!(
+        html.contains("<a href=\"http") || html.contains("<a href=\"mailto:"),
+        "html-minimal must render URL fields as anchors (http/mailto); got {} bytes",
+        html.len(),
+    );
+
+    // External-asset negation: same guards as the text-minimal test.
+    assert!(
+        !html.contains("src=\""),
+        "HTML must not contain any `src=\"...\"` references; found one in:\n{}",
+        preview(&html, "src=\""),
+    );
+    for bad in ["<link rel", "@font-face", "url("] {
+        assert!(
+            !html.contains(bad),
+            "HTML must not contain `{bad}`; found one in:\n{}",
+            preview(&html, bad),
+        );
+    }
+}
+
+#[test]
+fn html_minimal_compiles_sparse_fixture_without_errors() {
+    let data = read_fixture("tests/fixtures/render_sparse.json");
+    let theme = ferrocv::find_theme("html-minimal").expect("html-minimal must be registered");
+
+    let html = ferrocv::compile_html(theme, &data)
+        .expect("html-minimal must compile render_sparse.json to HTML");
+
+    assert!(
+        html.contains("Grace Hopper"),
+        "HTML must contain the sparse fixture's name 'Grace Hopper'; got {} bytes",
+        html.len(),
+    );
 }
 
 #[test]

--- a/tests/themes_cli.rs
+++ b/tests/themes_cli.rs
@@ -25,7 +25,7 @@ fn themes_list_prints_sorted_names() {
         .assert()
         .success()
         .stdout(predicate::eq(
-            "fantastic-cv\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
+            "fantastic-cv\nhtml-minimal\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
         ))
         .stderr(predicate::str::is_empty());
 }


### PR DESCRIPTION
## Summary

- New native Typst theme `assets/themes/html-minimal/resume.typ` authored directly against JSON Resume v1.0.0 using Typst 0.14's typed-HTML API (`html.h2`, `html.section`, `html.header`, `html.main`, `html.a`, `html.ul`, `html.li`). Produces semantically correct HTML where `text-minimal` produced flat `<p>`-heavy output.
- `resolve_theme_name` in `src/cli.rs` becomes format-aware: `--format html` defaults to `html-minimal`; PDF and text continue to default to `text-minimal`. Explicit `--theme` always wins.
- Registered in `src/theme.rs::THEMES` with the same single-file pattern as `text-minimal`.
- Test coverage: new structural asserts in `tests/render_html.rs` (`<h2>`, `<section>`, `<header>`, `<main>`, real-URL `<a href="http...">` / `mailto:`), renamed CLI default-theme test, new `html-minimal` happy-path scenario, relaxed the old fragment-anchor-only `href` guard (external-asset negation `src=` / `<link rel` / `@font-face` / `url(` remains).
- README usage section updated so the documented default matches the code.

## Acceptance (issue #64)

- [x] Compiles cleanly via `cargo test --test render_html`
- [x] Output contains real `<h2>`, `<section>`, `<a href>` elements
- [x] Tag-balance spot-check (`<body>`/`</body>`, structural tags)
- [x] External-reference negation holds (no `src=`, `<link rel`, `@font-face`, `url(`)
- [x] `tests/render_cli.rs` scenario tests updated to assert the new default

## Test plan

- [x] `make preflight` green (fmt-check, clippy, test 62/62, deny, audit, typos)
- [x] `ferrocv render resume.json --format html` with no `--theme` produces `<h2>` and `<section>` markup
- [x] `ferrocv render resume.json --format html --theme text-minimal` still works (explicit override)
- [x] `ferrocv render resume.json --format pdf` and `--format text` defaults unchanged (both still `text-minimal`)
- [x] `ferrocv themes list` shows `html-minimal` alongside the other four themes, sorted

## No goldens for HTML

Matches the existing `tests/render_html.rs` posture: Typst's HTML export is upstream-experimental and churns across minors; byte-exact goldens would produce noise PRs without catching real regressions. Structural substring assertions are the contract.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `html-minimal` native theme for HTML output with semantic structure.
  * HTML output now defaults to `html-minimal`; PDF and plain text remain `text-minimal`.
  * Included MIT license for the new HTML theme.

* **Documentation**
  * README updated to document per-format default theme behavior and usage examples.

* **Tests**
  * Added and updated tests to validate HTML theme behavior and listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->