### PR TITLE
Nightly fuzzing via cargo-fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,107 @@
+name: fuzz
+
+# Nightly coverage-guided fuzzing of the two untrusted-input boundaries:
+# JSON parse (serde_json) and schema validate (jsonschema). Runs both
+# cargo-fuzz targets on a 2-minute wall-clock budget, retains crash
+# corpora as a workflow artifact, and auto-files a GitHub issue on
+# failure so operators get paged without watching the schedule.
+#
+# Nightly Rust toolchain is fuzz-only; the main CI pipeline stays on
+# stable + MSRV. See .github/workflows/ci.yml for that story.
+
+on:
+  schedule:
+    - cron: "0 7 * * *"   # 07:00 UTC nightly (~midnight Pacific)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: cargo fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [parse, validate]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
+        with:
+          toolchain: nightly
+
+      - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-fuzz
+
+      # Seed corpus is materialized at CI time rather than committed
+      # under fuzz/corpus/ — tests/fixtures/ is the single source of
+      # truth. Copy all fixtures (valid, invalid, malformed) into both
+      # corpora; the fuzzer is coverage-guided and sorts out which
+      # inputs reach which branches.
+      - name: Seed corpus from tests/fixtures
+        run: |
+          mkdir -p fuzz/corpus/parse fuzz/corpus/validate
+          cp tests/fixtures/*.json fuzz/corpus/parse/
+          cp tests/fixtures/*.json fuzz/corpus/validate/
+
+      - name: Fuzz ${{ matrix.target }}
+        working-directory: fuzz
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=120
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-crashes-${{ matrix.target }}-${{ github.run_id }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Assemble issue body
+        if: failure()
+        run: |
+          cat > /tmp/fuzz-issue-body.md <<'FUZZBODY'
+          # Nightly fuzz failure: `${{ matrix.target }}`
+
+          The nightly `cargo-fuzz` run crashed.
+
+          - **Target:** `${{ matrix.target }}`
+          - **Commit:** `${{ github.sha }}`
+          - **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - **Crash corpus:** download the `fuzz-crashes-${{ matrix.target }}-${{ github.run_id }}` artifact from the run above.
+
+          ## Reproduce locally
+
+          ```bash
+          git fetch origin ${{ github.sha }}
+          git checkout ${{ github.sha }}
+          # Download the artifact and extract into fuzz/artifacts/${{ matrix.target }}/
+          cd fuzz
+          cargo +nightly fuzz run ${{ matrix.target }} fuzz/artifacts/${{ matrix.target }}/crash-<hash>
+          ```
+
+          Filed automatically by `.github/workflows/fuzz.yml`.
+          FUZZBODY
+
+      - name: File issue on failure
+        if: failure()
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: "Nightly fuzz failure: ${{ matrix.target }} @ ${{ github.sha }}"
+          content-filepath: /tmp/fuzz-issue-body.md
+          labels: |
+            area:ci
+            fuzz-failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ strings there are kept in lockstep with `.github/workflows/ci.yml`.
 - `make test` / `make clippy` / `make fmt` — individual targets.
 - `make install-tools` — first-time install of the non-stock tools
   (`cargo-deny`, `cargo-audit`, `typos-cli`).
+- `make fuzz` / `make fuzz-parse` / `make fuzz-validate` —
+  local cargo-fuzz smoke (60s per target, nightly Rust required).
+  Nightly CI runs these for 120s each; see
+  `.github/workflows/fuzz.yml`.
 - A single test: `cargo test --test <file> <name>` (integration tests
   live under `tests/`, e.g. `cargo test --test render_cli`).
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: help \
         preflight fmt-check fmt clippy test deny audit typos \
         build build-release check clean doc install \
-        install-tools
+        install-tools \
+        fuzz fuzz-parse fuzz-validate
 
 # CI-parity targets: keep command strings in sync with
 # .github/workflows/ci.yml so local runs match CI byte-for-byte.
@@ -34,6 +35,16 @@ audit: ## cargo-audit (CI parity)
 
 typos: ## typos check (CI parity)
 	typos
+
+# --- Fuzzing (nightly-only; not part of preflight) ---------------------------
+
+fuzz-parse: ## Run cargo-fuzz parse target for 60s (nightly required)
+	cd fuzz && cargo +nightly fuzz run parse -- -max_total_time=60
+
+fuzz-validate: ## Run cargo-fuzz validate target for 60s (nightly required)
+	cd fuzz && cargo +nightly fuzz run validate -- -max_total_time=60
+
+fuzz: fuzz-parse fuzz-validate ## Run both cargo-fuzz targets for 60s each (nightly required)
 
 # --- Build & dev -------------------------------------------------------------
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+coverage/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,49 @@
+# Standalone fuzz subcrate for ferrocv.
+#
+# This package is deliberately kept OUT of the main workspace via its
+# own empty `[workspace]` stanza below. The main `Cargo.toml` has no
+# `[workspace]`, so without this isolation Cargo would auto-detect
+# `fuzz/` as a member and `cargo fmt --all` / `cargo test --workspace`
+# / clippy would start pulling the `libfuzzer-sys` (nightly-only)
+# dependency tree into the stable toolchain build — breaking
+# `make preflight`.
+#
+# Fuzzing infrastructure is CI-time only. It does not enter the
+# shipped binary, and `fuzz/` is intentionally absent from the main
+# crate's `include = [...]` list so it never lands in the crates.io
+# tarball. Per CONSTITUTION §6.1, the runtime surface remains offline
+# and free of any fuzzer machinery.
+
+[package]
+name = "ferrocv-fuzz"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.89"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+# Empty workspace stanza: makes this package its own workspace root so
+# Cargo does not absorb it into the parent directory's implicit
+# workspace. See header comment above.
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+ferrocv = { path = ".." }
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "validate"
+path = "fuzz_targets/validate.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,15 @@
+//! Fuzz target: raw JSON parsing.
+//!
+//! Feeds arbitrary bytes to `serde_json::from_slice::<Value>`. The goal
+//! is to surface panics or UB in the parser path, not to assert any
+//! semantic property — parse failures are expected on random input.
+//!
+//! Part of the nightly fuzz workflow closing out issue #19.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use serde_json::Value;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<Value>(data);
+});

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -1,0 +1,18 @@
+//! Fuzz target: JSON Resume schema validation.
+//!
+//! Parses bytes as JSON; on parse success, drives the result through
+//! `ferrocv::validate_value`. The goal is to surface panics in the
+//! validator or the embedded-schema lookup path. Both Ok and Err are
+//! acceptable outcomes — only panics constitute a failure.
+//!
+//! Part of the nightly fuzz workflow closing out issue #19.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use serde_json::Value;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(value) = serde_json::from_slice::<Value>(data) {
+        let _ = ferrocv::validate_value(&value);
+    }
+});


### PR DESCRIPTION
## Summary
- New `fuzz/` subcrate with `libfuzzer-sys` targets for the two untrusted-input boundaries: `serde_json` parsing and `ferrocv::validate_value`.
- Nightly GitHub Actions workflow runs each target for 2 minutes at 07:00 UTC; crashes upload artifacts and auto-file an issue tagged `area:ci` / `fuzz-failure`.
- Local `make fuzz` / `make fuzz-parse` / `make fuzz-validate` for dev smoke (60s per target, nightly Rust required).

## Design notes
- Fuzz subcrate has its own `[workspace]` stanza so it stays invisible to `make preflight` — stable-toolchain CI is untouched.
- Seed corpus materialized from `tests/fixtures/*.json` at workflow time; no duplicated seed tree.
- Pinned-SHA style mirrors `.github/workflows/ci.yml`; least-privilege permissions (`issues: write` only on the fuzz job).

## Test plan
- [x] `make preflight` green — fuzz subcrate invisible to main workspace
- [x] `cargo +nightly fuzz build` (both targets) — local compile
- [ ] `cargo +nightly fuzz run parse -- -runs=1000` — local smoke (optional, nightly required)
- [ ] `cargo +nightly fuzz run validate -- -runs=1000` — local smoke (optional)
- [ ] Manual `gh workflow run fuzz.yml` dispatch green — confirms CI path end-to-end

Closes #19.