### PR TITLE
Recursively resolve transitive @preview/ deps in themes install

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -99,6 +99,13 @@ them requires a constitutional amendment, not a feature PR.
   is never invoked transitively from `render` or `validate`; its
   network-capable dependencies live behind a Cargo feature flag
   (`install`) so the default build contains no network code at all.
+  Fetches initiated by `themes install` recursively include the
+  transitive `@preview/...` packages reachable from the requested
+  package's source — installing `@preview/foo:1.0` whose source imports
+  `@preview/bar:2.0` populates both cache entries in one invocation.
+  This is a same-class extension of the existing network surface, not
+  a new one: the registry, the protocol, the integrity model, and the
+  `install` Cargo feature gate are unchanged.
   Package integrity is established by TLS only: `ferrocv` does not
   verify upstream checksums or signatures for v1 because the Typst
   Universe registry does not publish them. Users who need stronger

--- a/README.md
+++ b/README.md
@@ -94,20 +94,28 @@ machine-readable contract.
 
 `themes install` resolves transitive `@preview/...` dependencies
 recursively: installing one package also fetches every `@preview/...`
-package its source imports, so a subsequent offline `ferrocv render`
-against that package finds everything it needs in the cache. Cycles in
-declared imports are detected and do not loop. The primary's cache
+package its source declares as an import, hydrating the local cache for
+the whole graph in one invocation instead of N. Cycles in declared
+imports are detected and do not loop; missing transitive packages
+hard-fail with the primary still cached for retry. The primary's cache
 path is printed to stdout (one line, scriptable); a human-readable
-summary of any transitive deps installed or already cached is printed
-to stderr, e.g.
+summary of any transitive deps newly installed or already cached is
+printed to stderr, e.g.
 
 ```
 $ ferrocv themes install @preview/foo:1.0
 /.../packages/preview/foo/1.0
 installed @preview/foo:1.0 into /.../packages/preview/foo/1.0
-also installed 1 transitive dep(s):
+also resolved 1 transitive dep(s):
   @preview/bar:2.0 -> /.../packages/preview/bar/2.0 [installed]
 ```
+
+`render` resolves a top-level `--theme @preview/<name>:<version>` spec
+out of this cache (see `--theme resolution modes` below); inline
+`#import "@preview/..."` directives inside theme source remain
+rejected at render time per CONSTITUTION §6.1, so the practical benefit
+of recursive install today is one-shot cache hydration rather than
+chained imports at compile time.
 
 ### `--theme` resolution modes
 
@@ -143,8 +151,12 @@ Exit codes (shared across subcommands):
 - `2` — usage error, IO error, JSON parse error, unknown theme/format,
   render error, or unrecoverable stdout write failure
 
-No network is touched — the schema, theme, and fonts are all compiled
-into the binary.
+No network is touched by `render` or `validate` — the schema, theme,
+and fonts are all compiled into the binary, and any `@preview/...`
+theme spec is resolved from the local install cache. The only
+network-permitted entry point is `themes install` (gated behind the
+`install` Cargo feature), which fetches from the Typst Universe
+registry over HTTPS; see CONSTITUTION §6.1.
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ stdin if no path is given.
 sorted lexicographically, with no decoration — a stable
 machine-readable contract.
 
