### PR TITLE
Resolve @preview/... themes from installer cache (Stage C of #41, closes issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ stdin if no path is given.
 sorted lexicographically, with no decoration — a stable
 machine-readable contract.
 
+### `--theme` resolution modes
+
+`--theme <spec>` accepts three shapes, evaluated in this order:
+
+1. **Bundled name** — e.g. `--theme typst-jsonresume-cv` or
+   `--theme html-minimal`. Looked up in the compile-time theme
+   registry; see `ferrocv themes list` for the current set.
+2. **Local `.typ` path** — e.g. `--theme ./resume.typ` or
+   `--theme /abs/path/to/theme.typ`. Any spec containing a `/` or `\`,
+   ending in `.typ`, or starting with `.` / `/` takes this branch.
+   Single-file only — directory-based local themes are tracked as a
+   follow-up. Force a bare-name spec onto this branch with `./name`
+   or a `.typ` extension.
+3. **Typst Universe package** — e.g.
+   `--theme @preview/basic-resume:0.2.8`. Resolves out of the local
+   installer cache populated by a prior `ferrocv themes install`
+   (gated behind the `install` Cargo feature). Render itself never
+   makes a network call: a cache miss exits 2 with a single-line
+   "Run: ferrocv themes install ..." hint pointing at the install
+   subcommand. Cache location is
+   `${dirs::cache_dir()}/ferrocv/packages/preview/<name>/<version>/`
+   by default and overridable via `FERROCV_CACHE_DIR`. Builds without
+   the `install` feature reject `@preview/...` specs with a clear
+   "rebuild with `--features install`" message — the cache reader is
+   gated behind the same flag as the installer itself.
+
 Exit codes (shared across subcommands):
 
 - `0` — success

--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -82,12 +82,15 @@ pub fn ensure_parent_exists(final_path: &Path) -> Result<PathBuf, InstallError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     // `std::env::set_var` / `remove_var` are global process state;
     // serialize cache-dir tests so they do not race when the test
-    // runner parallelizes.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // runner parallelizes. ENV_LOCK lives in `crate::test_env` so all
+    // three sibling test modules that mutate `FERROCV_CACHE_DIR`
+    // (this one, `package_cache::tests`, and `theme::tests`) share
+    // one mutex. A private per-module lock would let parallel
+    // `cargo test` threads race on the env var.
+    use crate::test_env::ENV_LOCK;
 
     /// RAII guard that snapshots and restores an env var. Restoration
     /// happens in `Drop`, so a panicking test body still leaves the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod install;
 #[cfg(feature = "install")]
 pub mod package_cache;
 pub mod render;
+#[cfg(test)]
+mod test_env;
 pub mod theme;
 pub mod validate;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod cli;
 #[cfg(feature = "install")]
 pub mod install;
+#[cfg(feature = "install")]
+pub mod package_cache;
 pub mod render;
 pub mod theme;
 pub mod validate;

--- a/src/package_cache.rs
+++ b/src/package_cache.rs
@@ -277,9 +277,11 @@ fn collect_typ_files(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // Shared with `install::cache::tests` and `theme::tests` — all
+    // three mutate `FERROCV_CACHE_DIR` and must serialize through one
+    // process-wide lock. See `crate::test_env`.
+    use crate::test_env::ENV_LOCK;
 
     /// Snapshot+restore guard for `FERROCV_CACHE_DIR` so a panicking
     /// test body still leaves the env intact.

--- a/src/package_cache.rs
+++ b/src/package_cache.rs
@@ -356,11 +356,16 @@ mod tests {
                     expected_path,
                 } => {
                     assert_eq!(spec, "@preview/missing-pkg:1.0.0");
+                    // Compare via Path components rather than a string
+                    // substring check — on Windows the separator is
+                    // `\` and `to_string_lossy().contains("a/b")`
+                    // returns false even when the path does end with
+                    // those components. `Path::ends_with` is
+                    // separator-agnostic.
+                    let suffix = Path::new("missing-pkg").join("1.0.0");
                     assert!(
-                        expected_path
-                            .to_string_lossy()
-                            .contains("missing-pkg/1.0.0"),
-                        "expected path must point at missing-pkg/1.0.0; got: {}",
+                        expected_path.ends_with(&suffix),
+                        "expected path must end with missing-pkg/1.0.0; got: {}",
                         expected_path.display(),
                     );
                 }

--- a/src/package_cache.rs
+++ b/src/package_cache.rs
@@ -1,0 +1,428 @@
+//! Read a Typst Universe `@preview/...` package out of the local
+//! installer cache and materialize it as an [`OwnedTheme`] that the
+//! render pipeline can compile.
+//!
+//! Stage C of issue #41 connects the offline cache populated by
+//! Stage B's `ferrocv themes install` to the render path. The reader
+//! is **filesystem-only** — no `ureq`, no `flate2`, no `tar`. It
+//! shares the cache-path resolver and the manifest parser with
+//! [`crate::install`] (gated behind the same `install` Cargo feature)
+//! so we have one source of truth for the on-disk shape.
+//!
+//! # Architectural boundary (CONSTITUTION §6.1)
+//!
+//! This module is gated behind the `install` Cargo feature, just like
+//! [`crate::install`], because both depend on the `toml` and `dirs`
+//! crates. Crucially, the resolver entry point in [`crate::cli`]
+//! decides on a cache-miss to surface a clear "run `ferrocv themes
+//! install`" error rather than calling into [`crate::install`]: the
+//! render path does not import the network-capable installer module
+//! even when the feature is on. The "no network at render time"
+//! guarantee is a code-boundary property, not just a feature-flag
+//! property.
+
+use std::path::{Path, PathBuf};
+
+use crate::install::cache::package_cache_dir;
+use crate::install::manifest::parse_manifest;
+use crate::install::spec::PackageSpec;
+use crate::theme::{OwnedTheme, ThemeResolveError};
+
+/// Read every theme file in a cached package's directory tree and
+/// assemble an [`OwnedTheme`] anchored at the package's manifest
+/// `entrypoint`.
+///
+/// Behavior:
+///
+/// 1. Resolve the cache directory for `(name, version)` via
+///    [`package_cache_dir`].
+/// 2. If the directory does not exist, return
+///    [`ThemeResolveError::PreviewCacheMiss`] carrying the missing
+///    path so the CLI can format the "run `ferrocv themes install`"
+///    hint without re-deriving the location.
+/// 3. Read `<dir>/typst.toml`, parse the minimal manifest, validate
+///    that the manifest's `entrypoint` is a relative path that stays
+///    inside the package directory.
+/// 4. Walk the package tree, reading every regular file with a
+///    suffix Typst can compile (`.typ`) into the [`OwnedTheme`]'s
+///    `files` vector. Symlinks are not followed; non-`.typ` files
+///    (`README.md`, `LICENSE`, `CHANGELOG.md`, etc.) are skipped.
+///    The manifest's `typst.toml` is also skipped — Typst does not
+///    read it at compile time.
+/// 5. Return the [`OwnedTheme`] keyed under the virtual-path prefix
+///    `/themes/preview/<name>/<version>/...`. The version is part
+///    of the prefix so two cached versions of the same package
+///    cannot collide in the World.
+///
+/// # Offline guarantee
+///
+/// This function performs zero network calls. Cache misses produce
+/// [`ThemeResolveError::PreviewCacheMiss`]; the CLI handles that by
+/// pointing the user at `ferrocv themes install` rather than calling
+/// the installer transitively. Render and validate stay offline.
+pub fn resolve_preview_spec_from_cache(
+    spec: &PackageSpec,
+) -> Result<OwnedTheme, ThemeResolveError> {
+    let raw_spec = format!("@preview/{}:{}", spec.name, spec.version);
+
+    // Errors from `package_cache_dir` mean we could not even
+    // determine where the cache lives (e.g. `FERROCV_CACHE_DIR=""`).
+    // Surface those as a cache-miss too so the CLI message stays
+    // single-shape; the formatted path will read e.g. `<unresolved>`.
+    let cache_dir = package_cache_dir(&spec.name, &spec.version).map_err(|err| {
+        ThemeResolveError::PreviewCacheMiss {
+            spec: raw_spec.clone(),
+            expected_path: PathBuf::from(format!("<unresolved: {err}>")),
+        }
+    })?;
+
+    if !cache_dir.is_dir() {
+        return Err(ThemeResolveError::PreviewCacheMiss {
+            spec: raw_spec,
+            expected_path: cache_dir,
+        });
+    }
+
+    let manifest_path = cache_dir.join("typst.toml");
+    let manifest_src = std::fs::read_to_string(&manifest_path).map_err(|source| {
+        ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec.clone(),
+            path: manifest_path.clone(),
+            reason: format!("could not read typst.toml: {source}"),
+        }
+    })?;
+    let manifest =
+        parse_manifest(&manifest_src).map_err(|err| ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec.clone(),
+            path: manifest_path.clone(),
+            reason: format!("typst.toml parse failed: {err}"),
+        })?;
+    // The on-disk manifest must agree with the spec the user typed —
+    // catches a misnamed cache entry or a `--theme` typo that pointed
+    // at the wrong cached package by accident.
+    if manifest.name != spec.name || manifest.version != spec.version {
+        return Err(ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec,
+            path: manifest_path,
+            reason: format!(
+                "manifest declares @preview/{}:{} but cache directory is for @preview/{}:{}",
+                manifest.name, manifest.version, spec.name, spec.version,
+            ),
+        });
+    }
+
+    // Parse-time validation in `parse_manifest` already rejected
+    // `..` segments, absolute paths, and Windows drive prefixes, so
+    // joining is safe here. The resulting absolute path is used only
+    // for diagnostic output below.
+    let entrypoint_abs = cache_dir.join(&manifest.entrypoint);
+    if !entrypoint_abs.is_file() {
+        return Err(ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec,
+            path: entrypoint_abs,
+            reason: "manifest entrypoint does not exist on disk".to_owned(),
+        });
+    }
+
+    let virtual_prefix = format!("/themes/preview/{}/{}", spec.name, spec.version);
+    let entrypoint_virtual = format!(
+        "{virtual_prefix}/{}",
+        // Normalize back-slashes to forward-slashes so the virtual
+        // path is platform-independent (Typst's VirtualPath is
+        // forward-slash-only). The manifest validator already
+        // rejected `..` segments, so the only normalization left is
+        // the separator flip.
+        manifest.entrypoint.replace('\\', "/"),
+    );
+
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    collect_typ_files(
+        &cache_dir,
+        &cache_dir,
+        &virtual_prefix,
+        &mut files,
+        &raw_spec,
+    )?;
+
+    // Sanity check: the entrypoint must appear among the files we
+    // collected, otherwise `FerrocvWorld::from_bundle` will panic.
+    if !files.iter().any(|(p, _)| p == &entrypoint_virtual) {
+        return Err(ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec,
+            path: cache_dir,
+            reason: format!(
+                "manifest entrypoint {} did not match any cached .typ file under {}",
+                manifest.entrypoint, virtual_prefix,
+            ),
+        });
+    }
+
+    Ok(OwnedTheme {
+        name: format!("@preview/{}:{}", spec.name, spec.version),
+        files,
+        entrypoint: entrypoint_virtual,
+    })
+}
+
+/// Walk a cached-package directory tree and push every `.typ` file
+/// into `out` keyed under `<virtual_prefix>/<relative-path>`.
+///
+/// Symlinks are not followed (`metadata.is_file()` follows symlinks
+/// but we additionally check `symlink_metadata().is_symlink()` and
+/// skip those). Non-`.typ` files are ignored — Typst will not read
+/// `README.md`, `LICENSE`, etc. at compile time, and they are not
+/// theme assets we need to register in the World.
+fn collect_typ_files(
+    root: &Path,
+    dir: &Path,
+    virtual_prefix: &str,
+    out: &mut Vec<(String, Vec<u8>)>,
+    raw_spec: &str,
+) -> Result<(), ThemeResolveError> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|source| ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec.to_owned(),
+            path: dir.to_path_buf(),
+            reason: format!("read_dir failed: {source}"),
+        })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| ThemeResolveError::PreviewCacheCorrupt {
+            spec: raw_spec.to_owned(),
+            path: dir.to_path_buf(),
+            reason: format!("dir entry read failed: {source}"),
+        })?;
+        let path = entry.path();
+        // Reject symlinks defensively. `tar::Archive::unpack` does
+        // not normally extract symlinks, but a corrupted cache or a
+        // local edit could introduce one; following it would let a
+        // resume-time read escape the cache root.
+        let symlink_meta =
+            entry
+                .file_type()
+                .map_err(|source| ThemeResolveError::PreviewCacheCorrupt {
+                    spec: raw_spec.to_owned(),
+                    path: path.clone(),
+                    reason: format!("file type read failed: {source}"),
+                })?;
+        if symlink_meta.is_symlink() {
+            // Skip silently — non-fatal, matches "if Typst can't see
+            // it, neither will the resume render" semantics.
+            continue;
+        }
+        if symlink_meta.is_dir() {
+            collect_typ_files(root, &path, virtual_prefix, out, raw_spec)?;
+            continue;
+        }
+        if !symlink_meta.is_file() {
+            continue;
+        }
+        // Only ingest `.typ` source files. Everything else
+        // (README, LICENSE, manifest, etc.) is not part of the
+        // theme bundle Typst compiles against.
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or_default();
+        if !ext.eq_ignore_ascii_case("typ") {
+            continue;
+        }
+        let relative =
+            path.strip_prefix(root)
+                .map_err(|_| ThemeResolveError::PreviewCacheCorrupt {
+                    spec: raw_spec.to_owned(),
+                    path: path.clone(),
+                    reason: "cached file path escaped cache root".to_owned(),
+                })?;
+        // Build a forward-slash virtual path. `Path::display()` on
+        // Windows uses back-slashes; we explicitly join components so
+        // the result is portable.
+        let mut virtual_path = String::from(virtual_prefix);
+        for component in relative.components() {
+            match component {
+                std::path::Component::Normal(name) => {
+                    virtual_path.push('/');
+                    let s =
+                        name.to_str()
+                            .ok_or_else(|| ThemeResolveError::PreviewCacheCorrupt {
+                                spec: raw_spec.to_owned(),
+                                path: path.clone(),
+                                reason: "cached file path is not valid UTF-8".to_owned(),
+                            })?;
+                    virtual_path.push_str(s);
+                }
+                // Skip CurDir; ParentDir / RootDir / Prefix should
+                // be unreachable because we built `relative` via
+                // `strip_prefix`, but we handle them defensively.
+                std::path::Component::CurDir => {}
+                _ => {
+                    return Err(ThemeResolveError::PreviewCacheCorrupt {
+                        spec: raw_spec.to_owned(),
+                        path: path.clone(),
+                        reason: "unexpected component in relative cache path".to_owned(),
+                    });
+                }
+            }
+        }
+        let bytes =
+            std::fs::read(&path).map_err(|source| ThemeResolveError::PreviewCacheCorrupt {
+                spec: raw_spec.to_owned(),
+                path: path.clone(),
+                reason: format!("read failed: {source}"),
+            })?;
+        out.push((virtual_path, bytes));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Snapshot+restore guard for `FERROCV_CACHE_DIR` so a panicking
+    /// test body still leaves the env intact.
+    struct EnvGuard {
+        prior: Option<String>,
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests are serialized via ENV_LOCK held by the
+            // caller of `with_cache_dir`.
+            unsafe {
+                match &self.prior {
+                    Some(v) => std::env::set_var("FERROCV_CACHE_DIR", v),
+                    None => std::env::remove_var("FERROCV_CACHE_DIR"),
+                }
+            }
+        }
+    }
+
+    fn with_cache_dir<F: FnOnce()>(value: &Path, body: F) {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = EnvGuard {
+            prior: std::env::var("FERROCV_CACHE_DIR").ok(),
+        };
+        // SAFETY: serialized via ENV_LOCK above.
+        unsafe {
+            std::env::set_var("FERROCV_CACHE_DIR", value);
+        }
+        body();
+    }
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir -p");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    /// Construct a minimal valid cached package under `cache_root`.
+    fn populate_minimal_package(cache_root: &Path, name: &str, version: &str) -> PathBuf {
+        let pkg = cache_root
+            .join("packages")
+            .join("preview")
+            .join(name)
+            .join(version);
+        write(
+            &pkg.join("typst.toml"),
+            &format!(
+                "[package]\nname = \"{name}\"\nversion = \"{version}\"\nentrypoint = \"src/lib.typ\"\n",
+            ),
+        );
+        write(&pkg.join("src/lib.typ"), "= Hello\n");
+        write(&pkg.join("README.md"), "ignored\n");
+        pkg
+    }
+
+    #[test]
+    fn cache_miss_returns_preview_cache_miss_with_expected_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "missing-pkg".to_owned(),
+                version: "1.0.0".to_owned(),
+            };
+            let err =
+                resolve_preview_spec_from_cache(&spec).expect_err("missing cache entry must error");
+            match err {
+                ThemeResolveError::PreviewCacheMiss {
+                    spec,
+                    expected_path,
+                } => {
+                    assert_eq!(spec, "@preview/missing-pkg:1.0.0");
+                    assert!(
+                        expected_path
+                            .to_string_lossy()
+                            .contains("missing-pkg/1.0.0"),
+                        "expected path must point at missing-pkg/1.0.0; got: {}",
+                        expected_path.display(),
+                    );
+                }
+                other => panic!("expected PreviewCacheMiss, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn cache_hit_assembles_owned_theme() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pkg = populate_minimal_package(tmp.path(), "demo-pkg", "0.1.0");
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "demo-pkg".to_owned(),
+                version: "0.1.0".to_owned(),
+            };
+            let theme =
+                resolve_preview_spec_from_cache(&spec).expect("populated cache must resolve");
+            assert_eq!(theme.name, "@preview/demo-pkg:0.1.0");
+            assert_eq!(
+                theme.entrypoint,
+                "/themes/preview/demo-pkg/0.1.0/src/lib.typ"
+            );
+            // Non-`.typ` files are skipped: README.md must not appear
+            // in the file list.
+            assert!(
+                theme.files.iter().any(|(p, _)| p.ends_with("/src/lib.typ")),
+                "lib.typ must appear in files; got {:?}",
+                theme.files.iter().map(|(p, _)| p).collect::<Vec<_>>(),
+            );
+            assert!(
+                theme
+                    .files
+                    .iter()
+                    .all(|(p, _)| !p.to_lowercase().ends_with(".md")),
+                "README.md must be filtered out",
+            );
+        });
+    }
+
+    #[test]
+    fn cache_hit_with_manifest_mismatch_is_corrupt() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Manifest declares a different name than the directory.
+        let pkg = tmp.path().join("packages/preview/asked-for/1.0.0");
+        write(
+            &pkg.join("typst.toml"),
+            "[package]\nname = \"actually-different\"\nversion = \"1.0.0\"\nentrypoint = \"src/lib.typ\"\n",
+        );
+        write(&pkg.join("src/lib.typ"), "= Hi\n");
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "asked-for".to_owned(),
+                version: "1.0.0".to_owned(),
+            };
+            let err =
+                resolve_preview_spec_from_cache(&spec).expect_err("manifest mismatch must error");
+            assert!(
+                matches!(err, ThemeResolveError::PreviewCacheCorrupt { .. }),
+                "expected PreviewCacheCorrupt; got: {err:?}",
+            );
+        });
+    }
+}

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,21 @@
+//! Shared test-only utilities. Compiled only under `#[cfg(test)]`, so
+//! it never ships in any release artifact.
+//!
+//! Currently exports a single mutex used to serialize env-var
+//! mutations across unit tests in different modules. ferrocv has
+//! multiple test sites that mutate `FERROCV_CACHE_DIR`
+//! ([`crate::install::cache::tests`], [`crate::package_cache::tests`],
+//! and [`crate::theme::tests`]); without a process-wide lock,
+//! `cargo test`'s parallel threads would race on the env var and
+//! produce intermittent failures. One static lock here is the smallest
+//! solution that keeps all three test modules honest.
+
+use std::sync::Mutex;
+
+/// Process-wide serialization lock for env-var-mutating tests.
+///
+/// Acquire before any `unsafe { std::env::set_var(...) }` call in a
+/// test. The lock is poison-tolerant: a panic inside one test releases
+/// the lock and the next test recovers via `unwrap_or_else(|p|
+/// p.into_inner())`.
+pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -528,6 +528,18 @@ pub enum ThemeResolveError {
         /// The raw spec the user typed.
         spec: String,
     },
