### PR TITLE
Add basic-resume Typst Universe theme adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,10 @@ make install-tools
 
 - [`fruggiero/typst-jsonresume-cv`](https://github.com/fruggiero/typst-jsonresume-cv)
   — Typst template that accepts JSON Resume data.
-- [`fantastic-cv`](https://typst.app/universe/package/fantastic-cv/)
-  — Typst Universe template with a JSON Resume-shaped API.
-- [`basic-resume`](https://typst.app/universe/package/basic-resume/)
-  and [`modern-cv`](https://typst.app/universe/package/modern-cv/)
-  — Typst Universe resume templates we plan to ship adapters for.
+- [`fantastic-cv`](https://typst.app/universe/package/fantastic-cv/),
+  [`modern-cv`](https://typst.app/universe/package/modern-cv/), and
+  [`basic-resume`](https://typst.app/universe/package/basic-resume/)
+  — Typst Universe resume templates wrapped as bundled adapters.
 - [`jsonresume-renderer`](https://lib.rs/crates/jsonresume-renderer)
   — Rust CLI that renders JSON Resume via Tera templates (not Typst).
 - [`typst.ts`](https://github.com/Myriad-Dreamin/typst.ts) — proves Typst

--- a/assets/themes/basic-resume/LICENSE
+++ b/assets/themes/basic-resume/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/assets/themes/basic-resume/VENDORING.md
+++ b/assets/themes/basic-resume/VENDORING.md
@@ -1,0 +1,191 @@
+# Vendoring record — `basic-resume`
+
+This directory contains a vendored copy of [`stuxf/basic-typst-resume-template`]'s
+Typst source (the package published on Typst Universe as `basic-resume`),
+plus a ferrocv-authored glue entrypoint that maps JSON Resume v1.0.0 data
+to basic-resume's argument shapes. Vendoring satisfies the constitutional
+no-network constraint (see `CONSTITUTION.md` §6.1), and keeping the
+mapping isolated in `resume.typ` preserves the adapter/native separation
+(see `CONSTITUTION.md` §4).
+
+[`stuxf/basic-typst-resume-template`]: https://github.com/stuxf/basic-typst-resume-template
+
+See also: [`../VENDORING_CHECKLIST.md`](../VENDORING_CHECKLIST.md) —
+the shared runbook for initial vendoring, re-vendoring, and Typst
+bumps.
+
+## Provenance
+
+We vendor from the [`typst/packages`] mirror rather than the upstream
+GitHub repo because Typst Universe's published archive is the
+authoritative shape (release tags on the upstream repo do not always
+match the Universe-published `<name>-<version>.tar.gz` byte-for-byte).
+
+[`typst/packages`]: https://github.com/typst/packages
+
+| Field                | Value                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| Upstream             | https://github.com/stuxf/basic-typst-resume-template                                           |
+| Vendored from        | https://github.com/typst/packages/tree/main/packages/preview/basic-resume/0.2.9                |
+| Commit SHA           | `d22237083846d393b1f3693ab7652b072827451f` (typst/packages, last touch on `basic-resume/0.2.9`) |
+| Commit date          | 2025-09-29                                                                                     |
+| Package version      | 0.2.9                                                                                          |
+| Upstream source path | `packages/preview/basic-resume/0.2.9/src/resume.typ`                                           |
+| Vendor date          | 2026-04-27                                                                                     |
+
+We do **not** vendor the upstream `src/lib.typ`; it is a 4-line
+re-export shim whose sole purpose is Typst Universe packaging. Our
+glue imports directly from `basic-resume.typ` (renamed from upstream's
+`src/resume.typ` to avoid colliding with the ferrocv glue file's name).
+
+## License
+
+Upstream's `LICENSE` and its `typst.toml` `license` field both declare
+[**The Unlicense**] — no discrepancy to record.
+
+[**The Unlicense**]: https://unlicense.org/
+
+The Unlicense is a public-domain dedication that explicitly permits
+copy, modify, publish, and distribute under any terms, which makes it
+compatible with `ferrocv`'s **MIT OR Apache-2.0** dual license. The
+file-level [`LICENSE`](./LICENSE) is duplicated from upstream verbatim.
+
+Upstream LICENSE for reference:
+<https://github.com/typst/packages/blob/main/packages/preview/basic-resume/0.2.9/LICENSE>
+
+## Patches applied
+
+**One §6.1 patch**: the upstream `src/resume.typ` opens with
+
+```typst
+#import "@preview/scienceicons:0.1.0": orcid-icon
+```
+
+and uses `orcid-icon(...)` once, in the contact-line ORCID prefix:
+
+```typst
+contact-item(orcid, prefix: [#orcid-icon(color: rgb("#AECD54"))orcid.org/], link-type: "https://orcid.org/"),
+```
+
+CONSTITUTION §6.1 forbids `@preview/...` imports — `FerrocvWorld`
+rejects any `FileId` carrying a `PackageSpec` rather than fetching
+it. Both the import and the call site were rewritten:
+
+```typst
+// after patching
+contact-item(orcid, prefix: "ORCID: orcid.org/", link-type: "https://orcid.org/"),
+```
+
+The visual difference is one missing icon glyph in the contact line
+when an ORCID is present; the textual content (the literal "ORCID:"
+label and the `orcid.org/<id>` link) is unchanged. `text-minimal` and
+`html-minimal` users who want a fully glyph-free document already have
+those native themes; `basic-resume` users who want richer iconography
+can vendor a different theme.
+
+If upstream drops the `@preview/scienceicons` dependency in a later
+release (e.g. by inlining an SVG or removing the icon entirely), the
+re-vendor becomes a byte-for-byte copy and this patch can be retired.
+
+## Empty-URL safety audit
+
+Per the [shared checklist](../VENDORING_CHECKLIST.md) §2, every
+`link(...)` call site was traced back to its source. Audit results
+(line numbers in `basic-resume.typ` after patching):
+
+| Line | Call                                  | Guarded by                                  |
+| ---- | ------------------------------------- | ------------------------------------------- |
+| 83   | `link(link-type + value)`             | `if value != ""` in `contact-item` (L81)    |
+| 202  | `link("https://" + url)`              | `if url != "" and dates != ""`              |
+| 204  | `link("https://" + url)`              | `if url != "" and dates != ""`              |
+| 209  | `link("https://" + url)`              | `if dates == "" and url != ""`              |
+| 226  | `link("https://" + url)`              | `if url != ""` in `certificates`            |
+
+All five sites are guarded; no empty-URL patch is required. The
+sparse-fixture regression test
+(`basic_resume_renders_grace_hopper_sparse_to_expected_text` in
+`tests/render_theme.rs`) exercises a JSON Resume document with no
+profiles, no project URLs, and no certificate URLs, so a future
+re-vendor that breaks any of these guards becomes a committed golden
+diff.
+
+## What was NOT patched
+
+The following are deliberately upstream-as-is:
+
+- `resume(...)` show-rule signature (font, paper, margins, accent
+  color, author/personal-info alignment, ligatures-disabled text rule).
+- `edu`, `work`, `project`, `certificates`, `extracurriculars`
+  signatures.
+- The `generic-two-by-two`, `generic-one-by-two`, and `dates-helper`
+  internals.
+- Default font ("New Computer Modern" — bundled in `typst-assets::fonts()`,
+  no override needed for reproducibility), default font size (10pt),
+  default paper ("us-letter"), default margins (0.5in all sides), and
+  default accent color (`#000000`).
+
+The `resume.typ` glue invokes `resume.with(...)` passing only the
+contact fields it has data for — CONSTITUTION §5 says a second caller
+is the trigger to expose knobs, not the first.
+
+## JSON Resume mapping notes
+
+The ferrocv glue `resume.typ` handles these shape frictions without
+touching `basic-resume.typ`:
+
+- **No `profiles` argument:** basic-resume's show rule takes `github`,
+  `linkedin`, `personal-site`, and `orcid` as flat string arguments
+  (each gets `https://` prepended by `contact-item`). The glue
+  case-insensitively matches `basics.profiles[].network` against
+  `"GitHub"`, `"LinkedIn"`, etc. and strips any leading `https?://` so
+  the helper's prepend doesn't double up. Profiles for networks
+  basic-resume doesn't have a slot for (Mastodon, GitLab, etc.) are
+  dropped in v1.
+- **`personal-site`** comes from JSON Resume `basics.url` with the
+  scheme stripped (same prepend rule).
+- **`work[]` field renames:** JSON Resume `position` →
+  basic-resume `title`; JSON Resume `name` → basic-resume `company`.
+- **Sections without a basic-resume helper** — `volunteer`, `awards`,
+  `publications`, `skills` — are deferred to a follow-up issue. The
+  `basic-resume` template explicitly markets itself as ATS-minimal;
+  rendering those sections requires authoring custom layout in the
+  glue, and we'd rather track that as scoped work than smuggle it in
+  here.
+- **`projects` no `role` field:** JSON Resume schema has no per-project
+  role; the glue passes `name` only and lets basic-resume's `project`
+  helper degrade to a `*name*` heading. `description` and `highlights`
+  become bullets.
+- **Date ranges** use basic-resume's own `dates-helper` (which renders
+  the en-dash with ligatures disabled — the same trick upstream uses
+  internally). Open-ended `endDate` becomes `"Present"`.
+
+## Updating
+
+To re-vendor from a newer upstream:
+
+1. Pick the target version on Typst Universe
+   (<https://typst.app/universe/package/basic-resume/>); fetch the
+   archive directly or pull `src/resume.typ` from the
+   `typst/packages` mirror at the new version path.
+2. Copy it over `basic-resume.typ` in this directory, overwriting
+   byte-for-byte.
+3. **Re-apply the §6.1 patch** documented under "Patches applied"
+   above. `grep -n "@preview/" basic-resume.typ` must return only the
+   ferrocv comment-banner matches; `grep -n "orcid-icon" basic-resume.typ`
+   must return no matches at all. If upstream has dropped the
+   `@preview/scienceicons` dependency, the grep result will already
+   be clean and this step is a no-op.
+4. Update the Commit SHA, Commit date, Package version, and Vendor
+   date rows in the Provenance table above.
+5. Adjust `resume.typ` if any of basic-resume's helper signatures
+   changed. `grep -n "^#let " basic-resume.typ` enumerates every top-
+   level binding; `grep -n "^#import\|resume\.with\|^\s*\(work\|edu\|project\|certificates\)(" resume.typ`
+   enumerates every call site in the glue.
+6. Re-verify no new `@preview/...` imports crept in:
+   `grep -n "@preview/" basic-resume.typ` must return only the patch-
+   banner comments.
+7. Re-walk the [shared checklist](../VENDORING_CHECKLIST.md), in
+   particular §2 (empty-URL audit — `grep -n "link(" basic-resume.typ`
+   and re-verify each guard is still in place).
+8. Regenerate goldens: `UPDATE_GOLDEN=1 cargo test --test render_theme basic_resume`
+   and inspect the diffs before committing.

--- a/assets/themes/basic-resume/basic-resume.typ
+++ b/assets/themes/basic-resume/basic-resume.typ
@@ -1,0 +1,240 @@
+// ferrocv patch: upstream `#import "@preview/scienceicons:0.1.0": orcid-icon`
+// removed. CONSTITUTION §6.1 forbids `@preview/...` imports (the
+// FerrocvWorld rejects any FileId carrying a PackageSpec). The single
+// orcid-icon call site below has been rewritten to a plain "ORCID:"
+// label prefix; see VENDORING.md → Patches applied.
+
+#let resume(
+  author: "",
+  author-position: left,
+  personal-info-position: left,
+  pronouns: "",
+  location: "",
+  email: "",
+  github: "",
+  linkedin: "",
+  phone: "",
+  personal-site: "",
+  orcid: "",
+  accent-color: "#000000",
+  font: "New Computer Modern",
+  paper: "us-letter",
+  author-font-size: 20pt,
+  font-size: 10pt,
+  lang: "en",
+  body,
+) = {
+
+  // Sets document metadata
+  set document(author: author, title: author)
+
+  // Document-wide formatting, including font and margins
+  set text(
+    // LaTeX style font
+    font: font,
+    size: font-size,
+    lang: lang,
+    // Disable ligatures so ATS systems do not get confused when parsing fonts.
+    ligatures: false
+  )
+
+  // Reccomended to have 0.5in margin on all sides
+  set page(
+    margin: (0.5in),
+    paper: paper,
+  )
+
+  // Link styles
+  show link: underline
+
+
+  // Small caps for section titles
+  show heading.where(level: 2): it => [
+    #pad(top: 0pt, bottom: -10pt, [#smallcaps(it.body)])
+    #line(length: 100%, stroke: 1pt)
+  ]
+
+  // Accent Color Styling
+  show heading: set text(
+    fill: rgb(accent-color),
+  )
+
+  show link: set text(
+    fill: rgb(accent-color),
+  )
+
+  // Name will be aligned left, bold and big
+  show heading.where(level: 1): it => [
+    #set align(author-position)
+    #set text(
+      weight: 700,
+      size: author-font-size,
+    )
+    #pad(it.body)
+  ]
+
+  // Level 1 Heading
+  [= #(author)]
+
+  // Personal Info Helper
+  let contact-item(value, prefix: "", link-type: "") = {
+    if value != "" {
+      if link-type != "" {
+        link(link-type + value)[#(prefix + value)]
+      } else {
+        value
+      }
+    }
+  }
+
+  // Personal Info
+  pad(
+    top: 0.25em,
+    align(personal-info-position)[
+      #{
+        let items = (
+          contact-item(pronouns),
+          contact-item(phone),
+          contact-item(location),
+          contact-item(email, link-type: "mailto:"),
+          contact-item(github, link-type: "https://"),
+          contact-item(linkedin, link-type: "https://"),
+          contact-item(personal-site, link-type: "https://"),
+          // ferrocv patch: upstream prefix used #orcid-icon(...) from
+          // @preview/scienceicons; replaced with a plain "ORCID: " label
+          // to honor §6.1. See VENDORING.md → Patches applied.
+          contact-item(orcid, prefix: "ORCID: orcid.org/", link-type: "https://orcid.org/"),
+        )
+        items.filter(x => x != none).join("  |  ")
+      }
+    ],
+  )
+
+  // Main body.
+  set par(justify: true)
+
+  body
+}
+
+// Generic two by two component for resume
+#let generic-two-by-two(
+  top-left: "",
+  top-right: "",
+  bottom-left: "",
+  bottom-right: "",
+) = {
+  [
+    #top-left #h(1fr) #top-right \
+    #bottom-left #h(1fr) #bottom-right
+  ]
+}
+
+// Generic one by two component for resume
+#let generic-one-by-two(
+  left: "",
+  right: "",
+) = {
+  [
+    #left #h(1fr) #right
+  ]
+}
+
+// Cannot just use normal --- ligature becuase ligatures are disabled for good reasons
+#let dates-helper(
+  start-date: "",
+  end-date: "",
+) = {
+  start-date + " " + $dash.em$ + " " + end-date
+}
+
+// Section components below
+#let edu(
+  institution: "",
+  dates: "",
+  degree: "",
+  gpa: "",
+  location: "",
+  // Makes dates on upper right like rest of components
+  consistent: false,
+) = {
+  if consistent {
+    // edu-constant style (dates top-right, location bottom-right)
+    generic-two-by-two(
+      top-left: strong(institution),
+      top-right: dates,
+      bottom-left: emph(degree),
+      bottom-right: emph(location),
+    )
+  } else {
+    // original edu style (location top-right, dates bottom-right)
+    generic-two-by-two(
+      top-left: strong(institution),
+      top-right: location,
+      bottom-left: emph(degree),
+      bottom-right: emph(dates),
+    )
+  }
+}
+
+#let work(
+  title: "",
+  dates: "",
+  company: "",
+  location: "",
+) = {
+  generic-two-by-two(
+    top-left: strong(title),
+    top-right: dates,
+    bottom-left: company,
+    bottom-right: emph(location),
+  )
+}
+
+#let project(
+  role: "",
+  name: "",
+  url: "",
+  dates: "",
+) = {
+  generic-one-by-two(
+    left: {
+      if role == "" {
+        [*#name* #if url != "" and dates != "" [ (#link("https://" + url)[#url])]]
+      } else {
+        [*#role*, #name #if url != "" and dates != ""  [ (#link("https://" + url)[#url])]]
+      }
+    },
+    right: {
+      if dates == "" and url != "" {
+        link("https://" + url)[#url]
+      } else {
+        dates
+      }
+    },
+  )
+}
+
+#let certificates(
+  name: "",
+  issuer: "",
+  url: "",
+  date: "",
+) = {
+  [
+    *#name*, #issuer
+    #if url != "" {
+      [ (#link("https://" + url)[#url])]
+    }
+    #h(1fr) #date
+  ]
+}
+
+#let extracurriculars(
+  activity: "",
+  dates: "",
+) = {
+  generic-one-by-two(
+    left: strong(activity),
+    right: dates,
+  )
+}

--- a/assets/themes/basic-resume/resume.typ
+++ b/assets/themes/basic-resume/resume.typ
@@ -1,0 +1,199 @@
+// ferrocv glue entrypoint for the vendored `basic-resume` theme.
+//
+// This file is authored by ferrocv (NOT vendored). It imports the patched
+// upstream `basic-resume.typ` builders and adapts JSON Resume v1.0.0 data
+// into basic-resume's helper-function call shape (`resume`, `edu`, `work`,
+// `project`, `certificates`). The vendored file carries one §6.1 patch
+// (the `@preview/scienceicons` strip); see VENDORING.md.
+//
+// CONSTITUTION §1: JSON Resume is the canonical input; every field is
+// optional per the v1.0.0 schema. Every read uses `.at(..., default: ...)`.
+// CONSTITUTION §5: no section-toggle knobs; every section we render in v1
+// (basics, work, education, projects, certificates) renders when the data
+// is present. Volunteer / awards / publications / skills are deferred to
+// a follow-up issue — basic-resume has no native helper for them.
+
+#import "basic-resume.typ": resume, edu, work, project, certificates, dates-helper
+
+// The FerrocvWorld serves the JSON Resume bytes at the virtual path
+// "/resume.json". Same convention as every other ferrocv theme.
+#let r = json("/resume.json")
+
+// Strip a leading `https://` or `http://` from a URL so it slots into
+// basic-resume's helpers, which prepend `https://` themselves (see
+// `contact-item(..., link-type: "https://")` and the `project`/
+// `certificates` helpers in the upstream source). Returns the input
+// untouched if no scheme is present.
+#let __strip_scheme(u) = {
+  if u.starts-with("https://") { u.slice(8) }
+  else if u.starts-with("http://") { u.slice(7) }
+  else { u }
+}
+
+// Format a JSON Resume startDate/endDate pair using basic-resume's
+// `dates-helper` (which renders the en-dash with ligatures disabled).
+// Empty range → "" so the helpers' empty-string guards kick in.
+#let __fmt_range(start, end) = {
+  if start != "" and end != "" { dates-helper(start-date: start, end-date: end) }
+  else if start != "" { dates-helper(start-date: start, end-date: "Present") }
+  else if end != "" { end }
+  else { "" }
+}
+
+// Optional-field shim for `basics` — absent, null, or partially-filled
+// sub-objects must all render without a dict-lookup panic.
+#let basics = r.at("basics", default: (:))
+#let location_dict = basics.at("location", default: (:))
+#let city = location_dict.at("city", default: "")
+#let region = location_dict.at("region", default: "")
+#let address = if city != "" and region != "" {
+  city + ", " + region
+} else if city != "" {
+  city
+} else {
+  region
+}
+
+// Profiles → flat github / linkedin args. basic-resume takes them by
+// network name (no `profiles` argument), so case-insensitively pluck
+// the first matching entry. Anything else (e.g. Mastodon, GitLab) is
+// dropped in v1; iterate when a caller asks (CONSTITUTION §5).
+//
+// `lower()` is a global function on `str` content in Typst, not a
+// method — `s.lower()` and `s.to-lowercase()` both error out.
+#let __profile_url(network_name) = {
+  let profiles = basics.at("profiles", default: ())
+  let target = lower(network_name.replace(" ", ""))
+  let matches = profiles.filter(p => {
+    lower(p.at("network", default: "").replace(" ", "")) == target
+  })
+  if matches.len() > 0 {
+    let p = matches.at(0)
+    let u = p.at("url", default: "")
+    if u != "" { __strip_scheme(u) }
+    else { p.at("username", default: "") }
+  } else { "" }
+}
+
+// Apply basic-resume's `resume(...)` show rule.
+//
+// Font override: basic-resume's upstream default ("New Computer Modern")
+// is bundled in `typst-assets::fonts()` (same as `typst-jsonresume-cv`),
+// so we do NOT override it here — the golden stays reproducible across
+// hosts without a font-pin patch.
+//
+// CONSTITUTION §5: no other overrides. Iterate when a caller asks.
+#show: resume.with(
+  author: basics.at("name", default: ""),
+  location: address,
+  email: basics.at("email", default: ""),
+  phone: basics.at("phone", default: ""),
+  personal-site: __strip_scheme(basics.at("url", default: "")),
+  github: __profile_url("GitHub"),
+  linkedin: __profile_url("LinkedIn"),
+)
+
+// `basics.summary` → an unlabeled paragraph immediately under the
+// contact header. basic-resume has no helper for this; emit it as a
+// plain paragraph so search-friendly ATS systems still see it.
+#{
+  let summary = basics.at("summary", default: "")
+  if summary != "" [
+    #summary
+  ]
+}
+
+// Section: education → `= Education`. basic-resume's `edu` takes
+// `degree` as a single string; compose from JSON Resume `studyType` +
+// `area`. `gpa` ← `score`. JSON Resume has no education-level
+// `location`; default to empty.
+#if "education" in r and r.education != none and r.education.len() > 0 [
+  == Education
+
+  #for e in r.education {
+    let study_type = e.at("studyType", default: "")
+    let area = e.at("area", default: "")
+    let degree = if study_type != "" and area != "" { study_type + ", " + area }
+      else if study_type != "" { study_type }
+      else { area }
+    edu(
+      institution: e.at("institution", default: ""),
+      dates: __fmt_range(e.at("startDate", default: ""), e.at("endDate", default: "")),
+      degree: degree,
+      gpa: e.at("score", default: ""),
+      location: e.at("location", default: ""),
+    )
+    let courses = e.at("courses", default: ())
+    if courses.len() > 0 [
+      - Courses: #courses.join(", ")
+    ]
+  }
+]
+
+// Section: work → `= Experience`. basic-resume's `work` takes `title`
+// (the role) and `company` (the employer); JSON Resume `position` →
+// `title`, `name` → `company`. `summary` and `highlights` go into a
+// bullet list under the `work` row, mirroring upstream's example.
+#if "work" in r and r.work != none and r.work.len() > 0 [
+  == Experience
+
+  #for w in r.work {
+    work(
+      title: w.at("position", default: ""),
+      dates: __fmt_range(w.at("startDate", default: ""), w.at("endDate", default: "")),
+      company: w.at("name", default: ""),
+      location: w.at("location", default: ""),
+    )
+    let summary = w.at("summary", default: "")
+    let highlights = w.at("highlights", default: ())
+    if summary != "" or highlights.len() > 0 [
+      #if summary != "" [
+        - #summary
+      ]
+      #for h in highlights [
+        - #h
+      ]
+    ]
+  }
+]
+
+// Section: projects → `= Projects`. JSON Resume has no `role` per
+// project; the helper accepts `role` as optional and degrades to a
+// `*name*` heading when it's empty. `description` and `highlights`
+// become bullet rows.
+#if "projects" in r and r.projects != none and r.projects.len() > 0 [
+  == Projects
+
+  #for p in r.projects {
+    project(
+      name: p.at("name", default: ""),
+      url: __strip_scheme(p.at("url", default: "")),
+      dates: __fmt_range(p.at("startDate", default: ""), p.at("endDate", default: "")),
+    )
+    let description = p.at("description", default: "")
+    let highlights = p.at("highlights", default: ())
+    if description != "" or highlights.len() > 0 [
+      #if description != "" [
+        - #description
+      ]
+      #for h in highlights [
+        - #h
+      ]
+    ]
+  }
+]
+
+// Section: certificates → `= Certificates`. basic-resume's
+// `certificates` helper maps 1:1 to JSON Resume's certificate fields.
+#if "certificates" in r and r.certificates != none and r.certificates.len() > 0 [
+  == Certificates
+
+  #for c in r.certificates {
+    certificates(
+      name: c.at("name", default: ""),
+      issuer: c.at("issuer", default: ""),
+      url: __strip_scheme(c.at("url", default: "")),
+      date: c.at("date", default: ""),
+    )
+  }
+]