+`themes install` resolves transitive `@preview/...` dependencies
+recursively: installing one package also fetches every `@preview/...`
+package its source imports, so a subsequent offline `ferrocv render`
+against that package finds everything it needs in the cache. Cycles in
+declared imports are detected and do not loop. The primary's cache
+path is printed to stdout (one line, scriptable); a human-readable
+summary of any transitive deps installed or already cached is printed
+to stderr, e.g.
+
+```
+$ ferrocv themes install @preview/foo:1.0
+/.../packages/preview/foo/1.0
+installed @preview/foo:1.0 into /.../packages/preview/foo/1.0
+also installed 1 transitive dep(s):
+  @preview/bar:2.0 -> /.../packages/preview/bar/2.0 [installed]
+```
+
 ### `--theme` resolution modes
 
 `--theme <spec>` accepts three shapes, evaluated in this order:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,15 @@ enum ThemesCommands {
     /// spec, and atomically renames the staged directory onto its
     /// final cache path.
     ///
+    /// Transitive resolution: any `@preview/<name>:<version>` packages
+    /// imported by the requested package's source are fetched and cached
+    /// recursively. A summary of the transitive deps installed (or already
+    /// cached) is printed to stderr after the primary's status line.
+    /// Cycles in declared imports terminate cleanly. A transitive install
+    /// failure (404, malformed tarball, etc.) leaves the primary's cache
+    /// entry in place so a re-run after fixing the transitive does not
+    /// re-fetch the parent.
+    ///
     /// Cache location:
     /// - Default: `{dirs::cache_dir()}/ferrocv/packages/preview/<name>/<version>/`
     ///   (Linux: `$XDG_CACHE_HOME or $HOME/.cache/...`,
@@ -233,7 +242,7 @@ pub fn run() -> Result<ExitCode> {
 /// block so the compiler refuses to build it into the default binary.
 #[cfg(feature = "install")]
 fn run_themes_install(spec: &str) -> Result<ExitCode> {
-    use crate::install::{self, InstallError};
+    use crate::install::{self, InstallError, pipeline::InstallOutcome};
 
     let parsed = match install::spec::parse_spec(spec) {
         Ok(s) => s,
@@ -243,29 +252,85 @@ fn run_themes_install(spec: &str) -> Result<ExitCode> {
         }
     };
 
-    match install::install(&parsed) {
-        Ok(install::pipeline::InstallOutcome::Installed { path }) => {
+    match install::install_with_transitive(&parsed) {
+        Ok(summary) => {
+            let primary_path = summary.primary.path().clone();
             // One-line path on stdout for scripting; human-readable
             // summary on stderr so `$(ferrocv themes install ...)`
-            // captures just the path.
-            println!("{}", path.display());
-            eprintln!(
-                "installed @preview/{}:{} into {}",
-                parsed.name,
-                parsed.version,
-                path.display(),
-            );
+            // captures just the primary's path. Transitive dep paths
+            // intentionally do NOT appear on stdout — preserves the
+            // existing single-path scripting contract.
+            println!("{}", primary_path.display());
+            match &summary.primary {
+                InstallOutcome::Installed { .. } => {
+                    eprintln!(
+                        "installed @preview/{}:{} into {}",
+                        parsed.name,
+                        parsed.version,
+                        primary_path.display(),
+                    );
+                }
+                InstallOutcome::AlreadyCached { .. } => {
+                    eprintln!(
+                        "@preview/{}:{} already cached at {}",
+                        parsed.name,
+                        parsed.version,
+                        primary_path.display(),
+                    );
+                }
+            }
+            // Summary of transitive deps, if any. Suppressed entirely
+            // when zero transitives so older scripts that grep stderr
+            // for the primary's `installed`/`already cached` line keep
+            // working unchanged.
+            if !summary.transitive.is_empty() {
+                eprintln!(
+                    "also installed {} transitive dep(s):",
+                    summary.transitive.len(),
+                );
+                for (dep_spec, outcome) in &summary.transitive {
+                    let tag = match outcome {
+                        InstallOutcome::Installed { .. } => "installed",
+                        InstallOutcome::AlreadyCached { .. } => "cached",
+                    };
+                    eprintln!(
+                        "  @preview/{}:{} -> {} [{}]",
+                        dep_spec.name,
+                        dep_spec.version,
+                        outcome.path().display(),
+                        tag,
+                    );
+                }
+            }
             Ok(ExitCode::SUCCESS)
         }
-        Ok(install::pipeline::InstallOutcome::AlreadyCached { path }) => {
-            println!("{}", path.display());
+        Err(InstallError::TransitiveDepFailed {
+            parent,
+            child,
+            source,
+        }) => {
             eprintln!(
-                "@preview/{}:{} already cached at {}",
-                parsed.name,
-                parsed.version,
-                path.display(),
+                "error: failed to install transitive dep {child} required by {parent}: {source}",
             );
-            Ok(ExitCode::SUCCESS)
+            // Per the prompt-001 contract the primary's cache entry is
+            // left in place on a transitive failure. Tell the user
+            // where to find it so they don't think they need to
+            // manually clean up before retrying. `package_cache_dir`
+            // is a pure path computation; if even that fails (e.g.
+            // CacheDirUnresolved) we silently skip the note rather
+            // than emit a misleading path.
+            if let Ok(p) = install::cache::package_cache_dir(&parsed.name, &parsed.version)
+                && p.is_dir()
+            {
+                eprintln!(
+                    "note: primary @preview/{}:{} remains cached at {}; \
+                     rerun after fixing the transitive",
+                    parsed.name,
+                    parsed.version,
+                    p.display(),
+                );
+            }
+            Ok(ExitCode::from(2))
         }
         Err(err) => {
             eprintln!("error: {err}");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,8 +259,17 @@ fn run_themes_install(spec: &str) -> Result<ExitCode> {
             // summary on stderr so `$(ferrocv themes install ...)`
             // captures just the primary's path. Transitive dep paths
             // intentionally do NOT appear on stdout — preserves the
-            // existing single-path scripting contract.
-            println!("{}", primary_path.display());
+            // existing single-path scripting contract. Mirrors the
+            // locked-stdout error handling in `run_themes_list` so a
+            // broken pipe surfaces as a clean exit-2, not a panic.
+            {
+                let stdout = io::stdout();
+                let mut stdout = stdout.lock();
+                if let Err(err) = writeln!(stdout, "{}", primary_path.display()) {
+                    eprintln!("error: failed to write install path to stdout: {err}");
+                    return Ok(ExitCode::from(2));
+                }
+            }
             match &summary.primary {
                 InstallOutcome::Installed { .. } => {
                     eprintln!(
@@ -284,8 +293,11 @@ fn run_themes_install(spec: &str) -> Result<ExitCode> {
             // for the primary's `installed`/`already cached` line keep
             // working unchanged.
             if !summary.transitive.is_empty() {
+                // "resolved" rather than "installed" because the list
+                // mixes fresh installs and cache hits — see the per-dep
+                // `[installed|cached]` tag for the actual outcome.
                 eprintln!(
-                    "also installed {} transitive dep(s):",
+                    "also resolved {} transitive dep(s):",
                     summary.transitive.len(),
                 );
                 for (dep_spec, outcome) in &summary.transitive {

--- a/src/install/imports.rs
+++ b/src/install/imports.rs
@@ -1,0 +1,346 @@
+//! Scan a cached Typst Universe package's `.typ` source for transitive
+//! `@preview/<name>:<version>` references.
+//!
+//! Used by [`super::pipeline::install_with_transitive`] to discover
+//! the deps a freshly-installed package needs at compile time. The
+//! scanner is deliberately lexical: a tiny quote-state machine over
+//! the source string that records the contents of every double-quoted
+//! string literal and tries to parse those starting with `@preview/`
+//! as a [`PackageSpec`]. Anything that fails to parse is silently
+//! skipped — a string that happens to look like a preview spec but
+//! isn't valid is at worst a missed transitive that surfaces later as
+//! a clear cache-miss at render time, not a fatal install error.
+//!
+//! Comments (`//` and `/* ... */`) are consumed before the string
+//! scanner sees the `"`, so an `@preview/...` string inside a comment
+//! does not trigger a fetch.
+//!
+//! Walking the package tree mirrors the conservative shape of
+//! [`crate::package_cache::collect_typ_files`] (skip symlinks, recurse
+//! into subdirs, only ingest case-insensitive `.typ` extensions). Per
+//! CONSTITUTION §5 we do not extract a shared helper this round; the
+//! third caller is the trigger to generalize.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::InstallError;
+use super::spec::{PackageSpec, parse_spec};
+
+/// Scan every `.typ` file under `package_dir` for `@preview/...`
+/// imports and return the deduplicated list of specs.
+///
+/// `self_spec` is the spec of the package being scanned; matches
+/// against it (same name AND same version) are filtered out so a
+/// package that legally references its own name does not trigger a
+/// self-recursive install. Different versions of the same package ARE
+/// kept — version coexistence is legitimate.
+///
+/// The result is sorted by `(name, version)` lexicographically so the
+/// recursive driver's resolution order is reproducible across hosts.
+pub fn scan_preview_imports(
+    package_dir: &Path,
+    self_spec: &PackageSpec,
+) -> Result<Vec<PackageSpec>, InstallError> {
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut out: Vec<PackageSpec> = Vec::new();
+    walk_typ_files(package_dir, self_spec, &mut seen, &mut out)?;
+    out.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
+    Ok(out)
+}
+
+/// Recursively walk `dir`, scan every `.typ` file's contents for
+/// `@preview/...` imports, and push deduped specs into `out`.
+fn walk_typ_files(
+    dir: &Path,
+    self_spec: &PackageSpec,
+    seen: &mut HashSet<(String, String)>,
+    out: &mut Vec<PackageSpec>,
+) -> Result<(), InstallError> {
+    let entries = std::fs::read_dir(dir).map_err(|source| InstallError::Io {
+        context: format!("read_dir {}", dir.display()),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| InstallError::Io {
+            context: format!("read dir entry under {}", dir.display()),
+            source,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|source| InstallError::Io {
+            context: format!("stat {}", path.display()),
+            source,
+        })?;
+        // Skip symlinks defensively — a corrupted cache or a local edit
+        // could introduce one and following it would let the scanner
+        // escape the cache root.
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            walk_typ_files(&path, self_spec, seen, out)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or_default();
+        if !ext.eq_ignore_ascii_case("typ") {
+            continue;
+        }
+        let src = std::fs::read_to_string(&path).map_err(|source| InstallError::Io {
+            context: format!("read {}", path.display()),
+            source,
+        })?;
+        for literal in scan_imports_in_source(&src) {
+            // Only specs that parse cleanly are kept; a string that
+            // starts with `@preview/` but is malformed is silently
+            // skipped (see module-level docs for the rationale).
+            let Ok(spec) = parse_spec(&literal) else {
+                continue;
+            };
+            // Filter self-references: same name AND same version.
+            // Different versions of the same package ARE legitimate
+            // transitive deps and must not be filtered.
+            if spec.name == self_spec.name && spec.version == self_spec.version {
+                continue;
+            }
+            let key = (spec.name.clone(), spec.version.clone());
+            if seen.insert(key) {
+                out.push(spec);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Extract the contents of every double-quoted string literal in
+/// `src` whose contents start with `@preview/`. Comments are skipped.
+///
+/// State machine over `char`s with two states (`Outside` and
+/// `InsideString`). Line and block comments are consumed before the
+/// string scanner sees them so commented-out imports are filtered.
+fn scan_imports_in_source(src: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut chars = src.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '/' if chars.peek() == Some(&'/') => {
+                // Line comment: consume to end of line.
+                for cc in chars.by_ref() {
+                    if cc == '\n' {
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                // Block comment: consume until `*/`.
+                chars.next();
+                let mut prev = '\0';
+                for cc in chars.by_ref() {
+                    if prev == '*' && cc == '/' {
+                        break;
+                    }
+                    prev = cc;
+                }
+            }
+            '"' => {
+                let mut s = String::new();
+                while let Some(cc) = chars.next() {
+                    match cc {
+                        '\\' => {
+                            // Skip the escaped character.
+                            let _ = chars.next();
+                        }
+                        '"' => break,
+                        other => s.push(other),
+                    }
+                }
+                if s.starts_with("@preview/") {
+                    out.push(s);
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir -p");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    fn dummy_self() -> PackageSpec {
+        PackageSpec {
+            namespace: "preview".to_owned(),
+            name: "self-pkg".to_owned(),
+            version: "0.1.0".to_owned(),
+        }
+    }
+
+    fn make_pkg(root: &Path, files: &[(&str, &str)]) -> PathBuf {
+        let pkg = root.join("pkg");
+        for (rel, content) in files {
+            write(&pkg.join(rel), content);
+        }
+        pkg
+    }
+
+    #[test]
+    fn scans_single_import() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[("src/lib.typ", "#import \"@preview/foo:1.0.0\": *\n")],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "foo");
+        assert_eq!(result[0].version, "1.0.0");
+    }
+
+    #[test]
+    fn scans_multiple_imports_dedupes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[(
+                "src/lib.typ",
+                "#import \"@preview/foo:1.0.0\": *\n\
+                 #import \"@preview/foo:1.0.0\": bar\n",
+            )],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert_eq!(result.len(), 1, "duplicate imports must dedupe");
+        assert_eq!(result[0].name, "foo");
+    }
+
+    #[test]
+    fn scans_imports_across_multiple_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[
+                ("src/lib.typ", "#import \"@preview/foo:1.0.0\": *\n"),
+                ("src/helpers.typ", "#import \"@preview/bar:2.0.0\": *\n"),
+            ],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert_eq!(result.len(), 2);
+        // Result is sorted by (name, version).
+        assert_eq!(result[0].name, "bar");
+        assert_eq!(result[1].name, "foo");
+    }
+
+    #[test]
+    fn skips_self_reference() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let me = dummy_self();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[(
+                "src/lib.typ",
+                &format!(
+                    "#import \"@preview/{}:{}\": *\n\
+                     #import \"@preview/{}:9.9.9\": *\n",
+                    me.name, me.version, me.name,
+                ),
+            )],
+        );
+        let result = scan_preview_imports(&pkg, &me).expect("scan ok");
+        // Same name+version is filtered; same name with DIFFERENT
+        // version is kept (legitimate version coexistence).
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, me.name);
+        assert_eq!(result[0].version, "9.9.9");
+    }
+
+    #[test]
+    fn skips_line_comment_imports() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[("src/lib.typ", "// #import \"@preview/foo:1.0.0\": *\n")],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert!(
+            result.is_empty(),
+            "line-commented imports must be ignored: got {result:?}",
+        );
+    }
+
+    #[test]
+    fn skips_block_comment_imports() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[("src/lib.typ", "/* #import \"@preview/foo:1.0.0\": * */\n")],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert!(
+            result.is_empty(),
+            "block-commented imports must be ignored: got {result:?}",
+        );
+    }
+
+    #[test]
+    fn skips_invalid_specs_silently() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // `@preview/has spaces:1.0.0` is rejected by parse_spec because
+        // whitespace is illegal in a name. The scanner must skip it
+        // without surfacing an error.
+        let pkg = make_pkg(
+            tmp.path(),
+            &[("src/lib.typ", "#import \"@preview/has spaces:1.0.0\"\n")],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert!(result.is_empty(), "invalid specs must be skipped silently");
+    }
+
+    #[test]
+    fn non_typ_files_are_ignored() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[
+                ("src/lib.typ", "#import \"@preview/foo:1.0.0\": *\n"),
+                (
+                    "README.md",
+                    "see also @preview/bar:2.0.0 — but markdown is ignored\n\
+                     ```\n#import \"@preview/baz:3.0.0\"\n```\n",
+                ),
+            ],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        assert_eq!(result.len(), 1, "only .typ files are scanned");
+        assert_eq!(result[0].name, "foo");
+    }
+
+    #[test]
+    fn result_order_is_deterministic() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg = make_pkg(
+            tmp.path(),
+            &[(
+                "src/lib.typ",
+                "#import \"@preview/zeta:1.0\": *\n\
+                 #import \"@preview/alpha:1.0\": *\n\
+                 #import \"@preview/mu:1.0\": *\n",
+            )],
+        );
+        let result = scan_preview_imports(&pkg, &dummy_self()).expect("scan ok");
+        let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mu", "zeta"]);
+    }
+}

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -39,11 +39,12 @@
 pub mod cache;
 pub mod extract;
 pub mod fetch;
+pub mod imports;
 pub mod manifest;
 pub mod pipeline;
 pub mod spec;
 
-pub use pipeline::install;
+pub use pipeline::{InstallSummary, install, install_with_transitive};
 pub use spec::PackageSpec;
 
 use std::fmt;
@@ -133,6 +134,27 @@ pub enum InstallError {
     /// and `FERROCV_CACHE_DIR` was unset. Rare — `dirs::cache_dir()`
     /// returns `Some` on every common platform.
     CacheDirUnresolved,
+    /// A transitive `@preview/...` dep failed to install. The pipeline
+    /// installed `parent` successfully but a package reachable from
+    /// `parent`'s source could not be cached — typically because the
+    /// transitive is not on the registry (404) or its tarball is
+    /// malformed.
+    ///
+    /// The parent's cache entry is left in place so a re-run does not
+    /// re-fetch it; callers are expected to fix the transitive
+    /// (correct typo, file an upstream bug, vendor manually) and rerun.
+    TransitiveDepFailed {
+        /// The package whose source declared the failing import,
+        /// rendered as `@preview/<name>:<version>`.
+        parent: String,
+        /// The transitive spec that failed to install, rendered as
+        /// `@preview/<name>:<version>`.
+        child: String,
+        /// The underlying install error from the recursive call.
+        /// Boxed so `InstallError` stays a small enum (silences
+        /// `clippy::large_enum_variant`).
+        source: Box<InstallError>,
+    },
 }
 
 impl fmt::Display for InstallError {
@@ -185,6 +207,16 @@ impl fmt::Display for InstallError {
                      set FERROCV_CACHE_DIR to an explicit path and retry",
                 )
             }
+            InstallError::TransitiveDepFailed {
+                parent,
+                child,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to install transitive dep {child} required by {parent}: {source}",
+                )
+            }
         }
     }
 }
@@ -193,7 +225,53 @@ impl std::error::Error for InstallError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             InstallError::Io { source, .. } | InstallError::Extract { source, .. } => Some(source),
+            InstallError::TransitiveDepFailed { source, .. } => Some(&**source),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitive_dep_failed_displays_both_specs() {
+        let err = InstallError::TransitiveDepFailed {
+            parent: "@preview/parent:1.0.0".to_owned(),
+            child: "@preview/child:2.0.0".to_owned(),
+            source: Box::new(InstallError::HttpStatus {
+                url: "https://packages.typst.org/preview/child-2.0.0.tar.gz".to_owned(),
+                status: 404,
+            }),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@preview/parent:1.0.0"),
+            "Display must mention parent: {msg}",
+        );
+        assert!(
+            msg.contains("@preview/child:2.0.0"),
+            "Display must mention child: {msg}",
+        );
+    }
+
+    #[test]
+    fn transitive_dep_failed_chains_source() {
+        use std::error::Error;
+        let inner = InstallError::HttpStatus {
+            url: "https://packages.typst.org/preview/child-2.0.0.tar.gz".to_owned(),
+            status: 404,
+        };
+        let err = InstallError::TransitiveDepFailed {
+            parent: "@preview/parent:1.0.0".to_owned(),
+            child: "@preview/child:2.0.0".to_owned(),
+            source: Box::new(inner),
+        };
+        let chained = err.source().expect("source must be reachable");
+        assert!(
+            chained.to_string().contains("404"),
+            "chained source must surface the inner cause: {chained}",
+        );
     }
 }

--- a/src/install/pipeline.rs
+++ b/src/install/pipeline.rs
@@ -13,6 +13,7 @@
 //!    On rename-loses-race (another concurrent install won), clean up
 //!    the staging dir and return the winner's path.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use super::{
@@ -20,6 +21,7 @@ use super::{
     cache::{ensure_parent_exists, package_cache_dir},
     extract::extract_tarball,
     fetch::fetch_tarball,
+    imports::scan_preview_imports,
     manifest::parse_manifest,
 };
 
@@ -93,6 +95,104 @@ pub fn install(spec: &PackageSpec) -> Result<InstallOutcome, InstallError> {
     }
 }
 
+/// Outcome bundle for a recursive install: the primary package's
+/// outcome plus one [`InstallOutcome`] per transitive dep installed
+/// or already cached during this call.
+#[derive(Debug)]
+pub struct InstallSummary {
+    /// Outcome of installing the primary spec (the one the user typed).
+    pub primary: InstallOutcome,
+    /// Outcomes of every transitive dep, in the order they were
+    /// resolved. Each entry pairs the spec with the install outcome
+    /// (`AlreadyCached` for cache hits, `Installed` for fresh fetches).
+    /// Empty if the primary had no transitive `@preview/...` imports.
+    pub transitive: Vec<(PackageSpec, InstallOutcome)>,
+}
+
+/// Format a [`PackageSpec`] as the canonical `@preview/<name>:<version>`
+/// string used in error messages and worklist parent labels.
+fn format_spec(spec: &PackageSpec) -> String {
+    format!("@preview/{}:{}", spec.name, spec.version)
+}
+
+/// Install `spec` and every `@preview/...` package it transitively
+/// imports, terminating cleanly on cycles.
+///
+/// The primary spec is installed via [`install`]; its cache directory
+/// is then scanned for `@preview/...` imports via
+/// [`scan_preview_imports`], and each newly-discovered transitive is
+/// installed and scanned in turn. A `(name, version)` visited set
+/// guarantees termination even when packages reference each other in
+/// a cycle.
+///
+/// On a transitive failure the error is wrapped as
+/// [`InstallError::TransitiveDepFailed`] so the diagnostic preserves
+/// the parent attribution for multi-level chains. The primary's cache
+/// entry is left in place (a re-run won't re-fetch it) and the user
+/// is expected to fix the transitive and rerun.
+pub fn install_with_transitive(spec: &PackageSpec) -> Result<InstallSummary, InstallError> {
+    // Install the primary first; its outcome anchors the summary.
+    let primary_outcome = install(spec)?;
+    let primary_label = format_spec(spec);
+
+    // Visited set keyed on (name, version): seeded with the primary so
+    // a self-referential import does not loop. Different versions of
+    // the same package ARE legitimately distinct entries.
+    let mut visited: HashSet<(String, String)> = HashSet::new();
+    visited.insert((spec.name.clone(), spec.version.clone()));
+
+    // Worklist entries are `(child_spec, parent_label)` so error
+    // attribution survives multi-level chains: each grandchild's
+    // failure names the child that imported it, not the original
+    // primary.
+    let mut worklist: Vec<(PackageSpec, String)> = Vec::new();
+
+    // Seed the worklist with the primary's direct deps.
+    let direct = scan_preview_imports(primary_outcome.path(), spec)?;
+    for child in direct {
+        let key = (child.name.clone(), child.version.clone());
+        if visited.contains(&key) {
+            continue;
+        }
+        worklist.push((child, primary_label.clone()));
+    }
+
+    let mut transitive: Vec<(PackageSpec, InstallOutcome)> = Vec::new();
+
+    while let Some((child_spec, parent_label)) = worklist.pop() {
+        let key = (child_spec.name.clone(), child_spec.version.clone());
+        if !visited.insert(key) {
+            // Already installed (or attempted) in this call.
+            continue;
+        }
+        let child_label = format_spec(&child_spec);
+        let child_outcome =
+            install(&child_spec).map_err(|err| InstallError::TransitiveDepFailed {
+                parent: parent_label.clone(),
+                child: child_label.clone(),
+                source: Box::new(err),
+            })?;
+        // Even on `AlreadyCached`, scan for the dep's own deps —
+        // a previously-cached package may have transitives the
+        // current cache hasn't fetched yet. The visited set
+        // prevents re-scanning the same package twice in this call.
+        let grandchildren = scan_preview_imports(child_outcome.path(), &child_spec)?;
+        transitive.push((child_spec, child_outcome));
+        for grandchild in grandchildren {
+            let key = (grandchild.name.clone(), grandchild.version.clone());
+            if visited.contains(&key) {
+                continue;
+            }
+            worklist.push((grandchild, child_label.clone()));
+        }
+    }
+
+    Ok(InstallSummary {
+        primary: primary_outcome,
+        transitive,
+    })
+}
+
 /// Read the staged `typst.toml` and assert its name/version match
 /// `spec`. Returns [`InstallError::ManifestMissing`] if the file is
 /// absent, [`InstallError::ManifestParse`] if it is malformed, or
@@ -126,6 +226,146 @@ pub(crate) fn verify_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::test_env::ENV_LOCK;
+    use std::path::Path;
+
+    /// Snapshot+restore guard for `FERROCV_CACHE_DIR`. Mirrors the
+    /// shape used in `crate::install::cache::tests` and
+    /// `crate::package_cache::tests` so a panicking test body still
+    /// leaves the env intact.
+    struct EnvGuard {
+        prior: Option<String>,
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests are serialized via ENV_LOCK held by the
+            // caller of `with_cache_dir`.
+            unsafe {
+                match &self.prior {
+                    Some(v) => std::env::set_var("FERROCV_CACHE_DIR", v),
+                    None => std::env::remove_var("FERROCV_CACHE_DIR"),
+                }
+            }
+        }
+    }
+
+    fn with_cache_dir<F: FnOnce()>(value: &Path, body: F) {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = EnvGuard {
+            prior: std::env::var("FERROCV_CACHE_DIR").ok(),
+        };
+        // SAFETY: serialized via ENV_LOCK above.
+        unsafe {
+            std::env::set_var("FERROCV_CACHE_DIR", value);
+        }
+        body();
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir -p");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    /// Pre-populate a cache entry so `install()` returns
+    /// `AlreadyCached` instead of attempting a network fetch. `lib_typ`
+    /// is the contents of `src/lib.typ`; pass an `@preview/...` import
+    /// to seed transitive-dep discovery.
+    fn populate_cache_entry(cache_root: &Path, name: &str, version: &str, lib_typ: &str) {
+        let pkg = cache_root
+            .join("packages")
+            .join("preview")
+            .join(name)
+            .join(version);
+        write_file(
+            &pkg.join("typst.toml"),
+            &format!(
+                "[package]\nname = \"{name}\"\nversion = \"{version}\"\nentrypoint = \"src/lib.typ\"\n",
+            ),
+        );
+        write_file(&pkg.join("src/lib.typ"), lib_typ);
+    }
+
+    #[test]
+    fn install_summary_default_when_no_transitives() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Primary's source has no @preview/... imports.
+        populate_cache_entry(tmp.path(), "leaf-pkg", "1.0.0", "= Hello\n");
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "leaf-pkg".to_owned(),
+                version: "1.0.0".to_owned(),
+            };
+            let summary =
+                install_with_transitive(&spec).expect("populated cache must short-circuit");
+            assert!(
+                matches!(summary.primary, InstallOutcome::AlreadyCached { .. }),
+                "primary must be AlreadyCached: {:?}",
+                summary.primary,
+            );
+            assert!(
+                summary.transitive.is_empty(),
+                "no @preview imports => empty transitive list: {:?}",
+                summary.transitive,
+            );
+        });
+    }
+
+    #[test]
+    fn install_summary_visits_each_dep_once() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Cycle: A imports B, B imports A. Both pre-populated so
+        // `install()` returns AlreadyCached for each. The recursive
+        // driver must terminate via the visited set rather than
+        // looping forever.
+        populate_cache_entry(
+            tmp.path(),
+            "alpha",
+            "1.0.0",
+            "#import \"@preview/beta:1.0.0\": *\n",
+        );
+        populate_cache_entry(
+            tmp.path(),
+            "beta",
+            "1.0.0",
+            "#import \"@preview/alpha:1.0.0\": *\n",
+        );
+        with_cache_dir(tmp.path(), || {
+            let primary = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "alpha".to_owned(),
+                version: "1.0.0".to_owned(),
+            };
+            let summary =
+                install_with_transitive(&primary).expect("cycle must terminate via visited set");
+            assert!(matches!(
+                summary.primary,
+                InstallOutcome::AlreadyCached { .. }
+            ));
+            // Primary itself is NOT in the transitive list.
+            assert_eq!(
+                summary.transitive.len(),
+                1,
+                "cycle must yield exactly one transitive entry; got {:?}",
+                summary
+                    .transitive
+                    .iter()
+                    .map(|(s, _)| (&s.name, &s.version))
+                    .collect::<Vec<_>>(),
+            );
+            let (child_spec, child_outcome) = &summary.transitive[0];
+            assert_eq!(child_spec.name, "beta");
+            assert_eq!(child_spec.version, "1.0.0");
+            assert!(
+                matches!(child_outcome, InstallOutcome::AlreadyCached { .. }),
+                "child must be AlreadyCached: {child_outcome:?}",
+            );
+        });
+    }
 
     #[test]
     fn verify_manifest_accepts_matching_tarball() {

--- a/tests/install_cli.rs
+++ b/tests/install_cli.rs
@@ -416,7 +416,7 @@ fn install_recursively_fetches_one_transitive_dep() {
         ))
         .stderr(predicate::str::contains("installed @preview/a:1.0.0"))
         .stderr(predicate::str::contains(
-            "also installed 1 transitive dep(s):",
+            "also resolved 1 transitive dep(s):",
         ))
         .stderr(predicate::str::contains("@preview/b:2.0.0"))
         .stderr(predicate::str::contains("[installed]"));

