### PR TITLE
Add setup-ferrocv composite action

### DIFF
--- a/.github/actions/setup-ferrocv/action.yml
+++ b/.github/actions/setup-ferrocv/action.yml
@@ -1,0 +1,73 @@
+name: setup-ferrocv
+description: Download and install a pinned ferrocv release binary onto the runner's PATH.
+branding:
+  icon: file-text
+  color: orange
+
+inputs:
+  version:
+    description: "ferrocv release tag to install (e.g. v0.4.0). Required; no default, to force explicit pinning."
+    required: true
+
+outputs:
+  bin-path:
+    description: Absolute path to the installed ferrocv binary.
+    value: ${{ steps.install.outputs.bin-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: resolve target triple
+      id: target
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)   target=x86_64-unknown-linux-gnu; ext=tar.gz ;;
+          macOS-ARM64) target=aarch64-apple-darwin;     ext=tar.gz ;;
+          Windows-X64) target=x86_64-pc-windows-msvc;   ext=zip    ;;
+          *)
+            echo "::error::setup-ferrocv: unsupported runner ${RUNNER_OS}/${RUNNER_ARCH}. Supported: Linux/X64, macOS/ARM64, Windows/X64." >&2
+            exit 1
+            ;;
+        esac
+        echo "target=${target}" >> "${GITHUB_OUTPUT}"
+        echo "ext=${ext}" >> "${GITHUB_OUTPUT}"
+
+    - name: download, verify, install
+      id: install
+      shell: bash
+      run: |
+        set -euo pipefail
+        version='${{ inputs.version }}'
+        target='${{ steps.target.outputs.target }}'
+        ext='${{ steps.target.outputs.ext }}'
+        asset="ferrocv-${target}.${ext}"
+        base="https://github.com/cacack/ferrocv/releases/download/${version}"
+
+        work="$(mktemp -d)"
+        bin_dir="${RUNNER_TEMP}/ferrocv-bin"
+        mkdir -p "${bin_dir}"
+
+        curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${asset}" "${base}/${asset}"
+        curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${asset}.sha256" "${base}/${asset}.sha256"
+
+        (cd "${work}" && sha256sum -c "${asset}.sha256")
+
+        if [ "${ext}" = "tar.gz" ]; then
+          tar -xzf "${work}/${asset}" -C "${bin_dir}" ferrocv
+          chmod +x "${bin_dir}/ferrocv"
+          bin_path="${bin_dir}/ferrocv"
+        else
+          unzip -o "${work}/${asset}" ferrocv.exe -d "${bin_dir}"
+          bin_path="${bin_dir}/ferrocv.exe"
+        fi
+
+        rm -rf "${work}"
+
+        echo "${bin_dir}" >> "${GITHUB_PATH}"
+        echo "bin-path=${bin_path}" >> "${GITHUB_OUTPUT}"
+
+    - name: verify installation
+      shell: bash
+      run: ferrocv --version

--- a/.github/actions/setup-ferrocv/action.yml
+++ b/.github/actions/setup-ferrocv/action.yml
@@ -53,7 +53,16 @@ runs:
         curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${asset}" "${base}/${asset}"
         curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${checksum}" "${base}/${checksum}"
 
-        (cd "${work}" && sha256sum -c "${checksum}")
+        # macOS ships shasum (Perl) but not sha256sum; Linux ships
+        # sha256sum; Git for Windows ships sha256sum via coreutils.
+        if command -v sha256sum >/dev/null 2>&1; then
+          (cd "${work}" && sha256sum -c "${checksum}")
+        elif command -v shasum >/dev/null 2>&1; then
+          (cd "${work}" && shasum -a 256 -c "${checksum}")
+        else
+          echo "::error::setup-ferrocv: no sha256 verification tool found on runner" >&2
+          exit 1
+        fi
 
         if [ "${ext}" = "tar.gz" ]; then
           tar -xzf "${work}/${asset}" -C "${bin_dir}" ferrocv

--- a/.github/actions/setup-ferrocv/action.yml
+++ b/.github/actions/setup-ferrocv/action.yml
@@ -43,6 +43,7 @@ runs:
         target='${{ steps.target.outputs.target }}'
         ext='${{ steps.target.outputs.ext }}'
         asset="ferrocv-${target}.${ext}"
+        checksum="ferrocv-${target}.sha256"
         base="https://github.com/cacack/ferrocv/releases/download/${version}"
 
         work="$(mktemp -d)"
@@ -50,9 +51,9 @@ runs:
         mkdir -p "${bin_dir}"
 
         curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${asset}" "${base}/${asset}"
-        curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${asset}.sha256" "${base}/${asset}.sha256"
+        curl --proto '=https' --tlsv1.2 -fsSL -o "${work}/${checksum}" "${base}/${checksum}"
 
-        (cd "${work}" && sha256sum -c "${asset}.sha256")
+        (cd "${work}" && sha256sum -c "${checksum}")
 
         if [ "${ext}" = "tar.gz" ]; then
           tar -xzf "${work}/${asset}" -C "${bin_dir}" ferrocv

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: render pdf
         shell: bash