--- a/assets/themes/basic-resume/resume.typ
+++ b/assets/themes/basic-resume/resume.typ
@@ -61,6 +61,12 @@
 //
 // `lower()` is a global function on `str` content in Typst, not a
 // method — `s.lower()` and `s.to-lowercase()` both error out.
+//
+// Username fallback: when a profile has `username` but no `url`,
+// build the canonical host path (`github.com/<u>`,
+// `linkedin.com/in/<u>`) so basic-resume's helper produces a real
+// link after its `https://` prepend. Returning the bare username
+// would yield `https://<username>` — a broken URL.
 #let __profile_url(network_name) = {
   let profiles = basics.at("profiles", default: ())
   let target = lower(network_name.replace(" ", ""))
@@ -70,8 +76,15 @@
   if matches.len() > 0 {
     let p = matches.at(0)
     let u = p.at("url", default: "")
-    if u != "" { __strip_scheme(u) }
-    else { p.at("username", default: "") }
+    if u != "" {
+      __strip_scheme(u)
+    } else {
+      let username = p.at("username", default: "")
+      if username == "" { "" }
+      else if target == "github" { "github.com/" + username }
+      else if target == "linkedin" { "linkedin.com/in/" + username }
+      else { "" }
+    }
   } else { "" }
 }
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -48,8 +48,8 @@ pattern from.
 
 ## Anatomy of an adapter
 
