### PR TITLE
Ignore local Claude Code state under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /dist
 Cargo.lock.bak
 .prompts
+.claude/settings.local.json
+.claude/worktrees/
 
 # Added by ggshield
 .cache_ggshield


### PR DESCRIPTION
## Summary
- Ignore `.claude/settings.local.json` (per-machine permissions) and `.claude/worktrees/` (ephemeral agent state)
- Follows Anthropic's convention of treating `settings.json` as shareable while keeping `*.local.json` and worktrees out of the repo

## Test plan
- [x] `git status` no longer shows `.claude/` as untracked
- [x] Future shareable additions under `.claude/` (e.g. `settings.json`, `commands/`, `agents/`) remain trackable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude local development files and directories from version control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/ferrocv/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->