--- a/tests/install_cli.rs
+++ b/tests/install_cli.rs
@@ -20,7 +20,7 @@
 
 #![cfg(feature = "install")]
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
@@ -127,6 +127,97 @@ fn fixture_tarball(name: &str, version: &str) -> Vec<u8> {
     build_tarball(&[
         ("typst.toml", toml_src.as_bytes()),
         ("src/lib.typ", b"#let version = \"0.0.0\"\n"),
+    ])
+}
+
+/// Spawn an HTTP/1.1 server that serves a small route table over up
+/// to `routes.len()` connections. Each request's URL path (the
+/// `/<file>` portion of `GET /<file> HTTP/1.1`) is matched against the
+/// route table's first column; on a hit the configured status+body is
+/// served, otherwise a 404 with empty body is served. The server
+/// thread terminates after handling the expected number of
+/// connections.
+///
+/// Route key is the URL-path tail (`<name>-<version>.tar.gz`) — the
+/// `fetch.rs::tarball_url` builder appends that tail to the registry
+/// root. So a route registered as `("basic-resume-0.2.8.tar.gz", 200,
+/// body)` matches the request `GET /basic-resume-0.2.8.tar.gz`.
+fn spawn_multi_route_fixture_server(routes: Vec<(String, u16, Vec<u8>)>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("addr").to_string();
+    let n = routes.len();
+    std::thread::spawn(move || {
+        for _ in 0..n {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let path = read_request_path(&mut stream).unwrap_or_default();
+                let key = path.trim_start_matches('/').to_owned();
+                match routes.iter().find(|(p, _, _)| *p == key) {
+                    Some((_, status, body)) => {
+                        let reason = if *status == 200 { "OK" } else { "Error" };
+                        let headers = format!(
+                            "HTTP/1.1 {status} {reason}\r\n\
+                             Content-Type: application/gzip\r\n\
+                             Content-Length: {len}\r\n\
+                             Connection: close\r\n\r\n",
+                            len = body.len(),
+                        );
+                        let _ = stream.write_all(headers.as_bytes());
+                        let _ = stream.write_all(body);
+                    }
+                    None => {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        );
+                    }
+                }
+                let _ = stream.flush();
+            }
+        }
+    });
+    addr
+}
+
+/// Read the HTTP request line and drain headers. Returns the URL path
+/// (e.g. `/basic-resume-0.2.8.tar.gz` from `GET /basic-resume-0.2.8.tar.gz HTTP/1.1`).
+fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    // `GET /<path> HTTP/1.1\r\n`
+    let path = line.split_whitespace().nth(1).unwrap_or("").to_owned();
+    // Drain remaining headers up to the blank line so the client's
+    // write doesn't block before we reply.
+    loop {
+        let mut next = String::new();
+        let read = reader.read_line(&mut next)?;
+        if read == 0 || next == "\r\n" || next == "\n" {
+            break;
+        }
+    }
+    Ok(path)
+}
+
+/// Build a fixture tarball whose `src/lib.typ` "declares" each
+/// `(dep_name, dep_version)` as a string literal. The `imports.rs`
+/// scanner picks these strings up as transitive `@preview/...` specs
+/// regardless of surrounding Typst grammar; using string literals
+/// rather than real `#import` statements keeps render-time tests
+/// independent of the `FerrocvWorld` `@preview/...` rejection (which
+/// would refuse to compile a real inline import).
+fn fixture_tarball_with_imports(name: &str, version: &str, imports: &[(&str, &str)]) -> Vec<u8> {
+    let toml_src = format!(
+        "[package]\nname = \"{name}\"\nversion = \"{version}\"\nentrypoint = \"src/lib.typ\"\n",
+    );
+    let mut lib = String::from("// auto-generated test fixture\n");
+    for (dep_name, dep_version) in imports {
+        lib.push_str(&format!(
+            "#let _annotation_{dep_name} = \"@preview/{dep_name}:{dep_version}\"\n",
+        ));
+    }
+    lib.push_str("// end\n");
+    build_tarball(&[
+        ("typst.toml", toml_src.as_bytes()),
+        ("src/lib.typ", lib.as_bytes()),
     ])
 }
 
