### PR TITLE
Local-path theme resolution and ResolvedTheme foundation (Stage A of #41)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,8 @@ use clap::{Parser, Subcommand};
 use serde_json::Value;
 
 use crate::{
-    THEMES, ValidationError, compile_html, compile_text, compile_theme, find_theme, validate_value,
+    THEMES, ThemeResolveError, ValidationError, compile_html_resolved, compile_text_resolved,
+    compile_theme_resolved, resolve_theme, validate_value,
 };
 
 /// Render JSON Resume documents via embedded Typst.
@@ -48,7 +49,16 @@ enum Commands {
     /// the named theme.
     ///
     /// `--theme` is optional for all formats. PDF and text default to
-    /// `text-minimal`; HTML defaults to `html-minimal`.
+    /// `text-minimal`; HTML defaults to `html-minimal`. `--theme` also
+    /// accepts a path to a local `.typ` file — either relative
+    /// (`./resume.typ`), absolute (`/abs/path/resume.typ`), or any
+    /// string ending in `.typ` or containing a path separator — in
+    /// which case the file's bytes are loaded at invocation time and
+    /// run under the same Typst sandbox bundled themes do. Single
+    /// `.typ` files only for now; directory-based local themes land
+    /// in a follow-up on issue #41. To force a bare name with no
+    /// path-like signals to resolve as a local file, prefix it with
+    /// `./` or give it a `.typ` extension.
     ///
     /// HTML output uses Typst's experimental HTML export; output shape
     /// may shift across ferrocv releases when Typst is bumped. The CLI
@@ -62,9 +72,12 @@ enum Commands {
     Render {
         /// Path to a JSON Resume document. Reads stdin if omitted.
         path: Option<PathBuf>,
-        /// Theme name. See the registered themes in `ferrocv::THEMES`.
-        /// Optional for all formats. PDF and text default to
-        /// `text-minimal`; HTML defaults to `html-minimal`.
+        /// Theme name or local `.typ` file path. Bundled names (see
+        /// `ferrocv themes list`) resolve out of the compile-time
+        /// registry; anything ending in `.typ` or containing a path
+        /// separator loads from the local filesystem. Optional for
+        /// all formats: PDF and text default to `text-minimal`; HTML
+        /// defaults to `html-minimal`.
         #[arg(long)]
         theme: Option<String>,
         /// Output format: `pdf`, `text`, or `html`. Defaults to `pdf`.
@@ -268,14 +281,27 @@ fn run_render(
         return Ok(ExitCode::from(1));
     }
 
-    // Step 5: resolve theme. Unknown names list the alternatives so
-    // users know what they could have typed.
-    let theme = match find_theme(theme_name) {
-        Some(t) => t,
-        None => {
-            eprintln!("error: unknown theme `{theme_name}`");
-            let names: Vec<&'static str> = THEMES.iter().map(|t| t.name).collect();
-            eprintln!("available themes: {}", names.join(", "));
+    // Step 5: resolve theme. Accepts three spec shapes — bundled
+    // name, local `.typ` path, or `@preview/...` spec — and returns a
+    // ResolvedTheme the compile pipeline can consume without caring
+    // which shape the user supplied. Errors carry enough context for
+    // a single-line stderr message; we match on variants only to
+    // preserve the pre-#41 "available themes: ..." hint on unknown
+    // bundled names.
+    let theme = match resolve_theme(theme_name) {
+        Ok(t) => t,
+        Err(err) => {
+            match &err {
+                ThemeResolveError::NotFound { available, .. } => {
+                    eprintln!("error: {err}");
+                    let mut names: Vec<&'static str> = available.clone();
+                    names.sort_unstable();
+                    eprintln!("available themes: {}", names.join(", "));
+                }
+                _ => {
+                    eprintln!("error: {err}");
+                }
+            }
             return Ok(ExitCode::from(2));
         }
     };
@@ -284,21 +310,21 @@ fn run_render(
     // return a String which we convert to UTF-8 bytes for the shared
     // write path below.
     let bytes: Vec<u8> = match format {
-        Format::Pdf => match compile_theme(theme, &value) {
+        Format::Pdf => match compile_theme_resolved(&theme, &value) {
             Ok(bytes) => bytes,
             Err(err) => {
                 eprintln!("{err}");
                 return Ok(ExitCode::from(2));
             }
         },
-        Format::Text => match compile_text(theme, &value) {
+        Format::Text => match compile_text_resolved(&theme, &value) {
             Ok(text) => text.into_bytes(),
             Err(err) => {
                 eprintln!("{err}");
                 return Ok(ExitCode::from(2));
             }
         },
-        Format::Html => match compile_html(theme, &value) {
+        Format::Html => match compile_html_resolved(&theme, &value) {
             Ok(html) => html.into_bytes(),
             Err(err) => {
                 eprintln!("{err}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,12 @@ pub mod theme;
 pub mod validate;
 
 pub use render::{
-    RenderDiagnostic, RenderError, compile_html, compile_pdf, compile_text, compile_theme,
+    RenderDiagnostic, RenderError, compile_html, compile_html_resolved, compile_pdf, compile_text,
+    compile_text_resolved, compile_theme, compile_theme_resolved,
 };
-pub use theme::{THEMES, Theme, find_theme};
+pub use theme::{
+    OwnedTheme, ResolvedTheme, THEMES, Theme, ThemeResolveError, find_theme, resolve_theme,
+};
 pub use validate::{ValidationError, validate_value};
 
 /// JSON Resume v1.0.0 schema, embedded at compile time.

--- a/src/render.rs
+++ b/src/render.rs
@@ -109,7 +109,7 @@ use typst::{Feature, Library, LibraryExt, World};
 use typst_html::HtmlDocument;
 use typst_pdf::PdfOptions;
 
-use crate::theme::Theme;
+use crate::theme::{OwnedTheme, ResolvedTheme, Theme};
 
 /// Virtual path of the single-file source that [`compile_pdf`] serves.
 const MAIN_PATH: &str = "/main.typ";
@@ -309,6 +309,41 @@ pub fn compile_text(theme: &Theme, data: &Value) -> Result<String, RenderError> 
 /// for some theme sources) surface as plain compile errors here.
 pub fn compile_html(theme: &Theme, data: &Value) -> Result<String, RenderError> {
     let world = FerrocvWorld::from_theme(theme, data);
+    render_world_to_html(&world)
+}
+
+/// Compile a [`ResolvedTheme`] to PDF bytes against a JSON Resume
+/// value.
+///
+/// Thin dispatch shim over [`compile_theme`] — accepts either the
+/// bundled `&'static Theme` variant or an [`OwnedTheme`] loaded off the
+/// filesystem, returning identical output for equivalent sources.
+/// Exists so CLI and other higher-level callers do not have to
+/// match on [`ResolvedTheme`] variants themselves.
+///
+/// See [`compile_theme`] for the full contract.
+pub fn compile_theme_resolved(theme: &ResolvedTheme, data: &Value) -> Result<Vec<u8>, RenderError> {
+    let world = FerrocvWorld::from_bundle(theme, data);
+    render_world(&world)
+}
+
+/// Compile a [`ResolvedTheme`] to a UTF-8 plain-text rendering against
+/// a JSON Resume value.
+///
+/// Companion to [`compile_theme_resolved`]. See [`compile_text`] for
+/// the frame-walk extractor rationale.
+pub fn compile_text_resolved(theme: &ResolvedTheme, data: &Value) -> Result<String, RenderError> {
+    let world = FerrocvWorld::from_bundle(theme, data);
+    render_world_to_text(&world)
+}
+
+/// Compile a [`ResolvedTheme`] to a single-file HTML document against
+/// a JSON Resume value.
+///
+/// Companion to [`compile_theme_resolved`]. See [`compile_html`] for
+/// the experimental-upstream caveat.
+pub fn compile_html_resolved(theme: &ResolvedTheme, data: &Value) -> Result<String, RenderError> {
+    let world = FerrocvWorld::from_bundle(theme, data);
     render_world_to_html(&world)
 }
 
@@ -591,6 +626,55 @@ impl AsSourceDiagnostic for typst::diag::SourceDiagnostic {
     }
 }
 
+/// Crate-internal trait unifying the two ownership shapes a theme
+/// bundle can take: a `&'static` [`Theme`] pulled out of the registry,
+/// or an owned [`OwnedTheme`] assembled at runtime (e.g. from a
+/// user-supplied local `.typ` file).
+///
+/// Introduced so [`FerrocvWorld::from_bundle`] stays monomorphic
+/// without the caller materializing a temporary `Theme`. Kept
+/// `pub(crate)` — the public surface is the new `compile_*_resolved`
+/// family of functions, not the trait itself.
+pub(crate) trait ThemeBundle {
+    /// Virtual path of the file Typst starts compilation from. MUST
+    /// appear as a key in [`Self::files`].
+    fn entrypoint(&self) -> &str;
+
+    /// Iterate over `(virtual_path, bytes)` pairs for every file in
+    /// the bundle.
+    fn files(&self) -> Box<dyn Iterator<Item = (&str, &[u8])> + '_>;
+}
+
+impl ThemeBundle for Theme {
+    fn entrypoint(&self) -> &str {
+        self.entrypoint
+    }
+
+    fn files(&self) -> Box<dyn Iterator<Item = (&str, &[u8])> + '_> {
+        Box::new(self.files.iter().map(|(p, b)| (*p, *b as &[u8])))
+    }
+}
+
+impl ThemeBundle for OwnedTheme {
+    fn entrypoint(&self) -> &str {
+        &self.entrypoint
+    }
+
+    fn files(&self) -> Box<dyn Iterator<Item = (&str, &[u8])> + '_> {
+        Box::new(self.files.iter().map(|(p, b)| (p.as_str(), b.as_slice())))
+    }
+}
+
+impl ThemeBundle for ResolvedTheme {
+    fn entrypoint(&self) -> &str {
+        ResolvedTheme::entrypoint(self)
+    }
+
+    fn files(&self) -> Box<dyn Iterator<Item = (&str, &[u8])> + '_> {
+        ResolvedTheme::files(self)
+    }
+}
+
 /// The [`World`] implementation that backs [`compile_pdf`] and
 /// [`compile_theme`].
 ///
@@ -630,11 +714,22 @@ impl FerrocvWorld {
     /// additionally parsed into a [`Source`] (Typst needs a parsed
     /// `Source` for the main file — see [`World::main`]).
     fn from_theme(theme: &Theme, data: &Value) -> Self {
-        let entrypoint = FileId::new(None, VirtualPath::new(theme.entrypoint));
-        let mut theme_files: HashMap<FileId, Bytes> = HashMap::with_capacity(theme.files.len());
+        Self::from_bundle(theme, data)
+    }
+
+    /// Build a World from anything that implements [`ThemeBundle`].
+    ///
+    /// The unified path behind both [`Self::from_theme`] and the new
+    /// `compile_*_resolved` functions. Factors the per-file byte-copy
+    /// loop out of a world that only knew `&Theme` into one that can
+    /// also ingest [`ResolvedTheme`] / [`OwnedTheme`] without
+    /// allocating a temporary `Theme`.
+    fn from_bundle<B: ThemeBundle + ?Sized>(bundle: &B, data: &Value) -> Self {
+        let entrypoint = FileId::new(None, VirtualPath::new(bundle.entrypoint()));
+        let mut theme_files: HashMap<FileId, Bytes> = HashMap::new();
         let mut entrypoint_text: Option<String> = None;
 
-        for (path, bytes) in theme.files {
+        for (path, bytes) in bundle.files() {
             let id = FileId::new(None, VirtualPath::new(path));
             // The entrypoint gets parsed into a Source below. We also
             // keep its bytes in the map so a `file()` lookup works
@@ -642,8 +737,10 @@ impl FerrocvWorld {
             // for, e.g., span reporting; costs nothing to populate).
             if id == entrypoint {
                 // UTF-8 is a hard requirement for any `.typ` file
-                // Typst can parse. An invalid-UTF-8 theme source is
-                // a packaging bug; panic is the right response.
+                // Typst can parse. For bundled themes an invalid-UTF-8
+                // entrypoint is a packaging bug (caught by a build-
+                // time test); for local-path themes `resolve_theme`
+                // already validated UTF-8 before we reached this path.
                 let text = std::str::from_utf8(bytes)
                     .expect("theme entrypoint must be valid UTF-8 Typst source")
                     .to_owned();
@@ -652,7 +749,7 @@ impl FerrocvWorld {
             theme_files.insert(id, Bytes::new(bytes.to_vec()));
         }
 
-        let text = entrypoint_text.expect("Theme.entrypoint must appear as a key in Theme.files");
+        let text = entrypoint_text.expect("bundle entrypoint must appear as a key in bundle files");
         let entrypoint_source = Source::new(entrypoint, text);
 
         Self::assemble(entrypoint, entrypoint_source, theme_files, data)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -43,6 +43,27 @@
 //! iterate later") calls for the narrower solution here. Generalizing
 //! to a hashed lookup or a builder pattern should wait for a caller
 //! that actually needs it.
+//!
+//! # Theme resolution: bundled vs. local-path
+//!
+//! Issue #41's first stage introduces [`resolve_theme`], which takes
+//! the raw `--theme <spec>` string and returns a [`ResolvedTheme`] —
+//! an enum with two variants:
+//!
+//! - [`ResolvedTheme::Bundled`] wraps a `&'static` [`Theme`] picked
+//!   out of [`THEMES`] by name (the legacy path, byte-for-byte
+//!   equivalent to calling [`find_theme`]).
+//! - [`ResolvedTheme::Owned`] wraps an [`OwnedTheme`] assembled at
+//!   runtime from bytes the CLI read off the filesystem. v1 of the
+//!   local-path feature accepts a single `.typ` file; directory-based
+//!   themes are rejected with a clear error pointing at the follow-up
+//!   issue. No sibling imports, no package resolver — the file runs
+//!   under exactly the same Typst sandbox bundled themes do.
+//!
+//! `@preview/...` specs are recognized but deferred: in Stage A they
+//! return [`ThemeResolveError::PackageSpecDeferredToStageC`] so
+//! Stage B's installer and Stage C's cache reader land behind a clear
+//! contract.
 
 /// A themed Typst source bundle that [`crate::render::compile_theme`]
 /// can compile against a JSON Resume document.
@@ -56,6 +77,7 @@
 ///
 /// All fields are `'static` because themes are defined as `const`s
 /// and their contents come from [`include_bytes!`].
+#[derive(Debug)]
 pub struct Theme {
     /// Registry key. Matches the value passed to [`find_theme`].
     pub name: &'static str,
@@ -305,4 +327,459 @@ pub const THEMES: &[&Theme] = &[
 /// current handful of entries (CONSTITUTION §5).
 pub fn find_theme(name: &str) -> Option<&'static Theme> {
     THEMES.iter().copied().find(|t| t.name == name)
+}
+
+/// Virtual path a local-path `.typ` file is registered at inside the
+/// [`crate::render::FerrocvWorld`]. Keeping this centralized — rather
+/// than deriving it from the user-supplied path — means the file is
+/// served under a stable, predictable location regardless of where on
+/// disk it originated. Mirrors the `/themes/<name>/...` shape bundled
+/// themes use.
+const LOCAL_THEME_ENTRYPOINT: &str = "/themes/local/resume.typ";
+
+/// A Typst source bundle owned at runtime rather than baked into the
+/// binary.
+///
+/// Structural twin of [`Theme`] but with owned fields: strings and
+/// byte vectors instead of `&'static` references. Built by
+/// [`resolve_theme`] when the user points `--theme` at a local `.typ`
+/// file; downstream compilation goes through the same
+/// [`crate::render::FerrocvWorld`] path bundled themes do.
+///
+/// # Fields
+///
+/// - `name` — a human-readable identifier for diagnostics, e.g.
+///   `"local:/abs/path/to/resume.typ"`. Never collides with a bundled
+///   theme name because bundled names never contain `:` or `/`.
+/// - `files` — `(virtual_path, bytes)` pairs; same shape as
+///   [`Theme::files`] just with owned data. Virtual paths must begin
+///   with `/` and be unique.
+/// - `entrypoint` — virtual path of the file Typst starts compiling
+///   from. MUST appear as a key in `files`.
+///
+/// v1 of the local-path feature only ever populates one entry in
+/// `files`; the `Vec` shape is chosen so Stage C's cache-resolver can
+/// reuse [`OwnedTheme`] for multi-file `@preview/...` packages without
+/// another API churn.
+#[derive(Debug, Clone)]
+pub struct OwnedTheme {
+    /// Registry-key-equivalent identifier for diagnostics. Never
+    /// collides with bundled names.
+    pub name: String,
+    /// `(virtual_path, bytes)` pairs. Same invariants as
+    /// [`Theme::files`].
+    pub files: Vec<(String, Vec<u8>)>,
+    /// Virtual path of the file Typst starts compilation from. MUST
+    /// appear as a key in [`Self::files`].
+    pub entrypoint: String,
+}
+
+/// Outcome of [`resolve_theme`] — either a reference into the
+/// compile-time [`THEMES`] registry or an [`OwnedTheme`] assembled at
+/// runtime from user-supplied bytes.
+///
+/// Downstream code does not need to match on the variants; the helper
+/// methods ([`Self::name`], [`Self::entrypoint`], [`Self::files`])
+/// surface the uniform view every consumer needs. The render pipeline
+/// wraps each variant in an internal `ThemeBundle` trait impl (see
+/// `src/render.rs`) so Typst's `FerrocvWorld` can ingest both shapes
+/// without allocating a temporary [`Theme`].
+#[derive(Debug, Clone)]
+pub enum ResolvedTheme {
+    /// A theme picked out of the compile-time [`THEMES`] slice by
+    /// name. Byte-for-byte equivalent to the pre-#41 resolution path.
+    Bundled(&'static Theme),
+    /// A theme assembled at runtime from bytes the CLI read off the
+    /// filesystem (or, in Stage C, the local installer cache).
+    Owned(OwnedTheme),
+}
+
+impl ResolvedTheme {
+    /// Human-readable identifier for diagnostics.
+    ///
+    /// Bundled themes return their registry key; owned themes return
+    /// the synthetic `name` field (e.g. `"local:/abs/path/resume.typ"`).
+    pub fn name(&self) -> &str {
+        match self {
+            ResolvedTheme::Bundled(t) => t.name,
+            ResolvedTheme::Owned(o) => &o.name,
+        }
+    }
+
+    /// Virtual path of the file Typst starts compiling from.
+    pub fn entrypoint(&self) -> &str {
+        match self {
+            ResolvedTheme::Bundled(t) => t.entrypoint,
+            ResolvedTheme::Owned(o) => &o.entrypoint,
+        }
+    }
+
+    /// Iterate over `(virtual_path, bytes)` pairs for every file in
+    /// the resolved theme.
+    ///
+    /// Abstracts the two ownership shapes: bundled themes yield
+    /// `&'static [u8]` slices via [`Theme::files`]; owned themes yield
+    /// slices borrowed off their `Vec<u8>` entries. Callers get a
+    /// uniform borrowed view and never need to allocate.
+    pub fn files(&self) -> Box<dyn Iterator<Item = (&str, &[u8])> + '_> {
+        match self {
+            ResolvedTheme::Bundled(t) => Box::new(t.files.iter().map(|(p, b)| (*p, *b as &[u8]))),
+            ResolvedTheme::Owned(o) => {
+                Box::new(o.files.iter().map(|(p, b)| (p.as_str(), b.as_slice())))
+            }
+        }
+    }
+}
+
+/// Errors returned by [`resolve_theme`].
+///
+/// All variants map to CLI exit code 2 (usage/input error); the `cli`
+/// module owns that mapping. Each variant carries enough context that
+/// a single-line `error: ...` stderr message is actionable without a
+/// follow-up "why?" from the user.
+#[derive(Debug)]
+pub enum ThemeResolveError {
+    /// A bundled-style name (no path separators, no `.typ` suffix,
+    /// no `@preview/...` prefix) did not match any entry in
+    /// [`THEMES`]. The registered names are returned alongside so the
+    /// CLI can print a "did you mean..." hint.
+    NotFound {
+        /// The name the user typed.
+        name: String,
+        /// The names of every registered bundled theme, unsorted.
+        available: Vec<&'static str>,
+    },
+    /// A local-path spec resolved to an existing filesystem entry
+    /// that is not a regular `.typ` file — typically a directory or a
+    /// file without the `.typ` extension. Directory-based local themes
+    /// are tracked as a follow-up on issue #41.
+    LocalPathNotAFile {
+        /// The path the user typed, as given.
+        path: std::path::PathBuf,
+    },
+    /// A local-path spec pointed at a path that does not exist on the
+    /// filesystem.
+    LocalPathNotFound {
+        /// The path the user typed, as given.
+        path: std::path::PathBuf,
+    },
+    /// Reading a local-path `.typ` file failed for an IO reason other
+    /// than "not found" — e.g. permissions, a broken symlink, or an
+    /// unreadable device entry.
+    LocalPathIoError {
+        /// The path the user typed, as given.
+        path: std::path::PathBuf,
+        /// The underlying IO error.
+        source: std::io::Error,
+    },
+    /// A local-path `.typ` file contained bytes that are not valid
+    /// UTF-8. Typst source files are required to be UTF-8; this is a
+    /// clearer message than letting the compiler reject it later.
+    LocalPathNotUtf8 {
+        /// The path the user typed, as given.
+        path: std::path::PathBuf,
+    },
+    /// The user supplied an `@preview/<name>:<version>` spec. Stage A
+    /// of issue #41 recognizes these but defers resolution to Stage C;
+    /// the CLI prints a message pointing at the follow-up installer
+    /// subcommand that Stage B will land.
+    PackageSpecDeferredToStageC {
+        /// The raw spec the user typed.
+        spec: String,
+    },
+}
+
+impl std::fmt::Display for ThemeResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ThemeResolveError::NotFound { name, .. } => {
+                write!(f, "unknown theme `{name}`")
+            }
+            ThemeResolveError::LocalPathNotAFile { path } => write!(
+                f,
+                "local-path theme must point to a .typ file, not a directory or non-.typ file: {} \
+                 (directory-based local themes are tracked as a follow-up on issue #41; \
+                 for now concatenate your theme into a single .typ file)",
+                path.display()
+            ),
+            ThemeResolveError::LocalPathNotFound { path } => {
+                write!(f, "local-path theme not found: {}", path.display())
+            }
+            ThemeResolveError::LocalPathIoError { path, source } => write!(
+                f,
+                "failed to read local-path theme {}: {source}",
+                path.display()
+            ),
+            ThemeResolveError::LocalPathNotUtf8 { path } => write!(
+                f,
+                "local-path theme {} is not valid UTF-8 (Typst source files must be UTF-8)",
+                path.display()
+            ),
+            ThemeResolveError::PackageSpecDeferredToStageC { spec } => write!(
+                f,
+                "{spec} theme resolution arrives in stage C of issue #41; \
+                 for now install via the future `ferrocv theme install` command (stage B) \
+                 or vendor the theme manually under assets/themes/"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ThemeResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ThemeResolveError::LocalPathIoError { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Classify how a raw `--theme <spec>` string should be resolved.
+///
+/// Three variants, evaluated in this order: `@preview/...` specs come
+/// first (unambiguous prefix); path-indicative signals (leading `.` or
+/// `/`, a path separator anywhere in the string, or a `.typ` suffix)
+/// come next; everything else is treated as a bundled-theme name.
+enum ThemeSpecKind {
+    /// `@preview/<name>:<version>` — Typst Universe package spec;
+    /// Stage A defers resolution to Stage C.
+    PreviewPackage,
+    /// A filesystem path the CLI should read bytes from.
+    LocalPath,
+    /// A bundled theme name to look up in [`THEMES`].
+    BundledName,
+}
+
+/// Classify a `--theme` argument without performing any IO.
+fn classify_spec(spec: &str) -> ThemeSpecKind {
+    if spec.starts_with("@preview/") {
+        return ThemeSpecKind::PreviewPackage;
+    }
+    // Any explicit path-indicative signal routes to local-path mode.
+    // Bundled names contain only lowercase ASCII letters, digits, and
+    // hyphens by convention, so none of these signals misfires for a
+    // real bundled name.
+    let looks_like_path = spec.starts_with('.')
+        || spec.starts_with('/')
+        || spec.contains('/')
+        || spec.contains('\\')
+        || spec.ends_with(".typ");
+    if looks_like_path {
+        return ThemeSpecKind::LocalPath;
+    }
+    ThemeSpecKind::BundledName
+}
+
+/// Resolve a `--theme <spec>` string to a [`ResolvedTheme`].
+///
+/// Detection order (no IO performed until the path branch is taken):
+///
+/// 1. Specs starting with `@preview/` return
+///    [`ThemeResolveError::PackageSpecDeferredToStageC`]. Stage A
+///    recognizes the shape; Stage B's `ferrocv theme install`
+///    populates the local cache; Stage C wires render-time resolution
+///    against that cache.
+/// 2. Specs carrying path-indicative signals — a leading `.` or `/`,
+///    any `/` or `\` separator, or a `.typ` suffix — take the
+///    local-path branch: the CLI reads the bytes at the path,
+///    verifies it is a regular `.typ` file with valid UTF-8 content,
+///    and packages it into an [`OwnedTheme`] at a fixed virtual path.
+/// 3. Everything else is treated as a bundled-theme name and looked
+///    up in [`THEMES`]; unknown names return
+///    [`ThemeResolveError::NotFound`] with the full list of
+///    registered alternatives for hint generation.
+///
+/// # Errors
+///
+/// See [`ThemeResolveError`]. All errors are user-input failures and
+/// the CLI maps them to exit code 2.
+///
+/// # Offline guarantee
+///
+/// This function performs no network calls — the `@preview/...` branch
+/// fails fast without touching the filesystem or the network, upholding
+/// CONSTITUTION §6.1. Stage A introduces no network-capable code.
+pub fn resolve_theme(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
+    match classify_spec(spec) {
+        ThemeSpecKind::PreviewPackage => Err(ThemeResolveError::PackageSpecDeferredToStageC {
+            spec: spec.to_owned(),
+        }),
+        ThemeSpecKind::LocalPath => resolve_local_path(spec),
+        ThemeSpecKind::BundledName => match find_theme(spec) {
+            Some(theme) => Ok(ResolvedTheme::Bundled(theme)),
+            None => Err(ThemeResolveError::NotFound {
+                name: spec.to_owned(),
+                available: THEMES.iter().map(|t| t.name).collect(),
+            }),
+        },
+    }
+}
+
+/// Read a local-path `.typ` file into an [`OwnedTheme`].
+///
+/// Keeps the IO isolated to one function so [`resolve_theme`] stays a
+/// clean dispatch. The caller has already classified `spec` as
+/// path-like; this function performs all the filesystem checks.
+fn resolve_local_path(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
+    let path = std::path::PathBuf::from(spec);
+
+    // Use `try_exists` semantics: `metadata()` distinguishes "doesn't
+    // exist" from other IO failures (e.g. permission denied on a
+    // parent component). Keeping them separate gives clearer errors.
+    let metadata = match std::fs::metadata(&path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ThemeResolveError::LocalPathNotFound { path });
+        }
+        Err(err) => {
+            return Err(ThemeResolveError::LocalPathIoError { path, source: err });
+        }
+    };
+
+    // v1 scope locks us to a single `.typ` file. Directories, symlinks
+    // to directories, and non-`.typ` regular files all fail here with
+    // a clear pointer to the follow-up issue.
+    let has_typ_extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("typ"))
+        .unwrap_or(false);
+    if !metadata.is_file() || !has_typ_extension {
+        return Err(ThemeResolveError::LocalPathNotAFile { path });
+    }
+
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(err) => return Err(ThemeResolveError::LocalPathIoError { path, source: err }),
+    };
+
+    // Typst source must be UTF-8. Validate early so the user gets a
+    // pointed error rather than a cryptic compile diagnostic later.
+    if std::str::from_utf8(&bytes).is_err() {
+        return Err(ThemeResolveError::LocalPathNotUtf8 { path });
+    }
+
+    // Canonicalize the path for the display name so diagnostics and
+    // equality comparisons both see the fully-resolved form. Fall
+    // back to the user-supplied path if canonicalization fails (rare
+    // — implies the path was deleted between metadata and canonicalize).
+    let display_path = std::fs::canonicalize(&path).unwrap_or(path);
+    let name = format!("local:{}", display_path.display());
+
+    Ok(ResolvedTheme::Owned(OwnedTheme {
+        name,
+        files: vec![(LOCAL_THEME_ENTRYPOINT.to_owned(), bytes)],
+        entrypoint: LOCAL_THEME_ENTRYPOINT.to_owned(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unit coverage for the bundled-vs-local-vs-preview detection
+    /// heuristic. Uses only pure-string classification (no IO) except
+    /// where the bundled-name branch needs a registry lookup.
+    #[test]
+    fn classify_spec_bundled_names() {
+        // Every real bundled name classifies as bundled.
+        for theme in THEMES {
+            assert!(
+                matches!(classify_spec(theme.name), ThemeSpecKind::BundledName),
+                "bundled theme `{}` must classify as BundledName",
+                theme.name,
+            );
+        }
+    }
+
+    #[test]
+    fn classify_spec_preview_packages() {
+        assert!(matches!(
+            classify_spec("@preview/basic-resume:0.2.8"),
+            ThemeSpecKind::PreviewPackage
+        ));
+        assert!(matches!(
+            classify_spec("@preview/foo:1.0.0"),
+            ThemeSpecKind::PreviewPackage
+        ));
+    }
+
+    #[test]
+    fn classify_spec_local_paths() {
+        // Leading `./` or `../`, absolute paths, subdirectory paths,
+        // and bare `.typ` suffixes all route to LocalPath.
+        for spec in [
+            "./resume.typ",
+            "../themes/mine.typ",
+            "/abs/path/to/theme.typ",
+            "subdir/theme.typ",
+            "theme.typ",
+            ".\\win\\path.typ",
+            "C:\\Users\\me\\theme.typ",
+        ] {
+            assert!(
+                matches!(classify_spec(spec), ThemeSpecKind::LocalPath),
+                "spec `{spec}` must classify as LocalPath",
+            );
+        }
+    }
+
+    #[test]
+    fn classify_spec_unknown_bundled_name_is_bundled() {
+        // A name with no path signals and no `@preview/` prefix stays
+        // classified as a bundled name; the registry lookup then
+        // fails with NotFound rather than being misrouted to the
+        // local-path branch.
+        assert!(matches!(
+            classify_spec("not-a-real-theme"),
+            ThemeSpecKind::BundledName
+        ));
+    }
+
+    #[test]
+    fn resolve_theme_bundled_name_hits_registry() {
+        let resolved = resolve_theme("text-minimal").expect("text-minimal is bundled");
+        assert_eq!(resolved.name(), "text-minimal");
+        match resolved {
+            ResolvedTheme::Bundled(_) => {}
+            _ => panic!("expected Bundled variant"),
+        }
+    }
+
+    #[test]
+    fn resolve_theme_unknown_bundled_name_returns_not_found() {
+        let err =
+            resolve_theme("definitely-not-a-theme").expect_err("unknown bundled names must error");
+        match err {
+            ThemeResolveError::NotFound { name, available } => {
+                assert_eq!(name, "definitely-not-a-theme");
+                assert!(!available.is_empty(), "available list must be non-empty");
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_theme_preview_spec_defers_to_stage_c() {
+        let err = resolve_theme("@preview/basic-resume:0.2.8")
+            .expect_err("preview specs must error in stage A");
+        match err {
+            ThemeResolveError::PackageSpecDeferredToStageC { spec } => {
+                assert_eq!(spec, "@preview/basic-resume:0.2.8");
+            }
+            other => panic!("expected PackageSpecDeferredToStageC, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_theme_missing_local_path_errors() {
+        let err = resolve_theme("/nonexistent/path/definitely-not-there.typ")
+            .expect_err("missing local paths must error");
+        match err {
+            ThemeResolveError::LocalPathNotFound { path } => {
+                assert!(path.to_string_lossy().contains("definitely-not-there.typ"));
+            }
+            other => panic!("expected LocalPathNotFound, got {other:?}"),
+        }
+    }
 }

--- a/tests/fixtures/local-theme.typ
+++ b/tests/fixtures/local-theme.typ
@@ -1,0 +1,17 @@
+// Minimal Typst source used by the local-path theme scenario tests
+// in `tests/render_cli.rs`. Reads the JSON Resume from `/resume.json`
+// (the virtual path every `FerrocvWorld` exposes) and emits
+// `basics.name` as the document's single heading so tests can assert
+// the value round-trips end-to-end.
+//
+// Deliberately tiny and dependency-free — no imports, no package
+// references — so it also serves as the narrowest possible exercise
+// of `resolve_theme`'s local-path branch.
+
+#let resume = json("/resume.json")
+#let name = if type(resume) == dictionary and "basics" in resume {
+  let b = resume.at("basics")
+  if type(b) == dictionary and "name" in b { b.at("name") } else { "" }
+} else { "" }
+
+= #name

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -34,6 +34,15 @@ fn fixture(name: &str) -> PathBuf {
     path
 }
 
+/// Absolute path to a non-JSON fixture (e.g. a `.typ` theme source).
+fn typ_fixture(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(name);
+    path
+}
+
 /// Build a `Command` for the `ferrocv` binary under test.
 fn ferrocv() -> Command {
     Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
@@ -676,5 +685,220 @@ fn render_html_html_minimal_happy_path() {
         body.contains("<h2"),
         "html-minimal must emit at least one <h2 element; got {} bytes",
         body.len(),
+    );
+}
+
+// --- Local-path theme scenarios ----------------------------------------
+//
+// Stage A of issue #41: `--theme <path>` accepts a local `.typ` file in
+// addition to a bundled theme name. These tests exercise the
+// observable CLI contract (exit code, stderr, output file presence and
+// content). Detection-order unit tests live next to the implementation
+// in `src/theme.rs`.
+
+/// Happy path: absolute path to a local `.typ` fixture compiles and
+/// produces a PDF whose byte stream contains the resume name.
+#[test]
+fn render_with_local_path_theme() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    let theme_path = typ_fixture("local-theme.typ");
+    assert!(
+        theme_path.exists(),
+        "fixture `tests/fixtures/local-theme.typ` must exist"
+    );
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg(&theme_path)
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    assert_eq!(
+        read_prefix(&out, 5),
+        b"%PDF-",
+        "output must start with the PDF magic bytes",
+    );
+    // Render the same fixture to text so we can assert the resume
+    // name round-tripped through Typst. PDF bytes aren't reliably
+    // searchable after font-subsetting, so use text as the channel.
+    let text_out = tmp.path().join("out.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg(&theme_path)
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&text_out)
+        .assert()
+        .success();
+    let body = std::fs::read_to_string(&text_out).expect("text output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "local-theme text output must contain the rendered name; got: {body:?}"
+    );
+}
+
+/// A relative `./local-theme.typ` resolves against the binary's
+/// `current_dir`. Copies the fixture into a tempdir so the relative
+/// path has something to land on without polluting the repo.
+#[test]
+fn render_with_local_path_relative_theme() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    let src = typ_fixture("local-theme.typ");
+    let copied = tmp.path().join("my-theme.typ");
+    std::fs::copy(&src, &copied).expect("copy fixture into tempdir");
+
+    ferrocv()
+        .current_dir(tmp.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("./my-theme.typ")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    assert_eq!(read_prefix(&out, 5), b"%PDF-");
+}
+
+/// Missing local-path file exits 2 with the offending path called out
+/// on stderr; no output file is written.
+#[test]
+fn render_with_missing_local_path_exits_two() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    let missing = tmp.path().join("does-not-exist.typ");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg(&missing)
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("does-not-exist.typ"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on missing local-path"
+    );
+}
+
+/// A directory passed as `--theme` fails fast with a clear error
+/// pointing at the follow-up issue. No output file written.
+#[test]
+fn render_with_directory_local_path_exits_two() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    let dir = tmp.path().join("theme-dir");
+    std::fs::create_dir(&dir).expect("create a directory to pass as --theme");
+    // Directory path classifies as a local-path because of the `/`
+    // separator (on POSIX) / `\` on Windows; passing a trailing-dot
+    // plus path separator is the canonical way to force classification
+    // even if the dir name itself has no `.typ` suffix. We point
+    // directly at the directory path and expect the error to mention
+    // `.typ`.
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg(&dir)
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(".typ"))
+        .stderr(predicate::str::contains("#41"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on directory local-path"
+    );
+}
+
+/// Non-UTF-8 bytes in a `.typ` file fail with a clear UTF-8 error
+/// rather than a cryptic compile diagnostic.
+#[test]
+fn render_with_non_utf8_local_path_exits_two() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    // 0xFF is never valid UTF-8 on its own; 0xC3 0x28 is a classic
+    // invalid continuation-byte pair. Together they guarantee the
+    // bytes fail UTF-8 validation on every platform.
+    let bad = tmp.path().join("bad-bytes.typ");
+    std::fs::write(&bad, [0xFF, 0xC3, 0x28, 0xFF]).expect("write non-UTF-8 bytes");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg(&bad)
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("UTF-8"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on non-UTF-8 local-path"
+    );
+}
+
+/// `@preview/<name>:<version>` specs are recognized but deferred to
+/// stage C of issue #41. The error mentions the spec and points at
+/// the stage B `ferrocv theme install` follow-up.
+#[test]
+fn render_with_preview_spec_exits_two_stage_c_hint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.pdf");
+
+    ferrocv()
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/basic-resume:0.2.8")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("@preview/basic-resume:0.2.8"))
+        .stderr(predicate::str::contains("stage C").or(predicate::str::contains("theme install")));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on deferred preview spec"
     );
 }


### PR DESCRIPTION
## Summary

Stage A of a staged landing for issue #41 ("Theme resolution: local path, bundled name, Typst Universe package"). This PR delivers the refactor foundation and local-path resolution mode. Stages B (theme install subcommand) and C (Universe cache resolution + offline-guard) land in follow-up PRs.

Related to #41

## What's in scope

- **`ResolvedTheme` / `OwnedTheme` types** (`src/theme.rs`): new enum `ResolvedTheme { Bundled(&'static Theme), Owned(OwnedTheme) }` and `OwnedTheme { name, files: Vec<(String, Vec<u8>)>, entrypoint }` unify owned and borrowed theme shapes.
- **`ThemeResolveError`** (six variants): `NotFound`, `LocalPath{NotAFile, NotFound, IoError, NotUtf8}`, `PackageSpecDeferredToStageC`.
- **`resolve_theme(spec)`**: detection heuristic classifies a `--theme` value as `@preview/...` (Stage C deferral), path-indicative (leading `.`/`/`, any path separator, or `.typ` suffix -> local-path), or everything else (bundled registry lookup). All existing bundled names continue to classify as Bundled.
- **`ThemeBundle` trait** (`src/render.rs`): `pub(crate) trait ThemeBundle` with blanket impls for `&Theme`, `&OwnedTheme`, `&ResolvedTheme`; `FerrocvWorld::from_bundle` replaces `from_theme` internally. Three new `compile_*_resolved` public wrappers dispatch on `ResolvedTheme`.
- **CLI wire-up** (`src/cli.rs`): `run_render` now calls `resolve_theme` instead of `find_theme`; unknown-bundled-name error path preserves the `available themes:` hint; `Commands::Render` doc-comment updated to document the `./name` or `.typ` local-path escape hatch.
- **11 new tests**: 5 unit tests in `src/theme.rs` (classify heuristic + resolver happy/sad paths) and 6 scenario tests in `tests/render_cli.rs` (absolute path, relative path, missing path, directory path, non-UTF-8 content, `@preview/` deferral hint).
- **`tests/fixtures/local-theme.typ`**: minimal dependency-free Typst fixture used by the local-path scenario tests.

## What's explicitly out of scope

- No network code, no new Cargo dependencies.
- `@preview/...` spec returns a clear "deferred to Stage C" error -- no silent fetch, no panic.
- `src/install.rs` does not exist yet (Stage B).
- No cache layout, no XDG path logic, no eviction policy.

## Guarantees preserved

- `FerrocvWorld`'s `PackageSpec` rejection in `src/render.rs` is untouched; `tests/render.rs::preview_package_import_is_rejected_*` (both PDF and HTML variants) compile and pass unchanged.
- `themes list` stdout contract (`tests/themes_cli.rs`) unchanged.
- All existing public APIs (`compile_theme`, `compile_text`, `compile_html`) are byte-for-byte unchanged.

## Minor public-API note

`Theme` gains `#[derive(Debug)]` -- required for `ResolvedTheme` to derive `Debug`. This is backward-compatible (adding Debug is not a breaking change).

## Preflight

`make preflight` (fmt-check, clippy -D warnings, test, deny, audit, typos) passed clean. The 3 audit warnings (`paste`, `yaml-rust` via `typst-library`, `syntect`) are pre-existing upstream transitive deps already allow-listed in `deny.toml`.

## Documentation note

The README `--theme` usage block does not yet document the local-path mode (`./my-theme.typ`, `/abs/path/to/theme.typ`). Deferred to Stage C per the staged plan, when all three resolution modes are in place and a single coherent doc section can cover all of them.
