### PR TITLE
Add third-party trust badges and OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # ferrocv
 
+[![CI](https://github.com/cacack/ferrocv/actions/workflows/ci.yml/badge.svg)](https://github.com/cacack/ferrocv/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/ferrocv.svg)](https://crates.io/crates/ferrocv)
+[![docs.rs](https://img.shields.io/docsrs/ferrocv)](https://docs.rs/ferrocv)
+[![Downloads](https://img.shields.io/crates/d/ferrocv)](https://crates.io/crates/ferrocv)
+[![License](https://img.shields.io/crates/l/ferrocv)](#license)
+[![MSRV](https://img.shields.io/badge/MSRV-1.89-orange)](Cargo.toml)
+[![Dependencies](https://deps.rs/repo/github/cacack/ferrocv/status.svg)](https://deps.rs/repo/github/cacack/ferrocv)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cacack/ferrocv/badge)](https://scorecard.dev/viewer/?uri=github.com/cacack/ferrocv)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org)
+
 Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 [Typst](https://typst.app/) — single static binary, no Node or TeX required.
 


### PR DESCRIPTION
## Summary

- Adds a suite of README badges: CI, crates.io version, docs.rs, download count, license, MSRV, Conventional Commits.
- Replaces the hand-authored "supply chain" badge with two live third-party signals — **deps.rs** (continuous RustSec scanning of `Cargo.lock`) and **OpenSSF Scorecard** (weekly 0–10 score across ~18 security practices).
- Adds `.github/workflows/scorecard.yml` (weekly + push to main, SHA-pinned per repo convention) to produce the Scorecard score.

## Why

The previous hand-rolled badge was an un-audited claim. Third-party badges give readers independent evidence behind CONSTITUTION §6's trust commitments — especially §6.5 (reproducible, verifiable releases), which Scorecard actively measures (`Signed-Releases`, `Pinned-Dependencies`, `Token-Permissions`, etc.).

## Expected first-run behavior

- Scorecard badge shows `no data` until the workflow runs once.
- `publish_results: true` onboards the repo to the OpenSSF public dataset on first green run.
- Initial score will flag items like `Branch-Protection` and `Signed-Releases` — that's the point; the score doubles as a §6.5 punch list.

## Test plan

- [ ] CI is green on this PR.
- [ ] After merge, `scorecard` workflow runs on push to `main` and uploads SARIF to code scanning.
- [ ] deps.rs badge resolves to a live status within ~15 min of merge.
- [ ] Scorecard badge resolves to a numeric score after the first scheduled or push-triggered run.

Generated with [Claude Code](https://claude.com/claude-code)