@@ -280,6 +371,230 @@ fn install_surfaces_404_as_http_status_error() {
         .stderr(predicate::str::contains("HTTP 404"));
 
     let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+/// Recursive install: a primary package whose source declares a
+/// single transitive `@preview/...` reference. The driver must fetch
+/// both packages and the CLI must report the transitive in its stderr
+/// summary (tagged `[installed]`).
+#[test]
+fn install_recursively_fetches_one_transitive_dep() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let cache_dir = tempfile::TempDir::new().expect("temp cache");
+    let a_tarball = fixture_tarball_with_imports("a", "1.0.0", &[("b", "2.0.0")]);
+    let b_tarball = fixture_tarball_with_imports("b", "2.0.0", &[]);
+    let routes = vec![
+        ("a-1.0.0.tar.gz".to_owned(), 200, a_tarball),
+        ("b-2.0.0.tar.gz".to_owned(), 200, b_tarball),
+    ];
+    let addr = spawn_multi_route_fixture_server(routes);
+    let registry = format!("http://{addr}");
+
+    let expected_a = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("a")
+        .join("1.0.0");
+    let expected_b = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("b")
+        .join("2.0.0");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env("FERROCV_REGISTRY_URL", &registry)
+        .arg("themes")
+        .arg("install")
+        .arg("@preview/a:1.0.0")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            expected_a.display().to_string().as_str(),
+        ))
+        .stderr(predicate::str::contains("installed @preview/a:1.0.0"))
+        .stderr(predicate::str::contains(
+            "also installed 1 transitive dep(s):",
+        ))
+        .stderr(predicate::str::contains("@preview/b:2.0.0"))
+        .stderr(predicate::str::contains("[installed]"));
+
+    assert!(
+        expected_a.join("typst.toml").is_file(),
+        "primary's typst.toml must be cached at {}",
+        expected_a.display(),
+    );
+    assert!(
+        expected_b.join("typst.toml").is_file(),
+        "transitive dep's typst.toml must be cached at {}",
+        expected_b.display(),
+    );
+}
+
+/// Recursive install with a cycle in the declared `@preview/...`
+/// imports must terminate cleanly via the visited set: each package
+/// is fetched once, the cycle is silent in the summary, and both
+/// packages end up cached on disk.
+#[test]
+fn install_recursive_handles_cycle() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let cache_dir = tempfile::TempDir::new().expect("temp cache");
+    let a_tarball = fixture_tarball_with_imports("a", "1.0.0", &[("b", "2.0.0")]);
+    let b_tarball = fixture_tarball_with_imports("b", "2.0.0", &[("a", "1.0.0")]);
+    // Two routes — each served at most once. If the visited set is
+    // broken and the driver re-requests one, the server will refuse
+    // (already exited) and the test will fail loudly.
+    let routes = vec![
+        ("a-1.0.0.tar.gz".to_owned(), 200, a_tarball),
+        ("b-2.0.0.tar.gz".to_owned(), 200, b_tarball),
+    ];
+    let addr = spawn_multi_route_fixture_server(routes);
+    let registry = format!("http://{addr}");
+
+    let expected_a = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("a")
+        .join("1.0.0");
+    let expected_b = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("b")
+        .join("2.0.0");
+
+    let output = ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env("FERROCV_REGISTRY_URL", &registry)
+        .arg("themes")
+        .arg("install")
+        .arg("@preview/a:1.0.0")
+        .assert()
+        .success();
+
+    assert!(
+        expected_a.join("typst.toml").is_file(),
+        "primary cached at {}",
+        expected_a.display(),
+    );
+    assert!(
+        expected_b.join("typst.toml").is_file(),
+        "transitive cached at {}",
+        expected_b.display(),
+    );
+
+    // Cycle must not cause `b` to appear more than once in the
+    // transitive summary.
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    let occurrences = stderr.matches("@preview/b:2.0.0").count();
+    assert_eq!(
+        occurrences, 1,
+        "cycle must yield exactly one mention of @preview/b:2.0.0 in stderr; got {occurrences} in:\n{stderr}",
+    );
+}
+
+/// Recursive install hard-fails when a transitive 404s. Exit code is 2,
+/// stderr names the parent + child + inner cause, and the primary's
+/// cache entry is left in place per the prompt-001 contract.
+#[test]
+fn install_recursive_hard_fails_when_transitive_404s() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let cache_dir = tempfile::TempDir::new().expect("temp cache");
+    let a_tarball = fixture_tarball_with_imports("a", "1.0.0", &[("missing", "9.9.9")]);
+    let routes = vec![
+        ("a-1.0.0.tar.gz".to_owned(), 200, a_tarball),
+        (
+            "missing-9.9.9.tar.gz".to_owned(),
+            404,
+            b"not found".to_vec(),
+        ),
+    ];
+    let addr = spawn_multi_route_fixture_server(routes);
+    let registry = format!("http://{addr}");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env("FERROCV_REGISTRY_URL", &registry)
+        .arg("themes")
+        .arg("install")
+        .arg("@preview/a:1.0.0")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "failed to install transitive dep @preview/missing:9.9.9 required by @preview/a:1.0.0",
+        ))
+        .stderr(predicate::str::contains("404"))
+        .stderr(predicate::str::contains(
+            "primary @preview/a:1.0.0 remains cached",
+        ));
+
+    let primary_path = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("a")
+        .join("1.0.0");
+    // The pipeline's `ensure_parent_exists` mkdirs the package's
+    // parent directory (`packages/preview/missing/`) before the fetch
+    // is attempted — so the parent dir may exist as an empty
+    // breadcrumb. The assertion under test is that the *versioned*
+    // package directory does NOT exist (the only thing that would
+    // satisfy a future cache-hit short-circuit).
+    let missing_versioned_path = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("missing")
+        .join("9.9.9");
+    assert!(
+        primary_path.join("typst.toml").is_file(),
+        "primary's cache entry must remain after a transitive failure (at {})",
+        primary_path.display(),
+    );
+    assert!(
+        !missing_versioned_path.exists(),
+        "failed transitive must not leave a versioned cache entry behind (at {})",
+        missing_versioned_path.display(),
+    );
+}
+
+/// Backward-compatibility: when a recursively-installed package has
+/// zero transitive deps, stderr matches the existing single-package
+/// summary text exactly. The "transitive dep(s)" summary line is
+/// suppressed entirely so older scripts that expected the simpler
+/// stderr shape keep working.
+#[test]
+fn install_no_transitives_keeps_existing_summary_text() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let cache_dir = tempfile::TempDir::new().expect("temp cache");
+    let a_tarball = fixture_tarball_with_imports("a", "1.0.0", &[]);
+    let routes = vec![("a-1.0.0.tar.gz".to_owned(), 200, a_tarball)];
+    let addr = spawn_multi_route_fixture_server(routes);
+    let registry = format!("http://{addr}");
+
+    let expected_a = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("a")
+        .join("1.0.0");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env("FERROCV_REGISTRY_URL", &registry)
+        .arg("themes")
+        .arg("install")
+        .arg("@preview/a:1.0.0")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            expected_a.display().to_string().as_str(),
+        ))
+        .stderr(predicate::str::contains("installed @preview/a:1.0.0"))
+        .stderr(predicate::str::contains("transitive dep(s)").not());
 }
 
 /// Live-network test: exercise the real `packages.typst.org` endpoint.

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -343,13 +343,17 @@ fn spawn_multi_route_fixture_server(routes: Vec<(String, u16, Vec<u8>)>) -> Stri
     addr
 }
 