-The repo currently ships three adapters, deliberately picked to
-demonstrate three different vendoring shapes. Read whichever is closest
+The repo currently ships four adapters, deliberately picked to
+demonstrate four different vendoring shapes. Read whichever is closest
 to your case before authoring a new one.
 
 | Adapter                                           | Shape                  | Why it's the exemplar                                                                                  |
@@ -57,6 +57,7 @@ to your case before authoring a new one.
 | [`fantastic-cv`](../assets/themes/fantastic-cv/)             | Pure glue, light patch | Upstream needed only one compatibility patch (`link("")` guard); everything else is glue in `resume.typ`. |
 | [`typst-jsonresume-cv`](../assets/themes/typst-jsonresume-cv/) | Glue + optional-field shim | Upstream read a path the World doesn't serve, plus several dict lookups that crashed on sparse JSON Resume documents. |
 | [`modern-cv`](../assets/themes/modern-cv/)                   | Heavy patch            | Upstream pulled two `@preview/...` packages and read the system clock; required removing both and i18n-flattening to English. |
+| [`basic-resume`](../assets/themes/basic-resume/)             | Single `@preview` strip | Upstream pulled exactly one `@preview/...` package (`scienceicons` for the ORCID glyph); the icon call site rewrote to a plain text label. |
 
 Every adapter directory has the same shape:
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -36,13 +36,13 @@
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 2 ships five themes total: three adapters
-//! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`) and two native
-//! themes (`text-minimal`, `html-minimal`). A linear scan over
-//! `THEMES` is O(n) for small n; CONSTITUTION §5 ("simple now,
-//! iterate later") calls for the narrower solution here. Generalizing
-//! to a hashed lookup or a builder pattern should wait for a caller
-//! that actually needs it.
+//! Phase 2/3 ships six themes total: four adapters
+//! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`, `basic-resume`)
+//! and two native themes (`text-minimal`, `html-minimal`). A linear
+//! scan over `THEMES` is O(n) for small n; CONSTITUTION §5 ("simple
+//! now, iterate later") calls for the narrower solution here.
+//! Generalizing to a hashed lookup or a builder pattern should wait
+//! for a caller that actually needs it.
 //!
 //! # Theme resolution: bundled vs. local-path
 //!