+    /// The user supplied a string starting with `@preview/` that is
+    /// not a syntactically valid spec. The previous design folded this
+    /// into [`Self::PreviewCacheMiss`], but that produced a circular
+    /// hint ("Run: ferrocv themes install <bad spec>" — which would
+    /// hit the same parse failure). Splitting it lets the CLI print a
+    /// pointed "expected `@preview/<name>:<version>`" message instead.
+    PreviewSpecInvalid {
+        /// The raw spec the user typed.
+        spec: String,
+        /// Human-readable explanation from the spec parser.
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for ThemeResolveError {
@@ -576,6 +588,11 @@ impl std::fmt::Display for ThemeResolveError {
                 "theme '{spec}' requires a build with the `install` Cargo feature. \
                  Rebuild with `cargo install ferrocv --features install`, \
                  then run `ferrocv themes install {spec}` before this render."
+            ),
+            ThemeResolveError::PreviewSpecInvalid { spec, reason } => write!(
+                f,
+                "invalid Typst Universe spec '{spec}': {reason}. \
+                 Expected '@preview/<name>:<version>' (e.g. '@preview/basic-resume:0.2.8')."
             ),
         }
     }
@@ -696,15 +713,16 @@ fn resolve_preview_package(spec: &str) -> Result<ResolvedTheme, ThemeResolveErro
 
 #[cfg(feature = "install")]
 fn resolve_preview_package(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
-    // Parsing failures surface as PreviewCacheMiss with a synthetic
-    // path so the CLI mapping stays simple and the user sees a
-    // useful hint. Anything past `parse_spec` is a real cache lookup.
+    // Parse failures get their own variant so the user sees an
+    // actionable "expected '@preview/<name>:<version>'" message rather
+    // than a circular "run themes install <bad spec>" hint that would
+    // hit the same parse failure.
     let parsed = match crate::install::spec::parse_spec(spec) {
         Ok(p) => p,
         Err(err) => {
-            return Err(ThemeResolveError::PreviewCacheMiss {
+            return Err(ThemeResolveError::PreviewSpecInvalid {
                 spec: spec.to_owned(),
-                expected_path: std::path::PathBuf::from(format!("<invalid spec: {err}>")),
+                reason: format!("{err}"),
             });
         }
     };
@@ -882,17 +900,22 @@ mod tests {
         // real $HOME cache state. Use a unique tempdir per test so
         // parallel runs don't share state.
         let tmp = tempfile::TempDir::new().expect("tempdir");
-        // SAFETY: this is a single-threaded unit test entry point;
-        // the env var is restored on Drop via the local guard below.
+
+        // Serialize against every other test that mutates this env
+        // var. Without this, `package_cache::tests` and
+        // `install::cache::tests` (both in the same lib-test binary)
+        // can race with us on `FERROCV_CACHE_DIR` and produce
+        // intermittent failures.
+        let _lock = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
         struct Guard(Option<String>);
         impl Drop for Guard {
             fn drop(&mut self) {
-                // SAFETY: tests in this module are not invoked from
-                // multiple threads concurrently with respect to this
-                // env var (the `install` feature gates this whole
-                // block, and the only sibling test that writes
-                // `FERROCV_CACHE_DIR` lives in `package_cache.rs`
-                // and serializes through its own mutex).
+                // SAFETY: caller holds `crate::test_env::ENV_LOCK`
+                // for the lifetime of this guard, so no other
+                // env-var-mutating test runs concurrently.
                 unsafe {
                     match &self.0 {
                         Some(v) => std::env::set_var("FERROCV_CACHE_DIR", v),
@@ -902,7 +925,7 @@ mod tests {
             }
         }
         let _guard = Guard(std::env::var("FERROCV_CACHE_DIR").ok());
-        // SAFETY: same justification as in Drop above.
+        // SAFETY: serialized via `_lock` above.
         unsafe {
             std::env::set_var("FERROCV_CACHE_DIR", tmp.path());
         }
@@ -914,6 +937,39 @@ mod tests {
                 assert_eq!(spec, "@preview/missing-pkg-xyz:0.0.0");
             }
             other => panic!("expected PreviewCacheMiss, got {other:?}"),
+        }
+    }
+
+    /// Malformed `@preview/...` specs surface `PreviewSpecInvalid`,
+    /// not `PreviewCacheMiss`. The earlier variant produced a circular
+    /// "Run: ferrocv themes install <bad spec>" hint that would just
+    /// hit the same parse failure; this test guards against that
+    /// regression.
+    #[cfg(feature = "install")]
+    #[test]
+    fn resolve_theme_malformed_preview_spec_returns_preview_spec_invalid() {
+        // `@preview/foo` with no version separator is the canonical
+        // shape `parse_spec` rejects.
+        let err = resolve_theme("@preview/foo").expect_err("malformed spec must error");
+        match err {
+            ThemeResolveError::PreviewSpecInvalid { spec, reason } => {
+                assert_eq!(spec, "@preview/foo");
+                assert!(
+                    !reason.is_empty(),
+                    "PreviewSpecInvalid reason must be non-empty"
+                );
+                let rendered =
+                    format!("{}", ThemeResolveError::PreviewSpecInvalid { spec, reason });
+                assert!(
+                    rendered.contains("Expected '@preview/<name>:<version>'"),
+                    "user-facing message must point at correct syntax; got: {rendered}"
+                );
+                assert!(
+                    !rendered.to_lowercase().contains("themes install"),
+                    "must not produce a circular 'themes install' hint; got: {rendered}"
+                );
+            }
+            other => panic!("expected PreviewSpecInvalid, got {other:?}"),
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -60,10 +60,21 @@
 //!   issue. No sibling imports, no package resolver — the file runs
 //!   under exactly the same Typst sandbox bundled themes do.
 //!
-//! `@preview/...` specs are recognized but deferred: in Stage A they
-//! return [`ThemeResolveError::PackageSpecDeferredToStageC`] so
-//! Stage B's installer and Stage C's cache reader land behind a clear
-//! contract.
+//! `@preview/<name>:<version>` specs route through the offline
+//! installer cache populated by `ferrocv themes install` (Stage B).
+//! Cache hits resolve to [`ResolvedTheme::Owned`] and feed straight
+//! into the same compile pipeline bundled themes use; cache misses
+//! return [`ThemeResolveError::PreviewCacheMiss`] so the CLI can
+//! point the user at `ferrocv themes install` rather than calling the
+//! network-capable installer transitively. Render and validate stay
+//! fully offline (CONSTITUTION §6.1, post-Stage-B amendment).
+//!
+//! When the binary is built without the `install` Cargo feature the
+//! Universe-resolution path errors out with
+//! [`ThemeResolveError::PreviewSpecRequiresInstallFeature`] — the
+//! cache reader and the manifest parser both live behind that feature
+//! flag, so a default build cannot resolve `@preview/...` specs even
+//! against a populated cache.
 
 /// A themed Typst source bundle that [`crate::render::compile_theme`]
 /// can compile against a JSON Resume document.
@@ -479,11 +490,41 @@ pub enum ThemeResolveError {
         /// The path the user typed, as given.
         path: std::path::PathBuf,
     },
-    /// The user supplied an `@preview/<name>:<version>` spec. Stage A
-    /// of issue #41 recognizes these but defers resolution to Stage C;
-    /// the CLI prints a message pointing at the follow-up installer
-    /// subcommand that Stage B will land.
-    PackageSpecDeferredToStageC {
+    /// The user supplied an `@preview/<name>:<version>` spec but the
+    /// package was not present in the local installer cache. The CLI
+    /// formats this into a single-line "run `ferrocv themes install
+    /// @preview/...`" hint pointing at Stage B's subcommand. Carries
+    /// the cache path that was inspected so the diagnostic is
+    /// reproducible.
+    PreviewCacheMiss {
+        /// The raw spec the user typed.
+        spec: String,
+        /// Filesystem path the resolver expected to find the package
+        /// at. Showing it lets the user verify e.g. that
+        /// `FERROCV_CACHE_DIR` is set to what they think it is.
+        expected_path: std::path::PathBuf,
+    },
+    /// The cached package directory exists but is malformed —
+    /// missing `typst.toml`, broken manifest, manifest declares a
+    /// different name/version than the cache layout, or the declared
+    /// entrypoint does not exist on disk. Hint: re-install with
+    /// `ferrocv themes install --refresh` (TODO when that flag
+    /// lands) or delete the cache directory and retry.
+    PreviewCacheCorrupt {
+        /// The raw spec the user typed.
+        spec: String,
+        /// Path to the file or directory that triggered the
+        /// corruption diagnostic.
+        path: std::path::PathBuf,
+        /// Human-readable explanation of what was malformed.
+        reason: String,
+    },
+    /// The user supplied an `@preview/<name>:<version>` spec on a
+    /// build that does not include the `install` Cargo feature, so
+    /// the cache reader is not compiled in. CLI maps this to "rebuild
+    /// with `--features install`, run `ferrocv themes install`, retry
+    /// the render".
+    PreviewSpecRequiresInstallFeature {
         /// The raw spec the user typed.
         spec: String,
     },
@@ -515,11 +556,26 @@ impl std::fmt::Display for ThemeResolveError {
                 "local-path theme {} is not valid UTF-8 (Typst source files must be UTF-8)",
                 path.display()
             ),
-            ThemeResolveError::PackageSpecDeferredToStageC { spec } => write!(
+            ThemeResolveError::PreviewCacheMiss {
+                spec,
+                expected_path,
+            } => write!(
                 f,
-                "{spec} theme resolution arrives in stage C of issue #41; \
-                 for now install via the future `ferrocv theme install` command (stage B) \
-                 or vendor the theme manually under assets/themes/"
+                "theme '{spec}' not found in cache at {}. \
+                 Run: ferrocv themes install {spec}",
+                expected_path.display(),
+            ),
+            ThemeResolveError::PreviewCacheCorrupt { spec, path, reason } => write!(
+                f,
+                "cached theme {spec} is corrupt at {}: {reason}. \
+                 Remove the cache directory and re-run `ferrocv themes install {spec}`.",
+                path.display(),
+            ),
+            ThemeResolveError::PreviewSpecRequiresInstallFeature { spec } => write!(
+                f,
+                "theme '{spec}' requires a build with the `install` Cargo feature. \
+                 Rebuild with `cargo install ferrocv --features install`, \
+                 then run `ferrocv themes install {spec}` before this render."
             ),
         }
     }
@@ -574,11 +630,13 @@ fn classify_spec(spec: &str) -> ThemeSpecKind {
 ///
 /// Detection order (no IO performed until the path branch is taken):
 ///
-/// 1. Specs starting with `@preview/` return
-///    [`ThemeResolveError::PackageSpecDeferredToStageC`]. Stage A
-///    recognizes the shape; Stage B's `ferrocv theme install`
-///    populates the local cache; Stage C wires render-time resolution
-///    against that cache.
+/// 1. Specs starting with `@preview/` resolve through the offline
+///    installer cache (gated behind the `install` Cargo feature):
+///    cache hits return [`ResolvedTheme::Owned`]; cache misses
+///    return [`ThemeResolveError::PreviewCacheMiss`] so the CLI can
+///    point at `ferrocv themes install`. On default builds (no
+///    `install` feature) the spec is rejected with
+///    [`ThemeResolveError::PreviewSpecRequiresInstallFeature`].
 /// 2. Specs carrying path-indicative signals — a leading `.` or `/`,
 ///    any `/` or `\` separator, or a `.typ` suffix — take the
 ///    local-path branch: the CLI reads the bytes at the path,
@@ -596,14 +654,15 @@ fn classify_spec(spec: &str) -> ThemeSpecKind {
 ///
 /// # Offline guarantee
 ///
-/// This function performs no network calls — the `@preview/...` branch
-/// fails fast without touching the filesystem or the network, upholding
-/// CONSTITUTION §6.1. Stage A introduces no network-capable code.
+/// This function performs no network calls. The `@preview/...` branch
+/// reads only from the local installer cache populated by a prior
+/// `ferrocv themes install`; on cache miss it returns a clean error
+/// pointing at the install subcommand and never invokes the
+/// network-capable installer module transitively
+/// (CONSTITUTION §6.1, post-Stage-B amendment).
 pub fn resolve_theme(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
     match classify_spec(spec) {
-        ThemeSpecKind::PreviewPackage => Err(ThemeResolveError::PackageSpecDeferredToStageC {
-            spec: spec.to_owned(),
-        }),
+        ThemeSpecKind::PreviewPackage => resolve_preview_package(spec),
         ThemeSpecKind::LocalPath => resolve_local_path(spec),
         ThemeSpecKind::BundledName => match find_theme(spec) {
             Some(theme) => Ok(ResolvedTheme::Bundled(theme)),
@@ -613,6 +672,43 @@ pub fn resolve_theme(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
             }),
         },
     }
+}
+
+/// Resolve an `@preview/<name>:<version>` spec via the local installer
+/// cache.
+///
+/// Default-features build: returns
+/// [`ThemeResolveError::PreviewSpecRequiresInstallFeature`] without
+/// touching the filesystem — the cache reader is not compiled in.
+///
+/// `install`-feature build: parses the spec via the same parser the
+/// installer uses, then delegates to
+/// [`crate::package_cache::resolve_preview_spec_from_cache`]. That
+/// helper reads only from the cache directory; it never imports
+/// [`crate::install::fetch`] or any other network-capable module, so
+/// render and validate stay fully offline even on cache miss.
+#[cfg(not(feature = "install"))]
+fn resolve_preview_package(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
+    Err(ThemeResolveError::PreviewSpecRequiresInstallFeature {
+        spec: spec.to_owned(),
+    })
+}
+
+#[cfg(feature = "install")]
+fn resolve_preview_package(spec: &str) -> Result<ResolvedTheme, ThemeResolveError> {
+    // Parsing failures surface as PreviewCacheMiss with a synthetic
+    // path so the CLI mapping stays simple and the user sees a
+    // useful hint. Anything past `parse_spec` is a real cache lookup.
+    let parsed = match crate::install::spec::parse_spec(spec) {
+        Ok(p) => p,
+        Err(err) => {
+            return Err(ThemeResolveError::PreviewCacheMiss {
+                spec: spec.to_owned(),
+                expected_path: std::path::PathBuf::from(format!("<invalid spec: {err}>")),
+            });
+        }
+    };
+    crate::package_cache::resolve_preview_spec_from_cache(&parsed).map(ResolvedTheme::Owned)
 }
 
 /// Read a local-path `.typ` file into an [`OwnedTheme`].
@@ -759,15 +855,65 @@ mod tests {
         }
     }
 
+    /// On the default build (no `install` feature) `@preview/...`
+    /// specs are rejected with a clear "rebuild with --features
+    /// install" hint — the cache reader is not in the binary.
+    #[cfg(not(feature = "install"))]
     #[test]
-    fn resolve_theme_preview_spec_defers_to_stage_c() {
+    fn resolve_theme_preview_spec_requires_install_feature() {
         let err = resolve_theme("@preview/basic-resume:0.2.8")
-            .expect_err("preview specs must error in stage A");
+            .expect_err("preview specs need the install feature on default builds");
         match err {
-            ThemeResolveError::PackageSpecDeferredToStageC { spec } => {
+            ThemeResolveError::PreviewSpecRequiresInstallFeature { spec } => {
                 assert_eq!(spec, "@preview/basic-resume:0.2.8");
             }
-            other => panic!("expected PackageSpecDeferredToStageC, got {other:?}"),
+            other => panic!("expected PreviewSpecRequiresInstallFeature, got {other:?}"),
+        }
+    }
+
+    /// With the `install` feature on, `@preview/...` specs hit the
+    /// cache reader. The cache is empty in this unit test (no fixture
+    /// populated), so we expect a `PreviewCacheMiss` carrying the spec.
+    #[cfg(feature = "install")]
+    #[test]
+    fn resolve_theme_preview_spec_cache_miss_under_install_feature() {
+        // Point FERROCV_CACHE_DIR at an empty tempdir so the resolver
+        // sees a guaranteed cache miss regardless of the developer's
+        // real $HOME cache state. Use a unique tempdir per test so
+        // parallel runs don't share state.
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // SAFETY: this is a single-threaded unit test entry point;
+        // the env var is restored on Drop via the local guard below.
+        struct Guard(Option<String>);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                // SAFETY: tests in this module are not invoked from
+                // multiple threads concurrently with respect to this
+                // env var (the `install` feature gates this whole
+                // block, and the only sibling test that writes
+                // `FERROCV_CACHE_DIR` lives in `package_cache.rs`
+                // and serializes through its own mutex).
+                unsafe {
+                    match &self.0 {
+                        Some(v) => std::env::set_var("FERROCV_CACHE_DIR", v),
+                        None => std::env::remove_var("FERROCV_CACHE_DIR"),
+                    }
+                }
+            }
+        }
+        let _guard = Guard(std::env::var("FERROCV_CACHE_DIR").ok());
+        // SAFETY: same justification as in Drop above.
+        unsafe {
+            std::env::set_var("FERROCV_CACHE_DIR", tmp.path());
+        }
+
+        let err =
+            resolve_theme("@preview/missing-pkg-xyz:0.0.0").expect_err("empty cache must miss");
+        match err {
+            ThemeResolveError::PreviewCacheMiss { spec, .. } => {
+                assert_eq!(spec, "@preview/missing-pkg-xyz:0.0.0");
+            }
+            other => panic!("expected PreviewCacheMiss, got {other:?}"),
         }
     }
 

--- a/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/README.md
+++ b/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/README.md
@@ -1,0 +1,12 @@
+# Stage C malicious-import regression fixture
+
+This fixture mimics a cached `@preview/...` package whose source
+includes a forbidden `#import "@preview/cetz:0.2.0": *"` statement.
+Stage C resolves `@preview/...` specs *outside* the Typst World by
+materializing the cache contents into an `OwnedTheme`, but the World's
+own `source()` / `file()` methods still hard-reject `@preview/...`
+imports inline (CONSTITUTION §6.1). This fixture is the negative-test
+asset that proves the inline-rejection guarantee survived Stage C.
+
+The fixture is hand-authored under ferrocv's MIT-or-Apache-2.0 license;
+nothing in here is vendored from the Typst Universe.

--- a/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/src/lib.typ
+++ b/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/src/lib.typ
@@ -1,0 +1,12 @@
+// Stage C regression fixture: this entrypoint deliberately tries to
+// import another `@preview/...` package. Even though the SURROUNDING
+// theme was resolved out of the offline cache, the inline import must
+// still be rejected at compile time by `FerrocvWorld::source` /
+// `file` (CONSTITUTION §6.1). The scenario test in
+// `tests/render_preview_cli.rs` asserts the rejection.
+
+#import "@preview/cetz:0.2.0": *
+
+#let r = json("/resume.json")
+
+= #r.at("basics", default: (:)).at("name", default: "")

--- a/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/typst.toml
+++ b/tests/fixtures/cached-preview-malicious/imports-another-package/1.0.0/typst.toml
@@ -1,0 +1,9 @@
+# Test fixture, NOT a vendored upstream package. See README.md
+# in this directory for the rationale.
+[package]
+name = "imports-another-package"
+version = "1.0.0"
+entrypoint = "src/lib.typ"
+authors = ["ferrocv test fixtures"]
+license = "MIT OR Apache-2.0"
+description = "Stage C regression fixture: cached source containing a forbidden @preview/... import."

--- a/tests/fixtures/cached-preview/basic-resume/0.2.8/README.md
+++ b/tests/fixtures/cached-preview/basic-resume/0.2.8/README.md
@@ -1,0 +1,26 @@
+# Stage C cache-hit fixture (not vendored upstream)
+
+This directory mimics the on-disk shape that
+`ferrocv themes install @preview/basic-resume:0.2.8` would write into
+the cache. It is **not** a copy of the upstream `basic-resume` Typst
+Universe package — it is a hand-authored test asset under the
+`ferrocv` MIT-or-Apache-2.0 license.
+
+The fixture exists because the real upstream `basic-resume` package
+imports `@preview/scienceicons` at compile time. `FerrocvWorld` rejects
+every `@preview/...` import per CONSTITUTION §6.1, so the upstream
+package would fail to compile under our offline World even after a
+successful cache hit. This fixture deliberately has zero `@preview/...`
+imports so the cache-hit scenario test can assert on a clean PDF
+output.
+
+The directory layout (`typst.toml`, `src/lib.typ`, `src/helpers.typ`)
+mirrors the multi-file shape Stage C's resolver
+(`src/package_cache.rs::resolve_preview_spec_from_cache`) walks: the
+test exercises both the entrypoint registration and a sibling-file
+import.
+
+See also the malicious-import fixture under
+`tests/fixtures/cached-preview-malicious/` — that one DOES carry a
+`@preview/...` import and is used to regression-test the World-layer
+rejection on theme source.

--- a/tests/fixtures/cached-preview/basic-resume/0.2.8/src/helpers.typ
+++ b/tests/fixtures/cached-preview/basic-resume/0.2.8/src/helpers.typ
@@ -1,0 +1,17 @@
+// Sibling helper imported by `lib.typ`. Exists so the cached-package
+// resolver collects more than one `.typ` file and so the relative
+// `#import "./helpers.typ"` path resolves through the World's virtual
+// filesystem under `/themes/preview/basic-resume/0.2.8/src/`.
+
+#let resume-name(resume) = {
+  let basics = resume.at("basics", default: (:))
+  basics.at("name", default: "")
+}
+
+#let resume-summary(resume) = {
+  let basics = resume.at("basics", default: (:))
+  let summary = basics.at("summary", default: "")
+  if summary != "" {
+    [#summary]
+  }
+}

--- a/tests/fixtures/cached-preview/basic-resume/0.2.8/src/lib.typ
+++ b/tests/fixtures/cached-preview/basic-resume/0.2.8/src/lib.typ
@@ -1,0 +1,13 @@
+// Test fixture entrypoint for Stage C cache-hit scenarios. Reads the
+// JSON Resume document via the World's `/resume.json` slot and emits
+// `basics.name` plus `basics.summary` so the scenario test can assert
+// the round-tripped name appears in extracted text. Imports a sibling
+// file so the multi-file collection path in `package_cache.rs` is
+// exercised end-to-end (not just a single entrypoint file).
+#import "./helpers.typ": resume-name, resume-summary
+
+#let r = json("/resume.json")
+
+= #resume-name(r)
+
+#resume-summary(r)

--- a/tests/fixtures/cached-preview/basic-resume/0.2.8/typst.toml
+++ b/tests/fixtures/cached-preview/basic-resume/0.2.8/typst.toml
@@ -1,4 +1,4 @@
-# Test fixture, NOT a vendored upstream package. See VENDORING.md
+# Test fixture, NOT a vendored upstream package. See README.md
 # in this directory for the rationale.
 [package]
 name = "basic-resume"

--- a/tests/fixtures/cached-preview/basic-resume/0.2.8/typst.toml
+++ b/tests/fixtures/cached-preview/basic-resume/0.2.8/typst.toml
@@ -1,0 +1,9 @@
+# Test fixture, NOT a vendored upstream package. See VENDORING.md
+# in this directory for the rationale.
+[package]
+name = "basic-resume"
+version = "0.2.8"
+entrypoint = "src/lib.typ"
+authors = ["ferrocv test fixtures"]
+license = "MIT OR Apache-2.0"
+description = "Stage C cache-hit fixture; not the upstream basic-resume package."

--- a/tests/offline_guard.rs
+++ b/tests/offline_guard.rs
@@ -1,0 +1,235 @@
+//! Stage C offline-guard: prove that the render and validate call
+//! graphs do not import the network-capable installer modules even
+//! with the `install` Cargo feature ON.
+//!
+//! Stage B already enforced the feature-flag boundary
+//! (`tests/install_boundary.rs`): when the `install` feature is OFF,
+//! `src/install/*` does not compile and `ureq`/`tar`/`dirs` are not
+//! in the dependency graph. That is necessary but not sufficient for
+//! Stage C — once the feature is ON, nothing at the type system level
+//! prevents `src/render.rs` or `src/cli.rs::run_render` from calling
+//! into `src/install/fetch.rs` and triggering an HTTPS GET at render
+//! time. CONSTITUTION §6.1 (post-Stage-B amendment) carves out
+//! `ferrocv themes install` as the SINGLE network-permitted entry
+//! point; render and validate stay offline regardless of feature
+//! flags.
+//!
+//! This file enforces the property statically: it scans the source
+//! text of the files reachable from `compile_*` / `validate_value`
+//! and the `Render` / `Validate` CLI handlers and asserts that none
+//! of them carry a `use crate::install::{fetch, extract, pipeline}`
+//! import or call. The cache reader (`src/package_cache.rs`) and the
+//! cache-path / manifest helpers (`src/install/cache.rs`,
+//! `src/install/manifest.rs`, `src/install/spec.rs`) are pure
+//! filesystem / parsing modules and ARE reachable from the render
+//! path; they are explicitly allow-listed below.
+//!
+//! # Why a string-grep static check rather than a type-system test
+//!
+//! A compile-time `static_assertions` approach would require defining
+//! traits on the installer modules that name-collide with non-network
+//! ones. That is a lot of scaffolding for a property that, in this
+//! crate, is fundamentally a "which modules import which" question —
+//! a question source-text scanning answers directly. The check runs
+//! once per `cargo test` invocation; cost is negligible.
+//!
+//! If a future refactor splits the cache reader out from
+//! `src/install/`, update [`ALLOWED_INSTALL_SUBMODULES`] below to
+//! reflect the new module layout. The test will fail loudly until
+//! the allow-list matches reality.
+
+use std::path::{Path, PathBuf};
+
+/// Files reachable from the `render` and `validate` call graphs that
+/// MUST NOT import network-capable installer submodules.
+///
+/// `src/cli.rs` is on the list because `run_render` and `run_validate`
+/// live there. The `run_themes_install` handler in the same file is
+/// allowed to reference the installer (it IS the installer entry
+/// point); the per-line filter below tolerates `use crate::install::`
+/// inside `#[cfg(feature = "install")]` blocks, but the network-
+/// capable submodules (`fetch`, `extract`, `pipeline`) must never
+/// appear outside `run_themes_install`.
+const RENDER_PATH_FILES: &[&str] = &[
+    "src/render.rs",
+    "src/validate.rs",
+    "src/theme.rs",
+    "src/package_cache.rs",
+    "src/lib.rs",
+    "src/main.rs",
+];
+
+/// Installer submodules that perform pure filesystem / parsing work
+/// (no `ureq`, no `flate2`, no `tar`) and are therefore safe to be
+/// reachable from the render path.
+///
+/// If any of these grow a network call, move them out of the
+/// allow-list and the offline-guard regression test will catch it.
+const ALLOWED_INSTALL_SUBMODULES: &[&str] = &[
+    "crate::install::cache",
+    "crate::install::manifest",
+    "crate::install::spec",
+    // Bare `crate::install` (e.g. `crate::install::InstallError`)
+    // resolves to types defined in `src/install/mod.rs` — those
+    // types carry no behavior, just enum variants and Display
+    // impls. Allow.
+    "crate::install::InstallError",
+    "crate::install::PackageSpec",
+];
+
+/// Network-capable installer submodules that must never appear in
+/// the render path.
+const FORBIDDEN_INSTALL_SUBMODULES: &[&str] = &[
+    "crate::install::fetch",
+    "crate::install::extract",
+    "crate::install::pipeline",
+];
+
+#[test]
+fn render_path_does_not_import_network_capable_install_modules() {
+    let root = repo_root();
+    let mut violations: Vec<String> = Vec::new();
+
+    for relative in RENDER_PATH_FILES {
+        let path = root.join(relative);
+        let src = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for (line_no, line) in src.lines().enumerate() {
+            // Skip comments — `//` lines that mention forbidden modules
+            // are documentation, not imports.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+            for forbidden in FORBIDDEN_INSTALL_SUBMODULES {
+                if line.contains(forbidden) {
+                    violations.push(format!(
+                        "{}:{}: forbidden installer module reference: {}",
+                        relative,
+                        line_no + 1,
+                        forbidden,
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "render path imports forbidden network-capable installer modules:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+/// Sentinel: assert the cache-miss user-facing error message points
+/// at `ferrocv themes install`, not at any other escape hatch. If a
+/// future refactor changes the error wording, this test fails so the
+/// CONSTITUTION §6.1 contract ("uncached package -> error points at
+/// install, no silent fetch") stays explicit in code.
+#[test]
+fn cache_miss_error_message_directs_user_to_themes_install() {
+    let theme_rs =
+        std::fs::read_to_string(repo_root().join("src/theme.rs")).expect("read theme.rs");
+    assert!(
+        theme_rs.contains("Run: ferrocv themes install"),
+        "theme.rs must surface the `ferrocv themes install` hint verbatim",
+    );
+    assert!(
+        theme_rs.contains("PreviewCacheMiss"),
+        "theme.rs must define the PreviewCacheMiss error variant",
+    );
+}
+
+/// Sentinel: `src/cli.rs::run_render` does not call into
+/// `crate::install::pipeline::install` even under `#[cfg(feature =
+/// "install")]`. A different test asserts the same property for the
+/// other render-path files; this one anchors it on `cli.rs` because
+/// `cli.rs` is the only file that legitimately CALLS the installer
+/// (from `run_themes_install`) — the regression to guard against is
+/// `run_render` accidentally calling `install()` on cache miss.
+#[test]
+fn run_render_does_not_call_install_pipeline() {
+    let cli_rs = std::fs::read_to_string(repo_root().join("src/cli.rs")).expect("read cli.rs");
+    let render_block = extract_fn_body(&cli_rs, "fn run_render(");
+    assert!(
+        !render_block.contains("install::pipeline"),
+        "run_render must not reference install::pipeline; got body:\n{render_block}"
+    );
+    assert!(
+        !render_block.contains("install::fetch"),
+        "run_render must not reference install::fetch; got body:\n{render_block}"
+    );
+    assert!(
+        !render_block.contains("install::extract"),
+        "run_render must not reference install::extract; got body:\n{render_block}"
+    );
+}
+
+/// Sentinel that the `ALLOWED_INSTALL_SUBMODULES` list is non-empty
+/// and well-formed — catches a refactor that accidentally empties
+/// the allow-list and trivially passes the main grep test.
+#[test]
+fn allow_list_is_non_empty_and_disjoint_from_forbid_list() {
+    assert!(!ALLOWED_INSTALL_SUBMODULES.is_empty());
+    for allowed in ALLOWED_INSTALL_SUBMODULES {
+        for forbidden in FORBIDDEN_INSTALL_SUBMODULES {
+            assert!(
+                allowed != forbidden,
+                "submodule cannot be both allowed and forbidden: {allowed}",
+            );
+        }
+    }
+}
+
+/// Locate the workspace root. `CARGO_MANIFEST_DIR` is set by Cargo
+/// when running the integration test; it points at the package root.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Heuristically extract the body of a top-level `fn` block from
+/// Rust source. Returns the substring from the function signature
+/// through the matching closing brace (inclusive). Brace-counting is
+/// rudimentary — it tracks `{` / `}` ignoring string and char
+/// literals' interior braces for the simple cases — but it is good
+/// enough for the small set of functions we run it against. Yields
+/// `""` if the function is not found.
+fn extract_fn_body(src: &str, signature_prefix: &str) -> String {
+    let Some(start) = src.find(signature_prefix) else {
+        return String::new();
+    };
+    let after = &src[start..];
+    let Some(brace_idx) = after.find('{') else {
+        return String::new();
+    };
+    let mut depth = 0i32;
+    let bytes = after.as_bytes();
+    let mut end = bytes.len();
+    for (i, b) in bytes.iter().enumerate().skip(brace_idx) {
+        match *b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    after[..end].to_owned()
+}
+
+/// Just to ensure the `Path` import is exercised even on the
+/// minimal-features build. `repo_root()` always returns an existing
+/// directory; reading it confirms the test harness is wired right.
+#[test]
+fn repo_root_exists() {
+    let root: &Path = &repo_root();
+    assert!(root.is_dir(), "CARGO_MANIFEST_DIR must be a directory");
+    assert!(
+        root.join("Cargo.toml").is_file(),
+        "CARGO_MANIFEST_DIR must contain Cargo.toml",
+    );
+}

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -875,15 +875,28 @@ fn render_with_non_utf8_local_path_exits_two() {
     );
 }
 
-/// `@preview/<name>:<version>` specs are recognized but deferred to
-/// stage C of issue #41. The error mentions the spec and points at
-/// the stage B `ferrocv theme install` follow-up.
+/// `@preview/<name>:<version>` specs are recognized and route through
+/// the offline installer cache. With no cache populated (we point
+/// `FERROCV_CACHE_DIR` at an empty tempdir so we never accidentally
+/// hit the real `$HOME/Library/Caches/ferrocv` from a prior install),
+/// the render exits 2 with a message that names the spec and points
+/// at `ferrocv themes install`.
+///
+/// This test runs under both feature sets: with `install` ON the
+/// resolver hits the cache reader and reports a `PreviewCacheMiss`;
+/// with `install` OFF the resolver shortcircuits with a
+/// `PreviewSpecRequiresInstallFeature` error. Both paths must mention
+/// the spec and `ferrocv themes install` so the user always knows
+/// what to do next.
 #[test]
-fn render_with_preview_spec_exits_two_stage_c_hint() {
+fn render_with_preview_spec_exits_two_with_install_hint() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let out = tmp.path().join("out.pdf");
+    // Empty cache dir guarantees a miss regardless of $HOME state.
+    let empty_cache = tempfile::tempdir().expect("empty cache tempdir");
 
     ferrocv()
+        .env("FERROCV_CACHE_DIR", empty_cache.path())
         .arg("render")
         .arg(fixture("render_full"))
         .arg("--theme")
@@ -895,10 +908,10 @@ fn render_with_preview_spec_exits_two_stage_c_hint() {
         .assert()
         .code(2)
         .stderr(predicate::str::contains("@preview/basic-resume:0.2.8"))
-        .stderr(predicate::str::contains("stage C").or(predicate::str::contains("theme install")));
+        .stderr(predicate::str::contains("ferrocv themes install"));
 
     assert!(
         !out.exists(),
-        "no output file should be written on deferred preview spec"
+        "no output file should be written on uncached preview spec"
     );
 }

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -41,10 +41,13 @@ fn ferrocv() -> Command {
 }
 
 /// Recursively copy `src` into `dst`, creating `dst` if it does not
-/// exist. Symlinks are followed and rematerialized as plain files in
-/// the destination — fixture trees do not contain symlinks, but if a
+/// exist. Plain files and directories are copied; anything else
+/// (symlinks, devices, FIFOs) trips the explicit `else` arm and
+/// panics. Fixture trees do not contain such entries today, but if a
 /// regression introduces one we want the test to fail loudly rather
-/// than silently exclude it.
+/// than silently exclude it (the `is_dir`/`is_file` checks both return
+/// `false` for symlinks, so without the explicit panic arm a symlinked
+/// file would be silently dropped from the staged cache).
 fn copy_dir_recursive(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).expect("mkdir destination");
     for entry in std::fs::read_dir(src).expect("read_dir") {
@@ -56,6 +59,12 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
             copy_dir_recursive(&from, &to);
         } else if ft.is_file() {
             std::fs::copy(&from, &to).expect("copy file");
+        } else {
+            panic!(
+                "unexpected non-file/non-dir entry in fixture: {} (file_type: {:?})",
+                from.display(),
+                ft,
+            );
         }
     }
 }

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -1,0 +1,285 @@
+//! Scenario-style black-box tests for `ferrocv render --theme @preview/...`.
+//!
+//! Entire file is gated behind `#[cfg(feature = "install")]` because
+//! the cache reader (`src/package_cache.rs`) and the cache-path
+//! helpers (`src/install/cache.rs`) live behind that feature flag.
+//! The default-features path (where `--theme @preview/...` errors with
+//! a "rebuild with --features install" hint) is covered in
+//! `tests/render_cli.rs::render_with_preview_spec_*`.
+//!
+//! Coverage:
+//! - Cache hit: a pre-extracted fixture under
+//!   `tests/fixtures/cached-preview/basic-resume/0.2.8/` is staged into
+//!   a tempdir-backed cache, then `ferrocv render --theme @preview/basic-resume:0.2.8`
+//!   compiles the package against the standard test resume.
+//! - Cache miss: with an empty tempdir as the cache, the same render
+//!   exits 2 with a stderr message pointing at `ferrocv themes install`.
+//! - Inline-import regression: a cached package whose Typst source
+//!   does `#import "@preview/cetz:0.2.0": *"` still fails to compile,
+//!   proving CONSTITUTION §6.1 inline-import rejection survives
+//!   Stage C's pre-`World` resolver.
+
+#![cfg(feature = "install")]
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Absolute path to a JSON fixture under `tests/fixtures/`.
+fn fixture(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(format!("{name}.json"));
+    path
+}
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built with --features install")
+}
+
+/// Recursively copy `src` into `dst`, creating `dst` if it does not
+/// exist. Symlinks are followed and rematerialized as plain files in
+/// the destination — fixture trees do not contain symlinks, but if a
+/// regression introduces one we want the test to fail loudly rather
+/// than silently exclude it.
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).expect("mkdir destination");
+    for entry in std::fs::read_dir(src).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let ft = entry.file_type().expect("file type");
+        if ft.is_dir() {
+            copy_dir_recursive(&from, &to);
+        } else if ft.is_file() {
+            std::fs::copy(&from, &to).expect("copy file");
+        }
+    }
+}
+
+/// Lay a fixture cached package under `<cache_root>/packages/preview/<name>/<version>/`.
+fn stage_cached_package(cache_root: &Path, fixture_root: &Path, name: &str, version: &str) {
+    let dest = cache_root
+        .join("packages")
+        .join("preview")
+        .join(name)
+        .join(version);
+    copy_dir_recursive(fixture_root, &dest);
+}
+
+/// Path to the in-tree `cached-preview/<name>/<version>/` fixture
+/// directory that mirrors what Stage B's installer would have written.
+fn cached_preview_fixture(name: &str, version: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push("cached-preview");
+    path.push(name);
+    path.push(version);
+    path
+}
+
+/// Path to the in-tree malicious-import fixture used by the §6.1
+/// inline-import regression.
+fn malicious_preview_fixture(name: &str, version: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push("cached-preview-malicious");
+    path.push(name);
+    path.push(version);
+    path
+}
+
+/// Cache hit: the pre-staged fixture is found, parsed, and compiled
+/// against the standard `render_full.json` resume. The `--format text`
+/// path is deterministic, so we extract text and assert the resume
+/// name round-tripped through Typst — proves the cached package's
+/// `lib.typ` ran and read `/resume.json` correctly.
+#[test]
+fn render_resolves_preview_from_cache() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache");
+    stage_cached_package(
+        cache.path(),
+        &cached_preview_fixture("basic-resume", "0.2.8"),
+        "basic-resume",
+        "0.2.8",
+    );
+    let out = cache.path().join("out.txt");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/basic-resume:0.2.8")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(
+        body.contains("Ada Lovelace"),
+        "cached-preview text output must contain the rendered resume name; got: {body:?}"
+    );
+}
+
+/// Cache hit, PDF dispatch path: the same fixture under `--format pdf`
+/// produces a valid PDF stream. Pairs with the text-format test above
+/// so both compile-target dispatch paths are exercised.
+#[test]
+fn render_resolves_preview_from_cache_pdf() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache");
+    stage_cached_package(
+        cache.path(),
+        &cached_preview_fixture("basic-resume", "0.2.8"),
+        "basic-resume",
+        "0.2.8",
+    );
+    let out = cache.path().join("out.pdf");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/basic-resume:0.2.8")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let head = std::fs::read(&out)
+        .expect("read PDF")
+        .into_iter()
+        .take(5)
+        .collect::<Vec<_>>();
+    assert_eq!(head, b"%PDF-", "output must start with the PDF magic bytes");
+}
+
+/// Cache miss: empty cache directory, render exits 2 with a stderr
+/// message that contains both the spec and the install hint.
+#[test]
+fn render_preview_cache_miss_exits_two_with_install_hint() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache (intentionally empty)");
+    let out = cache.path().join("out.pdf");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/missing-preview-package:9.9.9")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "@preview/missing-preview-package:9.9.9",
+        ))
+        .stderr(predicate::str::contains("ferrocv themes install"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on cache miss"
+    );
+}
+
+/// CONSTITUTION §6.1 inline-import regression: even with the
+/// surrounding theme resolved from the offline cache, an inline
+/// `#import "@preview/..."` inside that theme's source still triggers
+/// `FerrocvWorld::source` / `file` package rejection. The render
+/// fails to compile (exit 2) with a diagnostic that mentions the
+/// rejected package or "package" / "not found".
+#[test]
+fn preview_import_in_cached_theme_source_still_rejected() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache");
+    stage_cached_package(
+        cache.path(),
+        &malicious_preview_fixture("imports-another-package", "1.0.0"),
+        "imports-another-package",
+        "1.0.0",
+    );
+    let out = cache.path().join("out.pdf");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/imports-another-package:1.0.0")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(
+            predicate::str::contains("preview")
+                .or(predicate::str::contains("cetz"))
+                .or(predicate::str::contains("package"))
+                .or(predicate::str::contains("not found")),
+        );
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on inline-import rejection"
+    );
+}
+
+/// Sanity: a corrupt cache (manifest declares a different name than
+/// the directory it lives in) is rejected with exit 2 and a clear
+/// "remove the cache directory" hint. Catches a future bug where the
+/// resolver would silently use the manifest's name instead of the
+/// requested spec.
+#[test]
+fn render_preview_cache_corrupt_exits_two() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache");
+    let pkg = cache
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("asked-for")
+        .join("1.0.0");
+    std::fs::create_dir_all(pkg.join("src")).expect("mkdir staging");
+    std::fs::write(
+        pkg.join("typst.toml"),
+        "[package]\nname = \"different-name\"\nversion = \"1.0.0\"\nentrypoint = \"src/lib.typ\"\n",
+    )
+    .expect("write manifest");
+    std::fs::write(pkg.join("src/lib.typ"), "= Corrupt fixture\n").expect("write entrypoint");
+
+    let out = cache.path().join("out.pdf");
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/asked-for:1.0.0")
+        .arg("--format")
+        .arg("pdf")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("corrupt"));
+
+    assert!(
+        !out.exists(),
+        "no output file should be written on cache corruption"
+    );
+}

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -212,8 +212,8 @@ fn render_preview_cache_miss_exits_two_with_install_hint() {
 /// surrounding theme resolved from the offline cache, an inline
 /// `#import "@preview/..."` inside that theme's source still triggers
 /// `FerrocvWorld::source` / `file` package rejection. The render
-/// fails to compile (exit 2) with a diagnostic that mentions the
-/// rejected package or "package" / "not found".
+/// fails to compile (exit 2) with a diagnostic that names the
+/// rejected package and signals a package-resolution failure.
 #[test]
 fn preview_import_in_cached_theme_source_still_rejected() {
     let cache = tempfile::TempDir::new().expect("tempdir cache");
@@ -225,6 +225,16 @@ fn preview_import_in_cached_theme_source_still_rejected() {
     );
     let out = cache.path().join("out.pdf");
 
+    // The fixture's `src/lib.typ` does `#import "@preview/cetz:0.2.0":
+    // *"`. The diagnostic from `FerrocvWorld`'s package rejection
+    // path must (a) name `cetz` (the rejected import — deterministic
+    // per the fixture) AND (b) carry a package-resolution signal
+    // ("package" or "not found"). The conjunction is strictly
+    // narrower than the previous OR-over-loose-phrases predicate,
+    // which any compile error could satisfy — a regression that
+    // broke World-layer rejection but still failed for some other
+    // reason (Typst syntax error in the fixture, unrelated panic)
+    // would have passed silently.
     ferrocv()
         .env("FERROCV_CACHE_DIR", cache.path())
         .arg("render")
@@ -237,12 +247,8 @@ fn preview_import_in_cached_theme_source_still_rejected() {
         .arg(&out)
         .assert()
         .code(2)
-        .stderr(
-            predicate::str::contains("preview")
-                .or(predicate::str::contains("cetz"))
-                .or(predicate::str::contains("package"))
-                .or(predicate::str::contains("not found")),
-        );
+        .stderr(predicate::str::contains("cetz"))
+        .stderr(predicate::str::contains("package").or(predicate::str::contains("not found")));
 
     assert!(
         !out.exists(),


### PR DESCRIPTION
## Summary

This is **Stage C of 3** for issue #41 ("Theme resolution: local path, bundled name, Typst Universe package"). The three stages:

- **Stage A** (PR #78): `ResolvedTheme` foundation + local-path (`--theme ./path/to/theme`) resolution.
- **Stage B** (PR #91): `ferrocv themes install @preview/<name>:<version>` subcommand, XDG-compliant cache layout, CONSTITUTION §6.1 amendment documenting the user-initiated install pattern.
- **Stage C** (this PR): wires the Stage B cache into the render path; `--theme @preview/<name>:<version>` now resolves offline from the populated cache. Closes #41.

## What is in scope

- `src/package_cache.rs` — new module (gated behind the `install` Cargo feature). `resolve_preview_spec_from_cache(&PackageSpec) -> Result<OwnedTheme, ThemeResolveError>` walks the cached package directory, validates the manifest, and materialises the theme into an `OwnedTheme` keyed under `/themes/preview/<name>/<version>/...`. No network calls; reads only what `ferrocv themes install` placed on disk.
- Three new `ThemeResolveError` variants: `PreviewCacheMiss { spec, expected_path }`, `PreviewCacheCorrupt { spec, path, reason }`, `PreviewSpecRequiresInstallFeature { spec }`. `PackageSpecDeferredToStageC` (placeholder added in Stage A) is removed.
- `tests/render_preview_cli.rs` — 5 scenario tests (cache hit text render, cache hit PDF render, cache miss exit-2 with install hint, inline-import rejection regression, cache-corruption error).
- `tests/offline_guard.rs` — 4 source-text sentinel tests asserting `crate::install::{fetch,extract,pipeline}` never appear in any render-path source file, even with `--features install` enabled.
- `README.md` — `--theme` resolution-modes subsection: bundled name, local path, `@preview/` cache-resolved (with cache-miss hint wording).

## Architectural boundary preserved

`FerrocvWorld`'s `PackageSpec` rejection in `source()` / `file()` is byte-for-byte unchanged. Stage C resolves `@preview/...` *outside* the World by pre-materialising cached files into an `OwnedTheme` before compilation begins. The two pre-existing offline-guard tests (`tests/render.rs::preview_package_import_is_rejected_no_network` and `..._in_html_compilation`) pass unchanged. A new inline-import regression test exercises a malicious cached fixture containing `#import "@preview/cetz:0.2.0": *` and asserts the World-layer rejection still triggers even when the outer theme is cache-resolved.

## Cache-miss UX

Cache misses exit 2 with a message of the form:

```
error: theme '@preview/<name>:<version>' not found in cache at <path>
Run: ferrocv themes install @preview/<name>:<version>
```

pointing directly at Stage B's `themes install` subcommand.

## Test summary

12 new tests across the PR:
- 3 unit tests in `src/package_cache.rs`
- 1 unit test in `src/theme.rs` (per-feature-gate path coverage)
- 5 scenario tests in `tests/render_preview_cli.rs`
- 4 offline-guard sentinels in `tests/offline_guard.rs`

Pre-existing `render_with_preview_spec_*` test in `tests/render_cli.rs` renamed and updated to assert the new install-hint wording (still runs on default features).

## Net Cargo.toml change: zero

No new deps. `toml` and `dirs` were already added by Stage B under the `install` feature; Stage C reads through the same gate.

## Reviewer attention: two items

1. **`ThemeResolveError` enum widening** — `PackageSpecDeferredToStageC` (placeholder from Stage A) is removed; three new variants (`PreviewCacheMiss`, `PreviewCacheCorrupt`, `PreviewSpecRequiresInstallFeature`) replace it. This is a public API change. Pre-1.0, no external users.

2. **Hand-authored fixture provenance** — `tests/fixtures/cached-preview/basic-resume/0.2.8/` is NOT a copy of the upstream `@preview/basic-resume` Universe package. The upstream package imports `@preview/scienceicons`, which `FerrocvWorld` rejects — it cannot serve as a cache-hit fixture in our offline sandbox. The fixture is hand-authored specifically for this test, ships under ferrocv MIT-or-Apache-2.0, and is documented in `tests/fixtures/cached-preview/basic-resume/0.2.8/README.md`. Similarly, `tests/fixtures/cached-preview-malicious/` is a purpose-built regression fixture, not vendored content.

## Closes

Closes #41

---

All three resolution modes are live on main after merge: bundled-name, local-path (`--theme ./file.typ`), and `@preview/<name>:<version>` from the offline cache populated by `ferrocv themes install`.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline theme resolution from the local preview package cache with explicit handling for cache hits, cache misses (exit code 2), and corrupt cached packages; actionable CLI hints guide next steps.

* **Documentation**
  * Clarified --theme resolution priority, cache directory defaults/override, offline behavior (no network during render), and build-time gating when install support is absent.

* **Tests**
  * Added integration and regression tests for cache-hit, cache-miss, corruption, and malicious-import cases; shared test helpers for environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->