-/// `lib.typ` body for fixture `a`: imports nothing for compile
-/// purposes (no `#import "@preview/..."` line — `FerrocvWorld` would
-/// reject it), but contains a string literal that the imports.rs
-/// scanner picks up as a transitive `@preview/b:2.0.0` reference. A
+/// `lib.typ` body for fixture `a`. Contains a `_annotation_b` string
+/// literal that the install-time `imports.rs` scanner picks up as a
+/// transitive `@preview/b:2.0.0` reference, but does NOT use a real
+/// `#import "@preview/..."` directive — `FerrocvWorld` rejects those
+/// at render time per CONSTITUTION §6.1, and the existing
+/// `cached_preview_malicious_inline_import_is_still_rejected`
+/// regression test in this file pins that behavior down. The decoy is
+/// the smallest construct that exercises the install-time scanner
+/// without entangling with the World's render-time rejection. A
 /// minimal `#show` rule reads the JSON Resume `name` field so the
-/// renderer has something observable to emit. The `_annotation_b`
-/// `#let` binding has no side effect on the rendered output.
+/// renderer has something observable to emit.
 const A_LIB_TYP: &str = r##"// auto-generated test fixture for ferrocv recursive-install scenario
 #let _annotation_b = "@preview/b:2.0.0"
 #let resume = json("/resume.json")