-        run: ferrocv render tests/fixtures/render_full.json --format pdf --output dist/out.pdf
+        # --theme is explicit because v0.4.0 predates the text-minimal
+        # default; drop once we bump to a release that includes it.
+        run: ferrocv render tests/fixtures/render_full.json --format pdf --theme typst-jsonresume-cv --output dist/out.pdf
 
       - name: render html
         shell: bash

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,0 +1,66 @@
+name: action-test
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/action-test.yml'
+      - 'tests/fixtures/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  setup-ferrocv:
+    name: setup-ferrocv (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: install ferrocv via local action
+        id: setup
+        uses: ./.github/actions/setup-ferrocv
+        with:
+          version: v0.4.0
+
+      - name: validate fixture
+        shell: bash
+        run: ferrocv validate tests/fixtures/valid_minimal.json
+
+      - name: render pdf
+        shell: bash
+        run: ferrocv render tests/fixtures/render_full.json --format pdf --output dist/out.pdf
+
+      - name: render html
+        shell: bash
+        run: ferrocv render tests/fixtures/render_full.json --format html --output dist/out.html
+
+      - name: render text
+        shell: bash
+        run: ferrocv render tests/fixtures/render_full.json --format text --output dist/out.txt
+
+      - name: assert outputs exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in dist/out.pdf dist/out.html dist/out.txt; do
+            if [ ! -s "$f" ]; then
+              echo "::error::missing or empty output: $f" >&2
+              exit 1
+            fi
+          done
+
+      - name: assert bin-path output is set
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin='${{ steps.setup.outputs.bin-path }}'
+          if [ -z "${bin}" ] || [ ! -x "${bin}" ]; then
+            echo "::error::bin-path output missing or not executable: ${bin}" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ ferrocv themes list
 The quickest way to try it end-to-end is
 [`ferrocv-example`](https://github.com/cacack/ferrocv-example), a
 forkable starter template that renders its own `resume.json` to PDF
-on every push via GitHub Actions and publishes the result to GitHub
-Pages.
+on every push via GitHub Actions (using the `setup-ferrocv` composite
+action below) and publishes the result to GitHub Pages.
 
 `render` defaults to `--format pdf`. `--theme` is optional for every
 format and defaults to the native `text-minimal` theme. When
@@ -89,6 +89,40 @@ Exit codes (shared across subcommands):
 
 No network is touched — the schema, theme, and fonts are all compiled
 into the binary.
+
+## GitHub Actions
+
+A composite action at `.github/actions/setup-ferrocv` installs a pinned
+`ferrocv` release onto the runner's `PATH`. Once installed, call any
+subcommand directly — there are no dedicated `render` / `validate`
+wrappers, because the CLI invocations are already one-liners.
+
+```yaml
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cacack/ferrocv/.github/actions/setup-ferrocv@v0.4.0
+        with:
+          version: v0.4.0
+      - run: ferrocv validate resume.json
+      - run: ferrocv render resume.json --theme typst-jsonresume-cv --output dist/resume.pdf
+      - uses: actions/upload-artifact@v4
+        with:
+          name: resume
+          path: dist/resume.pdf
+```
+
+Supported runners today: `ubuntu-latest` (x86_64), `macos-14` (arm64),
+`windows-latest` (x86_64) — matching the release asset matrix. The
+action downloads the matching tarball/zip, verifies its SHA256 against
+the sidecar file published alongside each release, and installs the
+binary under `${{ runner.temp }}/ferrocv-bin`. It also exposes a
+`bin-path` output for workflows that need the absolute path.
+
+Pin the action ref and the `version:` input to the same release tag to
+avoid drift.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- New composite action at `.github/actions/setup-ferrocv` that downloads a pinned ferrocv release, verifies its SHA256 against the sidecar file, and places the binary on the runner's `PATH`. Linux/X64, macOS/ARM64, and Windows/X64 — matches the release asset matrix.
- New `action-test.yml` workflow exercises the action across all three runners against `tests/fixtures/` — validates, renders PDF/HTML/text, and asserts outputs exist and the `bin-path` output is executable.
- README gets a new `GitHub Actions` section with a minimal usage snippet.

## Design notes

Install-only, not per-command wrappers. The duplication in `cacack/ferrocv-example` is the 8-line curl+tar install block — the actual `ferrocv validate` / `ferrocv render` invocations are already one-liners. Generalizing those would be low-leverage boilerplate. If per-command wrappers become valuable later, they compose cleanly on top of this action.

`version` input is required with no default — forces explicit pinning to match CONSTITUTION §6's reproducibility story.

## Test plan

- [ ] `action-test` workflow passes on all three matrix runners against `v0.4.0`.
- [ ] Review the action `.yml` for shell safety (`set -euo pipefail`, quoting, TLS flags on curl).
- [ ] Local `make preflight` — passes (cargo-deny warnings are pre-existing transitive `yaml-rust`/`paste` advisories, not introduced here).

## Follow-ups (separate issues)

- `cacack/ferrocv-example`: adopt the action, remove duplicated install.
- `resume` repo migration: consume the action when that repo switches off resumed+Playwright.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