@@ -121,6 +121,13 @@ const FANTASTIC_CV_PREFIX: &str = "/themes/fantastic-cv";
 /// fields stay in lockstep. If this prefix changes, every file path
 /// in [`MODERN_CV`] updates in one place.
 const MODERN_CV_PREFIX: &str = "/themes/modern-cv";
+
+/// Virtual-path prefix for this theme's files inside the World.
+///
+/// Centralized as a private `const` so the `files` and `entrypoint`
+/// fields stay in lockstep. If this prefix changes, every file path
+/// in [`BASIC_RESUME`] updates in one place.
+const BASIC_RESUME_PREFIX: &str = "/themes/basic-resume";
 
 /// Adapter for [`fruggiero/typst-jsonresume-cv`]'s `basic-resume`
 /// theme, vendored under `assets/themes/typst-jsonresume-cv/`.
@@ -225,6 +232,39 @@ const _: () = {
     assert!(!MODERN_CV_PREFIX.is_empty());
 };
 
+/// Adapter for [`stuxf/basic-typst-resume-template`] (Typst Universe
+/// `basic-resume`), vendored under `assets/themes/basic-resume/`.
+///
+/// Like [`MODERN_CV`] this is a **patched** vendor: the upstream pulls
+/// `@preview/scienceicons` for an ORCID glyph, which CONSTITUTION §6.1
+/// forbids. The single icon call site was rewritten to a plain
+/// `"ORCID:"` text prefix; see `assets/themes/basic-resume/VENDORING.md`
+/// for the patch record. The entrypoint is our authored glue
+/// `resume.typ`, which imports the patched `basic-resume.typ` from the
+/// same virtual directory.
+///
+/// [`stuxf/basic-typst-resume-template`]: https://github.com/stuxf/basic-typst-resume-template
+pub const BASIC_RESUME: Theme = Theme {
+    name: "basic-resume",
+    files: &[
+        (
+            // Must agree with BASIC_RESUME_PREFIX + "/basic-resume.typ".
+            concat!("/themes/basic-resume", "/basic-resume.typ"),
+            include_bytes!("../assets/themes/basic-resume/basic-resume.typ"),
+        ),
+        (
+            concat!("/themes/basic-resume", "/resume.typ"),
+            include_bytes!("../assets/themes/basic-resume/resume.typ"),
+        ),
+    ],
+    entrypoint: concat!("/themes/basic-resume", "/resume.typ"),
+};
+
+// Compile-time sanity check: same shape as for TYPST_JSONRESUME_CV.
+const _: () = {
+    assert!(!BASIC_RESUME_PREFIX.is_empty());
+};
+
 /// Virtual path of the `text-minimal` theme's entrypoint.
 ///
 /// Single per-file constant used by both the [`Theme::files`] key and