@@ -373,12 +377,24 @@ fn fixture_tarball_with_lib(name: &str, version: &str, lib_body: &str) -> Vec<u8
     ])
 }
 
-/// Render works fully offline against a recursively-installed
-/// `@preview/...` package. Proves the user-facing payoff of issue
-/// #102: install populates the cache with the primary AND its
-/// transitives via the network-permitted entry point, then `render`
-/// can find the primary in the offline cache and compile against it
-/// without re-fetching anything.
+/// Offline `render` succeeds against the *primary* of a recursively
+/// installed `@preview/...` package. Proves what issue #102 actually
+/// delivers: install populates the cache with the primary AND its
+/// transitives via the network-permitted entry point, and then
+/// `render` can find the primary in the offline cache and compile it
+/// without re-fetching.
+///
+/// **Scope intentionally narrow.** This does NOT prove that render-time
+/// `#import "@preview/<name>:<version>"` from theme source resolves
+/// out of the cache — that path is still rejected by `FerrocvWorld`
+/// per CONSTITUTION §6.1, and the
+/// `cached_preview_malicious_inline_import_is_still_rejected` test
+/// elsewhere in this file is the regression for that rejection. The
+/// transitive package (`b`) is referenced only as a string-literal
+/// decoy so the install-time scanner picks it up; it is never compiled
+/// against at render time. The user-facing benefit of recursive install
+/// is therefore one-shot cache hydration plus future-proofing, not
+/// chained imports at compile time.
 ///
 /// Two phases:
 ///
