### PR TITLE
Pin nightly fuzz workflow to gnu host triple

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -57,9 +57,16 @@ jobs:
           cp tests/fixtures/*.json fuzz/corpus/parse/
           cp tests/fixtures/*.json fuzz/corpus/validate/
 
+      # Pin the build target to the runner's actual host triple. The
+      # cargo-fuzz binary installed by taiki-e/install-action is itself
+      # musl-linked, and cargo-fuzz defaults to its own build target —
+      # which causes it to invoke `cargo build --target
+      # x86_64-unknown-linux-musl` here, where (a) the musl std isn't
+      # installed and (b) AddressSanitizer is incompatible with musl's
+      # static libc. Forcing -gnu sidesteps both.
       - name: Fuzz ${{ matrix.target }}
         working-directory: fuzz
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=120
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=120
 
       - name: Upload crash artifacts
         if: failure()


### PR DESCRIPTION
## Summary

- The nightly `fuzz` workflow has failed on every run since it landed (8 spurious `fuzz-failure` issues filed: #85, #86, #87, #88, #89, #90, #93, #94).
- Root cause is not a fuzzer crash — it's a build failure. `taiki-e/install-action` ships a musl-linked `cargo-fuzz`, and `cargo-fuzz` defaults `--target` to its own build triple, so on the gnu runner it tries to compile against `x86_64-unknown-linux-musl` (target std not installed; ASan also incompatible with musl's static libc).
- Fix: pass `--target x86_64-unknown-linux-gnu` explicitly to `cargo fuzz run`.

## Verification

- Manually dispatched on this branch: workflow run [25026956123](https://github.com/cacack/ferrocv/actions/runs/25026956123) — both `parse` and `validate` jobs ran the full 120 s fuzz budget and exited green (no crashes, no issue auto-filed).

## Follow-up

- After merge, the 8 spurious `fuzz-failure` issues will be closed referencing this PR.

## Test plan

- [x] `workflow_dispatch` run on branch goes green
- [ ] First scheduled nightly run after merge stays green