@@ -316,18 +356,19 @@ pub const HTML_MINIMAL: Theme = Theme {
 
 /// All themes registered with this build of `ferrocv`.
 ///
-/// Phase 2 ships three adapters (`typst-jsonresume-cv`, `fantastic-cv`,
-/// `modern-cv`) and two native themes (`text-minimal`, `html-minimal`).
-/// See the module doc for why this is a `&[&Theme]` rather than a
-/// `HashMap` or a builder pattern — a linear scan over a handful of
-/// entries is fine, and CONSTITUTION §5 calls for the narrower
-/// solution until a caller actually needs more. See the module doc as
-/// well for the §4 deferral on splitting native themes into their own
-/// module.
+/// Phase 2/3 ships four adapters (`typst-jsonresume-cv`, `fantastic-cv`,
+/// `modern-cv`, `basic-resume`) and two native themes (`text-minimal`,
+/// `html-minimal`). See the module doc for why this is a `&[&Theme]`
+/// rather than a `HashMap` or a builder pattern — a linear scan over
+/// a handful of entries is fine, and CONSTITUTION §5 calls for the
+/// narrower solution until a caller actually needs more. See the
+/// module doc as well for the §4 deferral on splitting native themes
+/// into their own module.
 pub const THEMES: &[&Theme] = &[
     &TYPST_JSONRESUME_CV,
     &FANTASTIC_CV,
     &MODERN_CV,
+    &BASIC_RESUME,
     &TEXT_MINIMAL,
     &HTML_MINIMAL,
 ];

--- a/tests/goldens/basic-resume-sparse.txt
+++ b/tests/goldens/basic-resume-sparse.txt
@@ -1,0 +1,7 @@
+Grace Hopper
+
+Rear admiral and pioneer of computer programming.
+Experience
+Rear Admiral 1944-07-01  —  Present
+US Navy• Worked on the Mark I computer at Harvard.
+• Developed the first compiler for a computer programming language.

--- a/tests/goldens/basic-resume.txt
+++ b/tests/goldens/basic-resume.txt
@@ -1,0 +1,21 @@
+Ada Lovelace
+ +44-20-0000-0000  |  London, England  |   ada@example.com   |   github.example.com/ada   |   linkedin.example.com/in/ada-
+lovelace   |   example.com/ada
+
+Mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical general-purpose computer,  the Analytical Engine.
+Education
+ University of LondonSelf-directed, Mathematics 1833-01-01  —  1843-01-01
+
+Experience
+Programmer 1843-01-01  —  1852-11-27
+Analytical Engines Ltd• Translated and annotated Menabrea's paper on the Analytical Engine; wrote the first published algorithm intended for machine execution.
+• Published the first algorithm designed for a machine (Bernoulli numbers)
+• Introduced the concept of a general-purpose computing device
+
+Projects
+Notes on the Analytical Engine  ( example.com/notes-g ) 1842-01-01  —  1843-07-01
+• Expanded translation of Menabrea's sketch, including the first published algorithm for a computing machine.
+• Note G — the Bernoulli-number algorithm
+
+Certificates
+ Honorary Fellowship in Computing History , Analytical Engines Ltd ( example.com/cert ) 1843-09-01

--- a/tests/render_theme.rs
+++ b/tests/render_theme.rs
@@ -131,6 +131,27 @@ fn modern_cv_renders_grace_hopper_sparse_to_expected_text() {
     );
 }
 
