### PR TITLE
Honest framing of install-based vs. vendored adapter paths

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -46,6 +46,74 @@ themes, and native themes do not depend on adapter internals
 guide will land when there's a second native theme to draw the
 pattern from.
 
+## Two ways to use a Typst Universe template
+
+There is one **adapter shape contributors author today**: the
+vendored adapter pattern (the rest of this guide). It is the
+recommended path for any new adapter.
+
+There is one **runtime feature users can reach for** that does not
+require an adapter at all: install-based passthrough. The user runs
+`ferrocv themes install @preview/<name>:<ver>` once, then renders with
+`--theme @preview/<name>:<ver>`. The CLI's resolver materializes the
+cached package and hands it to the same compile pipeline bundled
+themes use; no `assets/themes/<name>/` directory, no `Theme` registry
+entry, no in-tree code at all.
+
+| | Vendored adapter (contributor work) | Install-based passthrough (user only, today) |
+|---|---|---|
+| Default-build availability | yes | no — needs `--features install` |
+| User setup | none — bundled in the binary | `ferrocv themes install @preview/...:<ver>` once |
+| In-tree footprint | `assets/themes/<name>/` + `src/theme.rs` registration + goldens | none |
+| JSON Resume mapping | authored glue (`resume.typ`) | upstream must read `/resume.json` itself |
+| Upstream `@preview/...` imports | patched out at vendor time | **not supported** at render — see Limitations |
+| Upstream-bump diff | re-vendor + re-apply patches | bump version, re-run `themes install` |
+| Selectable via `--theme <bundled-name>` | yes | no — must spell `@preview/<name>:<ver>` |
+
+### When install-based passthrough actually works
+
+The runtime resolver is real (see `tests/render_preview_cli.rs::render_resolves_preview_from_cache`),
+but it only renders a usable resume when **both** of these hold for
+the upstream package:
+
+1. **The package is JSON-Resume-aware out of the box.** The package's
+   own entrypoint must read JSON Resume from `/resume.json` and emit
+   content. There is no glue layer in the install-based path: whatever
+   the package's `entrypoint` does is what gets compiled. Most Typst
+   Universe resume templates expect their own bespoke data shape (a
+   `cv` dict the user fills in), so they will compile to a blank or
+   placeholder document against an arbitrary `resume.json`.
+2. **The package's source contains no `@preview/...` imports.** The
+   `FerrocvWorld` rejects every `@preview/...` import at render time
+   for CONSTITUTION §6.1 reasons (`src/render.rs::source` and
+   `src/render.rs::file`); cache hydration of transitive deps via
+   `themes install` does not change that. A regression test
+   (`tests/render_preview_cli.rs::preview_import_in_cached_theme_source_still_rejected`)
+   pins the rejection.
+
+If either condition fails, the install-based path is not usable for
+that upstream today. Vendor it instead.
+
+### Limitations: the in-tree shim shape is not viable yet
+
+A natural-looking pattern — register a `Theme` whose entrypoint is a
+small ferrocv-authored shim that does
+`#import "@preview/<name>:<ver>": *` and then maps JSON Resume fields
+into the template's API — **does not work today**. The World rejects
+the `@preview/...` import even when the package is in the cache.
+
+This is the gap that would let install-based adapters carry glue (and
+therefore work for upstreams that aren't JSON-Resume-aware, which is
+most of them). It is tracked separately; until that lands, the
+recommendation is unchanged: **for any adapter that needs glue or
+imports `@preview/...` packages, write a vendored adapter** using the
+walkthrough below.
+
+The recursive transitive-install machinery from issue #102 is in
+place precisely so that, once the World learns to resolve cached
+`@preview/...` imports, the cache layer is already populated and
+ready. For now, treat that machinery as future-proofing.
+
 ## Anatomy of an adapter
 
 The repo currently ships four adapters, deliberately picked to
@@ -79,6 +147,11 @@ and the glue continues to work as long as the upstream signatures
 didn't change.
 
 ## Step-by-step: adding a new adapter
+
+This walkthrough is the **vendored adapter** path — the only adapter
+shape contributors author today. See "Two ways to use a Typst Universe
+template" above for why install-based passthrough is a runtime
+feature, not a contributor pattern.
 
 ### 1. Vet the upstream
 


### PR DESCRIPTION
## Summary

Reframes `docs/adapters.md` to honestly describe what the install-based path does today versus the aspirational shape #103 originally proposed.

- New **"Two ways to use a Typst Universe template"** section contrasts the two paths: vendored adapter (contributor work, recommended for general adapters) vs. install-based passthrough (runtime feature, narrow conditions).
- Spells out the actual conditions for install-based passthrough: upstream must read `/resume.json` itself AND have zero `@preview/...` imports. Most Typst Universe resume templates fail one or both.
- **Limitations** subsection: in-tree shim adapters that `#import "@preview/..."` aren't viable until `FerrocvWorld` learns to read transitive imports from the cache. Tracked in #114.
- Vendored walkthrough's intro now recommends it for any adapter that needs glue or imports `@preview/...` packages, until #114 lands.

`VENDORING_CHECKLIST.md` left alone per the issue scope.

## Why this diverges from #103's original scope

The issue proposed an in-tree shim shape that does `#import "@preview/<name>:<ver>": *` and relies on the user having run `themes install`. After tracing the World code and the existing regression tests, that shape doesn't work today — `FerrocvWorld::source` (`src/render.rs:841`) and `::file` (`src/render.rs:861`) reject every `@preview/...` import regardless of cache state, pinned by the `preview_import_in_cached_theme_source_still_rejected` regression. The transitive-install machinery from #102/#110 hydrates the cache but doesn't extend the World; the scope-limit comment on `render_against_recursively_installed_primary_works_offline` (`tests/render_preview_cli.rs:380-397`) is explicit about that.

Full rationale and evidence in the issue thread.

## Implication for #97-#101

All five remaining adapter issues (#97 impressive-impression, #98 moderner-cv, #99 lavandula, #100 cobalt-cv, #101 neat-cv) should be vendored under current conditions, since none of those upstreams are JSON-Resume-aware. Effort labels on those issues remain accurate. When #114 ships, the docs get a third pass and any of those that haven't been picked up yet can revisit shape choice.

Closes #103. Refs #114.

## Test plan

- [x] `make preflight` clean (only pre-existing allowed unmaintained-dep warnings)
- [x] No code changes — pure docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanation of two approaches for using Typst Universe templates
  * Documented when install-based passthrough works and its limitations
  * Clarified the contributor path for vendored adapters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->