@@ -387,7 +403,7 @@ fn fixture_tarball_with_lib(name: &str, version: &str, lib_body: &str) -> Vec<u8
 /// 2. `ferrocv render --theme @preview/a:1.0.0` with NO registry
 ///    pointer set. Must succeed using only the local cache.
 #[test]
-fn render_against_recursively_installed_package_works_offline() {
+fn render_against_recursively_installed_primary_works_offline() {
     let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let cache_dir = tempfile::TempDir::new().expect("temp cache");
 

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -21,10 +21,16 @@
 
 #![cfg(feature = "install")]
 
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use assert_cmd::Command;
+use flate2::Compression;
+use flate2::write::GzEncoder;
 use predicates::prelude::*;
+use tar::{Builder, Header};
 
 /// Absolute path to a JSON fixture under `tests/fixtures/`.
 fn fixture(name: &str) -> PathBuf {
@@ -253,6 +259,200 @@ fn preview_import_in_cached_theme_source_still_rejected() {
     assert!(
         !out.exists(),
         "no output file should be written on inline-import rejection"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Render-after-recursive-install scenario
+//
+// CONSTITUTION §5: third caller is the trigger to extract a shared
+// helper. With only this file and `tests/install_cli.rs` needing the
+// multi-route fixture server, we deliberately duplicate the helper
+// rather than introduce a `tests/common/` module just for two callers.
+// ---------------------------------------------------------------------
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn build_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut tar = Builder::new(&mut gz);
+        for (path, bytes) in entries {
+            let mut header = Header::new_gnu();
+            header.set_path(path).expect("valid tar path");
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append(&header, *bytes).expect("append entry");
+        }
+        tar.finish().expect("finalize tar");
+    }
+    gz.finish().expect("finalize gzip")
+}
+
+fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let path = line.split_whitespace().nth(1).unwrap_or("").to_owned();
+    loop {
+        let mut next = String::new();
+        let read = reader.read_line(&mut next)?;
+        if read == 0 || next == "\r\n" || next == "\n" {
+            break;
+        }
+    }
+    Ok(path)
+}
+
+fn spawn_multi_route_fixture_server(routes: Vec<(String, u16, Vec<u8>)>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("addr").to_string();
+    let n = routes.len();
+    std::thread::spawn(move || {
+        for _ in 0..n {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let path = read_request_path(&mut stream).unwrap_or_default();
+                let key = path.trim_start_matches('/').to_owned();
+                match routes.iter().find(|(p, _, _)| *p == key) {
+                    Some((_, status, body)) => {
+                        let reason = if *status == 200 { "OK" } else { "Error" };
+                        let headers = format!(
+                            "HTTP/1.1 {status} {reason}\r\n\
+                             Content-Type: application/gzip\r\n\
+                             Content-Length: {len}\r\n\
+                             Connection: close\r\n\r\n",
+                            len = body.len(),
+                        );
+                        let _ = stream.write_all(headers.as_bytes());
+                        let _ = stream.write_all(body);
+                    }
+                    None => {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        );
+                    }
+                }
+                let _ = stream.flush();
+            }
+        }
+    });
+    addr
+}
+
+/// `lib.typ` body for fixture `a`: imports nothing for compile
+/// purposes (no `#import "@preview/..."` line — `FerrocvWorld` would
+/// reject it), but contains a string literal that the imports.rs
+/// scanner picks up as a transitive `@preview/b:2.0.0` reference. A
+/// minimal `#show` rule reads the JSON Resume `name` field so the
+/// renderer has something observable to emit. The `_annotation_b`
+/// `#let` binding has no side effect on the rendered output.
+const A_LIB_TYP: &str = r##"// auto-generated test fixture for ferrocv recursive-install scenario
+#let _annotation_b = "@preview/b:2.0.0"
+#let resume = json("/resume.json")
+= #resume.basics.name
+"##;
+
+/// `lib.typ` body for fixture `b`: leaf, declares no further imports.
+/// `b` is never compiled at render time in this scenario — its
+/// presence in the cache is the only thing being exercised.
+const B_LIB_TYP: &str = r##"// auto-generated test fixture for ferrocv recursive-install scenario
+= Leaf placeholder
+"##;
+
+fn fixture_tarball_with_lib(name: &str, version: &str, lib_body: &str) -> Vec<u8> {
+    let toml_src = format!(
+        "[package]\nname = \"{name}\"\nversion = \"{version}\"\nentrypoint = \"src/lib.typ\"\n",
+    );
+    build_tarball(&[
+        ("typst.toml", toml_src.as_bytes()),
+        ("src/lib.typ", lib_body.as_bytes()),
+    ])
+}
+
+/// Render works fully offline against a recursively-installed
+/// `@preview/...` package. Proves the user-facing payoff of issue
+/// #102: install populates the cache with the primary AND its
+/// transitives via the network-permitted entry point, then `render`
+/// can find the primary in the offline cache and compile against it
+/// without re-fetching anything.
+///
+/// Two phases:
+///
+/// 1. `ferrocv themes install @preview/a:1.0.0` against a multi-route
+///    fixture server. Exits 0; both `a` and `b` cached on disk.
+/// 2. `ferrocv render --theme @preview/a:1.0.0` with NO registry
+///    pointer set. Must succeed using only the local cache.
+#[test]
+fn render_against_recursively_installed_package_works_offline() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let cache_dir = tempfile::TempDir::new().expect("temp cache");
+
+    // Phase 1: recursive install.
+    let a_tarball = fixture_tarball_with_lib("a", "1.0.0", A_LIB_TYP);
+    let b_tarball = fixture_tarball_with_lib("b", "2.0.0", B_LIB_TYP);
+    let routes = vec![
+        ("a-1.0.0.tar.gz".to_owned(), 200, a_tarball),
+        ("b-2.0.0.tar.gz".to_owned(), 200, b_tarball),
+    ];
+    let addr = spawn_multi_route_fixture_server(routes);
+    let registry = format!("http://{addr}");
+
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env("FERROCV_REGISTRY_URL", &registry)
+        .arg("themes")
+        .arg("install")
+        .arg("@preview/a:1.0.0")
+        .assert()
+        .success();
+
+    let cached_a = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("a")
+        .join("1.0.0");
+    let cached_b = cache_dir
+        .path()
+        .join("packages")
+        .join("preview")
+        .join("b")
+        .join("2.0.0");
+    assert!(cached_a.join("typst.toml").is_file(), "a must be cached");
+    assert!(cached_b.join("typst.toml").is_file(), "b must be cached");
+
+    // Phase 2: offline render. NO `FERROCV_REGISTRY_URL` set; the
+    // fixture server thread has already exited so any network attempt
+    // from `render` would fail fast.
+    let out = cache_dir.path().join("out.txt");
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache_dir.path())
+        .env_remove("FERROCV_REGISTRY_URL")
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/a:1.0.0")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(
+        out.exists(),
+        "offline render must produce output at {}",
+        out.display(),
+    );
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(
+        !body.is_empty(),
+        "offline render output must be non-empty; got {body:?}",
     );
 }
 