+// basic-resume adapter goldens.
+#[test]
+fn basic_resume_renders_ada_lovelace_to_expected_text() {
+    run_golden(
+        "basic-resume",
+        "tests/fixtures/render_full.json",
+        "tests/goldens/basic-resume.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn basic_resume_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "basic-resume",
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/basic-resume-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
 /// Shared golden-file workflow: compile the named adapter against the
 /// named fixture, extract and normalize the PDF text, and compare
 /// against (or rewrite, under `UPDATE_GOLDEN`) the committed golden.

--- a/tests/themes_cli.rs
+++ b/tests/themes_cli.rs
@@ -25,7 +25,7 @@ fn themes_list_prints_sorted_names() {
         .assert()
         .success()
         .stdout(predicate::eq(
-            "fantastic-cv\nhtml-minimal\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
+            "basic-resume\nfantastic-cv\nhtml-minimal\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
         ))
         .stderr(predicate::str::is_empty());
 }


### PR DESCRIPTION
## Summary

- Vendor `basic-resume@0.2.9` (Typst Universe / `stuxf/basic-typst-resume-template`) under `assets/themes/basic-resume/` and wire it up as a ferrocv adapter.
- Strip the upstream `@preview/scienceicons` import per CONSTITUTION §6.1; the single `orcid-icon(...)` call site is rewritten to a plain `"ORCID:"` text label. All other helper code is upstream-as-is.
- Author a ferrocv glue `resume.typ` that maps JSON Resume v1.0.0 → basic-resume's `resume`/`edu`/`work`/`project`/`certificates` helper shape. Volunteer / awards / publications / skills are deferred (basic-resume has no native helper for them) — to be tracked as a follow-up issue.
- Two golden tests (full + sparse fixtures) exercising normalized text extraction; the sparse golden pins the optional-field shim and the empty-URL guards in the vendored source.

## Provenance

- Vendored from `typst/packages` at `d22237083846d393b1f3693ab7652b072827451f` (path `packages/preview/basic-resume/0.2.9`, last touched 2025-09-29).
- Upstream license: Unlicense (consistent in `typst.toml` and `LICENSE` — no discrepancy to record).

## Test plan

- [x] `make preflight` green (fmt-check, clippy, test, deny, audit, typos, no-network-deps check).
- [x] `cargo test --test render_theme` — 8 golden tests pass (4 adapters × 2 fixtures).
- [x] `cargo test --test themes_cli` — exact-stdout assertion updated for the new entry.
- [x] `grep -n "@preview/" assets/themes/basic-resume/*.typ` matches only patch-banner comments (CONSTITUTION §6.1).
- [x] Empty-URL audit — all 5 `link()` call sites are guarded (recorded in `VENDORING.md`).
- [x] Manual PDF render confirmed via `cargo run -- render --theme basic-resume tests/fixtures/render_full.json`.

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bundled "basic-resume" theme for generating resumes from JSON Resume data (education, experience, projects, certificates).

* **Documentation**
  * Updated adapter docs and README to list the expanded bundled themes and describe vendoring/handling for the new theme.
  * Added vendoring record and an explicit license for the theme.

* **Tests**
  * Added golden-file tests and fixtures to validate resume rendering.

* **CLI**
  * Theme list updated to include the new theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->