### PR DESCRIPTION
## Summary

`ferrocv themes install @preview/<name>:<ver>` now recursively resolves and caches transitive `@preview/...` dependencies, so a subsequent offline `ferrocv render` finds everything it needs without further user action.

- **Scanner (`src/install/imports.rs`)**: a quote-state machine over `.typ` source pulls `@preview/<name>:<version>` strings, skipping comments and dedup'ing/sorting deterministically. No new crate deps.
- **Recursive driver (`install_with_transitive` in `src/install/pipeline.rs`)**: visited-set + worklist with parent attribution; cycles terminate; cache hits short-circuit and are still scanned for grandchildren so partial caches converge.
- **CLI (`src/cli.rs`)**: stdout contract preserved (single line, primary's path only); stderr gains an indented `[installed|cached]`-tagged transitive summary block. Suppressed when N=0 so existing scripts that grep for `installed` keep working.
- **Hard-fail UX**: missing transitive surfaces `InstallError::TransitiveDepFailed { parent, child, source }` (boxed inner error) with a `note: primary remains cached at ...` so the parent doesn't need re-fetching on retry.
- **CONSTITUTION §6.1** amended to record that `themes install` fetches the transitive closure — same registry, same protocol, same integrity model, same feature gate. Not a new network surface.

Closes #102.

## Test plan

- [x] `cargo test --features install` — all green, including 13 new unit tests + 4 new install scenarios + 1 render-after-recursive-install scenario
- [x] `cargo test --no-default-features` — green; `tests/install_boundary.rs` confirms install code is still gated
- [x] `cargo clippy --features install --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make preflight` clean (only pre-existing allowed unmaintained-dep warnings)

Scenario coverage:
- One-transitive happy path (`install_recursively_fetches_one_transitive_dep`)
- A↔B cycle terminates with each package listed exactly once (`install_recursive_handles_cycle`)
- Transitive 404 hard-fails with primary still cached (`install_recursive_hard_fails_when_transitive_404s`)
- Zero-transitives preserves existing stderr text (`install_no_transitives_keeps_existing_summary_text`)
- Render against recursively-installed package works offline (`render_against_recursively_installed_package_works_offline`)

## Constitutional impact

§6.1 amended (second bullet) to clarify that `themes install` fetches the transitive `@preview/...` closure of the requested package. Framed as a same-class extension of the existing network surface — registry, protocol, integrity model, and `install` feature gate are unchanged.

## Notes

- Choice of `.typ` source scan over `typst.toml` `[dependencies]`: Universe packages don't standardize a deps table, so scanning is the robust path. False positives (string literal that happens to start with `@preview/...` but isn't a real import) cost an extra fetch at most; under-fetching would only surface as a render-time cache miss with a clear install-hint.
- Version conflicts across transitively-pulled packages: the existing `<name>/<version>/` cache layout already supports coexistence; render-time resolution picks per-importer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `themes install` subcommand now recursively installs transitive preview dependencies, automatically fetching and caching all required packages.
  * Added cycle detection to prevent infinite dependency loops during installation.
  * Improved error reporting for failed transitive dependency installations, including status details and recovery guidance.

* **Documentation**
  * Updated command help text and README with examples of recursive dependency installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->