### PR TITLE
Resolve cached @preview/... imports from theme source at render time

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -85,13 +85,19 @@ them requires a constitutional amendment, not a feature PR.
   `ferrocv render` and `ferrocv validate` are fully offline. Themes
   ship vendored in-tree (`assets/themes/`) and are baked into the
   binary; the JSON Resume schema is vendored the same way. The
-  embedded Typst `World` actively rejects any `@preview/...` package
-  import rather than fetching it — this rejection is hard and is not
-  relaxed by any feature flag or subcommand. Rendering may read from
-  the local installer cache populated by a prior
-  `ferrocv themes install` (see next bullet); that is a local
-  filesystem read, not a network call, and does not weaken the
-  `render`-is-offline guarantee.
+  embedded Typst `World` never fetches a `@preview/...` package; on
+  cache miss it rejects the import with a structured "package not
+  found" diagnostic. Rendering may read from the local installer cache
+  populated by a prior `ferrocv themes install` (see next bullet); that
+  is a local filesystem read, not a network call, and does not weaken
+  the `render`-is-offline guarantee. The cache-read allowance covers
+  both the primary spec resolved at the CLI boundary and any
+  `@preview/...` imports the Typst World resolves on a cached
+  package's behalf at compile time — a same-class extension of the
+  same local-filesystem-read principle, gated behind the same
+  `install` Cargo feature. Default-features builds do not include the
+  cache reader at all and keep the historical blanket rejection of
+  every `@preview/...` import.
 - **`ferrocv themes install` is the single, enumerated network-permitted
   entry point.** It is an explicit, user-initiated subcommand that
   fetches only from the Typst Universe `@preview` registry over HTTPS

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -60,59 +60,48 @@ cached package and hands it to the same compile pipeline bundled
 themes use; no `assets/themes/<name>/` directory, no `Theme` registry
 entry, no in-tree code at all.
 
-| | Vendored adapter (contributor work) | Install-based passthrough (user only, today) |
-|---|---|---|
-| Default-build availability | yes | no — needs `--features install` |
-| User setup | none — bundled in the binary | `ferrocv themes install @preview/...:<ver>` once |
-| In-tree footprint | `assets/themes/<name>/` + `src/theme.rs` registration + goldens | none |
-| JSON Resume mapping | authored glue (`resume.typ`) | upstream must read `/resume.json` itself |
-| Upstream `@preview/...` imports | patched out at vendor time | **not supported** at render — see Limitations |
-| Upstream-bump diff | re-vendor + re-apply patches | bump version, re-run `themes install` |
-| Selectable via `--theme <bundled-name>` | yes | no — must spell `@preview/<name>:<ver>` |
+There is also a **third shape, available to contributors today**: an
+**in-tree shim adapter** — a bundled `Theme` whose entrypoint is a
+small ferrocv-authored shim that `#import`s the upstream `@preview/...`
+package and maps JSON Resume fields into the upstream's API. The shim
+ships in-tree and is `--features install`-only, since it relies on
+render-time cache resolution. Issue #114 unlocked this shape by
+teaching the World to resolve `@preview/...` imports from the offline
+cache.
+
+| | Vendored adapter (contributor work) | In-tree shim adapter (contributor work, `install`-only) | Install-based passthrough (user only) |
+|---|---|---|---|
+| Default-build availability | yes | no — needs `--features install` | no — needs `--features install` |
+| User setup | none — bundled in the binary | `ferrocv themes install @preview/...:<ver>` once | `ferrocv themes install @preview/...:<ver>` once |
+| In-tree footprint | `assets/themes/<name>/` + `src/theme.rs` registration + goldens | small `resume.typ` shim + `src/theme.rs` registration + goldens | none |
+| JSON Resume mapping | authored glue (`resume.typ`) | authored glue inside the shim | upstream must read `/resume.json` itself |
+| Upstream `@preview/...` imports | patched out at vendor time | resolved at render time from cache | resolved at render time from cache |
+| Upstream-bump diff | re-vendor + re-apply patches | bump version literals in the shim, re-run `themes install` | bump version, re-run `themes install` |
+| Selectable via `--theme <bundled-name>` | yes | yes | no — must spell `@preview/<name>:<ver>` |
 
 ### When install-based passthrough actually works
 
 The runtime resolver is real (see `tests/render_preview_cli.rs::render_resolves_preview_from_cache`),
-but it only renders a usable resume when **both** of these hold for
-the upstream package:
+but it only renders a usable resume when the upstream package is
+**JSON-Resume-aware out of the box**. The package's own entrypoint
+must read JSON Resume from `/resume.json` and emit content. There is
+no glue layer in the install-based path: whatever the package's
+`entrypoint` does is what gets compiled. Most Typst Universe resume
+templates expect their own bespoke data shape (a `cv` dict the user
+fills in), so they will compile to a blank or placeholder document
+against an arbitrary `resume.json`.
 
-1. **The package is JSON-Resume-aware out of the box.** The package's
-   own entrypoint must read JSON Resume from `/resume.json` and emit
-   content. There is no glue layer in the install-based path: whatever
-   the package's `entrypoint` does is what gets compiled. Most Typst
-   Universe resume templates expect their own bespoke data shape (a
-   `cv` dict the user fills in), so they will compile to a blank or
-   placeholder document against an arbitrary `resume.json`.
-2. **The package's source contains no `@preview/...` imports.** The
-   `FerrocvWorld` rejects every `@preview/...` import at render time
-   for CONSTITUTION §6.1 reasons (`src/render.rs::source` and
-   `src/render.rs::file`); cache hydration of transitive deps via
-   `themes install` does not change that. A regression test
-   (`tests/render_preview_cli.rs::preview_import_in_cached_theme_source_still_rejected`)
-   pins the rejection.
+If the upstream is not JSON-Resume-aware, write either a **vendored
+adapter** (default-features available, no `themes install` step) or an
+**in-tree shim adapter** (smaller in-tree footprint, but requires the
+user to run `themes install` once).
 
-If either condition fails, the install-based path is not usable for
-that upstream today. Vendor it instead.
-
-### Limitations: the in-tree shim shape is not viable yet
-
-A natural-looking pattern — register a `Theme` whose entrypoint is a
-small ferrocv-authored shim that does
-`#import "@preview/<name>:<ver>": *` and then maps JSON Resume fields
-into the template's API — **does not work today**. The World rejects
-the `@preview/...` import even when the package is in the cache.
-
-This is the gap that would let install-based adapters carry glue (and
-therefore work for upstreams that aren't JSON-Resume-aware, which is
-most of them). It is tracked separately; until that lands, the
-recommendation is unchanged: **for any adapter that needs glue or
-imports `@preview/...` packages, write a vendored adapter** using the
-walkthrough below.
-
-The recursive transitive-install machinery from issue #102 is in
-place precisely so that, once the World learns to resolve cached
-`@preview/...` imports, the cache layer is already populated and
-ready. For now, treat that machinery as future-proofing.
+Transitive `@preview/...` imports inside the upstream are no longer a
+blocker for either install-based path: render-time resolution of
+cached `@preview/...` imports lands in issue #114, with the regression
+test `uncached_preview_import_in_cached_theme_source_still_rejected`
+pinning the narrowed §6.1 boundary (imports of *uncached* packages
+still reject, with an install hint).
 
 ## Anatomy of an adapter
 
@@ -353,11 +342,15 @@ often they bite:
   `link(x.url)` where `x.url` might be an empty string will die at
   compile. Guard the call itself, not afterward (see
   `assets/themes/fantastic-cv/VENDORING.md` patch rationale).
-- **`@preview/...` imports are rejected by the World.** Even if the
-  package is harmless in isolation, the import triggers a package
-  resolver that the World refuses to implement (CONSTITUTION §6.1).
+- **`@preview/...` imports are rejected by the World in vendored
+  adapters.** Vendored themes are baked into the binary at compile
+  time; nothing runs `themes install` for them, so the cache reader
+  (which the World uses to resolve cached imports — see issue #114)
+  always misses, and the import errors with `package not found`.
   Either remove the import and inline a stub, or pick a different
-  upstream.
+  upstream. **For an in-tree shim adapter**, the `@preview/...` import
+  is the entire point and is expected to work — the user runs
+  `themes install` once and the cache resolves it at render time.
 - **`datetime.today()` returns `None`.** Defaults like
   `date: datetime.today().display(...)` crash on first call. Replace
   with `date: ""` and let the glue pass an explicit value (or accept

--- a/src/package_cache.rs
+++ b/src/package_cache.rs
@@ -23,10 +23,50 @@
 
 use std::path::{Path, PathBuf};
 
+use typst::syntax::VirtualPath;
+
 use crate::install::cache::package_cache_dir;
 use crate::install::manifest::parse_manifest;
 use crate::install::spec::PackageSpec;
 use crate::theme::{OwnedTheme, ThemeResolveError};
+
+/// Map a `(PackageSpec, VirtualPath)` pair to an absolute filesystem
+/// path under the local installer cache.
+///
+/// Used by the render-time `FerrocvWorld` branch that resolves
+/// `@preview/...` imports from cache (issue #114), and unit-tested in
+/// isolation so the path-translation rules stay debuggable.
+///
+/// Returns `None` when the path cannot be constructed for any reason —
+/// either the cache root could not be resolved (e.g. `FERROCV_CACHE_DIR`
+/// is set to the empty string) or the supplied `vpath` carries a
+/// component the cache layer refuses to honor (`ParentDir`, etc.). At
+/// the World layer both shapes degrade to `FileError::Package(NotFound)`,
+/// so collapsing them here keeps the caller's match arms tight.
+///
+/// # Path-traversal defense
+///
+/// Typst normalizes virtual paths internally, so a `..` component
+/// reaching this function would be a Typst bug rather than a hostile
+/// input. We still reject anything other than `Normal` and `CurDir`
+/// components as defense-in-depth — the cache lives under the user's
+/// `~/.cache` (or `FERROCV_CACHE_DIR`) and our invariants there hold
+/// only if every render-time read stays inside the requested package
+/// directory.
+pub(crate) fn package_file_path(spec: &PackageSpec, vpath: &VirtualPath) -> Option<PathBuf> {
+    if spec.namespace != "preview" {
+        return None;
+    }
+    let cache_dir = package_cache_dir(&spec.name, &spec.version).ok()?;
+    let relative = vpath.as_rootless_path();
+    for component in relative.components() {
+        match component {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    Some(cache_dir.join(relative))
+}
 
 /// Read every theme file in a cached package's directory tree and
 /// assemble an [`OwnedTheme`] anchored at the package's manifest
@@ -431,5 +471,78 @@ mod tests {
                 "expected PreviewCacheCorrupt; got: {err:?}",
             );
         });
+    }
+
+    #[test]
+    fn package_file_path_happy_path_joins_under_cache_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "demo".to_owned(),
+                version: "1.2.3".to_owned(),
+            };
+            let vpath = VirtualPath::new("/src/lib.typ");
+            let path = package_file_path(&spec, &vpath)
+                .expect("path must resolve under populated cache root");
+            let expected = tmp.path().join("packages/preview/demo/1.2.3/src/lib.typ");
+            assert_eq!(path, expected);
+        });
+    }
+
+    #[test]
+    fn package_file_path_root_vpath_is_cache_dir_itself() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "preview".to_owned(),
+                name: "demo".to_owned(),
+                version: "1.2.3".to_owned(),
+            };
+            let vpath = VirtualPath::new("/");
+            let path = package_file_path(&spec, &vpath)
+                .expect("root vpath must still resolve to the cache dir");
+            let expected = tmp.path().join("packages/preview/demo/1.2.3");
+            assert_eq!(path, expected);
+        });
+    }
+
+    #[test]
+    fn package_file_path_rejects_non_preview_namespace() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        with_cache_dir(tmp.path(), || {
+            let spec = PackageSpec {
+                namespace: "local".to_owned(),
+                name: "x".to_owned(),
+                version: "1.0".to_owned(),
+            };
+            let vpath = VirtualPath::new("/lib.typ");
+            assert!(
+                package_file_path(&spec, &vpath).is_none(),
+                "only @preview/ namespace is resolvable from cache",
+            );
+        });
+    }
+
+    #[test]
+    fn package_file_path_returns_none_when_cache_root_unresolved() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = EnvGuard {
+            prior: std::env::var("FERROCV_CACHE_DIR").ok(),
+        };
+        // SAFETY: serialized via ENV_LOCK above.
+        unsafe {
+            std::env::set_var("FERROCV_CACHE_DIR", "");
+        }
+        let spec = PackageSpec {
+            namespace: "preview".to_owned(),
+            name: "demo".to_owned(),
+            version: "1.0.0".to_owned(),
+        };
+        let vpath = VirtualPath::new("/lib.typ");
+        assert!(
+            package_file_path(&spec, &vpath).is_none(),
+            "empty FERROCV_CACHE_DIR must collapse to None",
+        );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -35,15 +35,20 @@
 //!   `std::process::Command`, no shelling out to the `typst` CLI,
 //!   ever.
 //! - **§6.1 — No network calls at render time.** The [`FerrocvWorld`]
-//!   does not implement a package resolver. Any `FileId` carrying a
-//!   `PackageSpec` (i.e. `@preview/...` imports) returns
-//!   [`FileError::Package(PackageError::NotFound(_))`]. There is no
-//!   code path by which Typst can reach the network from inside
-//!   `compile_pdf`, `compile_theme`, `compile_text`, or
-//!   `compile_html`. HTML compilation reuses the same World and the
-//!   same `source`/`file` implementations, so the guarantee applies
-//!   uniformly. Tests in `tests/render.rs` enforce this for both PDF
-//!   and HTML paths.
+//!   never fetches a package. Under the `install` Cargo feature, an
+//!   `@preview/...` `FileId` is resolved from the local installer
+//!   cache populated by a prior `ferrocv themes install` — a local
+//!   filesystem read, not a network call (CONSTITUTION §6.1
+//!   same-class extension; see [`resolve_package_file`]). On cache
+//!   miss the World returns [`FileError::Package(PackageError::NotFound(_))`].
+//!   Default-features builds do not compile in the cache reader and
+//!   keep the historical blanket rejection. There is no code path by
+//!   which Typst can reach the network from inside `compile_pdf`,
+//!   `compile_theme`, `compile_text`, or `compile_html`. HTML
+//!   compilation reuses the same World and the same `source`/`file`
+//!   implementations, so the guarantee applies uniformly. Tests in
+//!   `tests/render.rs` and `tests/install_boundary.rs` enforce this
+//!   for both feature shapes and both compile targets.
 //! - **§6.4 — Themes run under Typst's native sandbox, nothing more.**
 //!   We do not add filesystem-wide access, shell-escape, or any
 //!   custom capabilities. The World exposes exactly the virtual
@@ -604,11 +609,37 @@ where
 {
     let diagnostics: Vec<RenderDiagnostic> = diags
         .into_iter()
-        .map(|d| RenderDiagnostic {
-            message: d.message_string(),
+        .map(|d| {
+            let mut message = d.message_string();
+            // When Typst reports "package not found" for an `@preview/...`
+            // spec, append the same actionable install hint the
+            // resolver-time `ThemeResolveError::PreviewCacheMiss` variant
+            // surfaces. The detection is a substring match against
+            // Typst's canonical "package not found (searched for ...)"
+            // format; that string is part of the upstream `PackageError`
+            // Display impl, so it is stable across `ferrocv` versions
+            // bound to a single typst minor. If upstream rewords it the
+            // hint silently disappears — failing open rather than
+            // emitting a misleading nudge.
+            if let Some(spec) = extract_preview_spec_from_package_not_found(&message) {
+                message.push_str(&format!(". Run: ferrocv themes install {spec}"));
+            }
+            RenderDiagnostic { message }
         })
         .collect();
     RenderError { diagnostics }
+}
+
+/// If `message` is Typst's canonical "package not found (searched for
+/// <spec>)" diagnostic and `<spec>` is an `@preview/...` package,
+/// return the spec verbatim. Returns `None` for any other shape, which
+/// includes non-preview namespaces (we only ship resolution for
+/// `@preview/` in v1) and rewordings of the upstream message.
+fn extract_preview_spec_from_package_not_found(message: &str) -> Option<&str> {
+    let prefix = "package not found (searched for ";
+    let after = message.strip_prefix(prefix)?;
+    let spec = after.strip_suffix(')')?;
+    spec.starts_with("@preview/").then_some(spec)
 }
 
 /// Helper trait so we can accept either an owned or borrowed
@@ -819,6 +850,89 @@ fn shared_fonts() -> &'static (LazyHash<FontBook>, Vec<Font>) {
     })
 }
 
+/// Resolve a `@preview/<name>:<version>` `FileId` from the local
+/// installer cache, returning the file's bytes.
+///
+/// Issue #114: prior to this branch, `FerrocvWorld::source` / `::file`
+/// unconditionally rejected every package-rooted `FileId` with
+/// `FileError::Package(NotFound)`. That kept the render path offline but
+/// also broke any cached upstream package whose source contains a real
+/// `#import "@preview/<helper>:<ver>"` directive — including the
+/// recursive-install cache hydration that issue #102 already populates.
+///
+/// Under the `install` Cargo feature, this function reads the requested
+/// file from the cache directory populated by `ferrocv themes install`.
+/// CONSTITUTION §6.1: the cache is a local filesystem read source, not a
+/// network call; we do not import the network-capable installer module
+/// even on cache miss.
+///
+/// Under default features the cache reader is not compiled in, so the
+/// function preserves the historical blanket rejection and `themes
+/// install` is unreachable to begin with.
+///
+/// # Error shape
+///
+/// - Cache directory does not exist: `FileError::Package(PackageError::
+///   NotFound(spec))`. The render diagnostic formatter detects this
+///   exact shape and appends a `ferrocv themes install <spec>` hint.
+/// - File inside the cached package does not exist (e.g. the upstream's
+///   manifest entrypoint is wrong, or a relative import names a missing
+///   sibling): `FileError::NotFound(vpath)`.
+/// - Filesystem IO failure (permissions, etc.): mapped via
+///   `FileError::from_io`.
+#[cfg(feature = "install")]
+fn resolve_package_file(
+    spec: &typst::syntax::package::PackageSpec,
+    vpath: &VirtualPath,
+) -> FileResult<Vec<u8>> {
+    // Bridge from Typst's PackageSpec (EcoString fields, struct
+    // PackageVersion) into our installer-side PackageSpec (String
+    // fields, semver-as-string). The Display impl on Typst's
+    // PackageVersion emits "major.minor.patch" — the exact shape our
+    // cache layout uses.
+    let our_spec = crate::install::spec::PackageSpec {
+        namespace: spec.namespace.to_string(),
+        name: spec.name.to_string(),
+        version: spec.version.to_string(),
+    };
+    // Reject any non-preview namespace up front. v1 only ships
+    // resolution for `@preview/...`; surfacing the rejection as
+    // `Package(NotFound)` keeps the diagnostic shape consistent.
+    if our_spec.namespace != "preview" {
+        return Err(FileError::Package(PackageError::NotFound(spec.clone())));
+    }
+    let fs_path = crate::package_cache::package_file_path(&our_spec, vpath)
+        .ok_or_else(|| FileError::Package(PackageError::NotFound(spec.clone())))?;
+    // If the cache directory itself is absent, surface a structured
+    // "package not found" — the user needs to run `themes install`.
+    // Distinguishing this from a missing inner file is important: the
+    // former implies "package is not on disk at all", the latter
+    // implies "package is here but malformed", and the render
+    // diagnostic formatter only appends the install hint for the
+    // former.
+    let cache_dir =
+        match crate::install::cache::package_cache_dir(&our_spec.name, &our_spec.version) {
+            Ok(p) => p,
+            Err(_) => return Err(FileError::Package(PackageError::NotFound(spec.clone()))),
+        };
+    if !cache_dir.is_dir() {
+        return Err(FileError::Package(PackageError::NotFound(spec.clone())));
+    }
+    std::fs::read(&fs_path).map_err(|err| FileError::from_io(err, &fs_path))
+}
+
+/// Default-features stub: every package-rooted FileId is rejected at
+/// the World layer, exactly as before issue #114. The cache reader
+/// (`crate::package_cache`) is not compiled in, so there is no fallback
+/// path to exercise.
+#[cfg(not(feature = "install"))]
+fn resolve_package_file(
+    spec: &typst::syntax::package::PackageSpec,
+    _vpath: &VirtualPath,
+) -> FileResult<Vec<u8>> {
+    Err(FileError::Package(PackageError::NotFound(spec.clone())))
+}
+
 impl World for FerrocvWorld {
     fn library(&self) -> &LazyHash<Library> {
         shared_library()
@@ -836,10 +950,15 @@ impl World for FerrocvWorld {
         if id == self.entrypoint {
             return Ok(self.entrypoint_source.clone());
         }
-        // §6.1: package-rooted imports are rejected at the World
-        // layer. No package resolver, no network call.
+        // Package-rooted imports: under the `install` Cargo feature,
+        // resolve `@preview/...` FileIds from the local installer cache
+        // (issue #114, CONSTITUTION §6.1 same-class extension). Under
+        // default features the cache reader is not compiled in, so we
+        // keep the blanket rejection.
         if let Some(spec) = id.package() {
-            return Err(FileError::Package(PackageError::NotFound(spec.clone())));
+            let bytes = resolve_package_file(spec, id.vpath())?;
+            let text = std::str::from_utf8(&bytes).map_err(|_| FileError::InvalidUtf8)?;
+            return Ok(Source::new(id, text.to_owned()));
         }
         // Theme files: parse on demand. Caching is deferred (§5) —
         // a fresh `Source` per lookup is cheap enough for Phase 1.
@@ -855,11 +974,13 @@ impl World for FerrocvWorld {
         if id == self.resume_id {
             return Ok(self.resume_bytes.clone());
         }
-        // §6.1: same package-rejection rule as `source`. Anything
-        // claiming to be inside a `@preview/...` package is a network
-        // request we refuse to make.
+        // Package-rooted imports: mirror the `source` branch so the
+        // manifest read (`world.file(@preview/...:typst.toml)`) and any
+        // raw `read()` calls inside a package resolve from the same
+        // local cache the source lookup uses.
         if let Some(spec) = id.package() {
-            return Err(FileError::Package(PackageError::NotFound(spec.clone())));
+            let bytes = resolve_package_file(spec, id.vpath())?;
+            return Ok(Bytes::new(bytes));
         }
         if let Some(bytes) = self.theme_files.get(&id) {
             return Ok(bytes.clone());
@@ -957,6 +1078,33 @@ mod tests {
         assert_eq!(
             out, "",
             "empty document must extract to empty string; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn preview_spec_extractor_matches_canonical_message() {
+        let msg = "package not found (searched for @preview/basic-resume:0.2.8)";
+        assert_eq!(
+            extract_preview_spec_from_package_not_found(msg),
+            Some("@preview/basic-resume:0.2.8"),
+        );
+    }
+
+    #[test]
+    fn preview_spec_extractor_rejects_non_preview_namespace() {
+        let msg = "package not found (searched for @local/mine:1.0.0)";
+        assert!(
+            extract_preview_spec_from_package_not_found(msg).is_none(),
+            "v1 only surfaces install hints for @preview/ specs",
+        );
+    }
+
+    #[test]
+    fn preview_spec_extractor_rejects_unrelated_messages() {
+        assert!(extract_preview_spec_from_package_not_found("").is_none());
+        assert!(
+            extract_preview_spec_from_package_not_found("file not found (searched at /foo)")
+                .is_none()
         );
     }
 }

--- a/tests/install_boundary.rs
+++ b/tests/install_boundary.rs
@@ -56,4 +56,61 @@ mod install_feature_off {
         // nothing in this module references `ferrocv::install`, so
         // the default build cannot link against it.
     }
+
+    /// Issue #114 boundary check: even when a theme source file
+    /// contains a real `#import "@preview/..."`, the default-features
+    /// World still rejects it. The cache reader added in #114 is
+    /// `#[cfg(feature = "install")]`, so the no-install fallback
+    /// inside `resolve_package_file` preserves the historical blanket
+    /// rejection. This pins the "no network at render time" guarantee
+    /// at the *code* level (the no-network feature flag enforces it at
+    /// the *dependency* level).
+    #[test]
+    fn render_rejects_preview_imports_even_with_cache_dir_set() {
+        use assert_cmd::Command;
+        use predicates::prelude::*;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // Local-path theme with an inline `@preview/...` import.
+        let theme_path = tmp.path().join("local-theme.typ");
+        std::fs::write(
+            &theme_path,
+            "#import \"@preview/some-pkg:1.0.0\": *\n\
+             #let resume = json(\"/resume.json\")\n\
+             = #resume.basics.name\n",
+        )
+        .expect("write theme");
+
+        // Minimal valid resume.
+        let resume_path = tmp.path().join("resume.json");
+        std::fs::write(
+            &resume_path,
+            "{\"basics\":{\"name\":\"Test\"},\"$schema\":\"https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json\"}",
+        )
+        .expect("write resume");
+
+        let out = tmp.path().join("out.pdf");
+        Command::cargo_bin("ferrocv")
+            .expect("ferrocv binary")
+            // Even setting FERROCV_CACHE_DIR has no effect under
+            // default features — the cache reader is not linked.
+            .env("FERROCV_CACHE_DIR", tmp.path())
+            .arg("render")
+            .arg(&resume_path)
+            .arg("--theme")
+            .arg(&theme_path)
+            .arg("--format")
+            .arg("pdf")
+            .arg("--output")
+            .arg(&out)
+            .assert()
+            .code(2)
+            .stderr(predicate::str::contains("@preview/some-pkg:1.0.0"))
+            .stderr(predicate::str::contains("package not found"));
+
+        assert!(
+            !out.exists(),
+            "default build must not produce output when theme imports @preview/...",
+        );
+    }
 }

--- a/tests/render_preview_cli.rs
+++ b/tests/render_preview_cli.rs
@@ -14,10 +14,15 @@
 //!   compiles the package against the standard test resume.
 //! - Cache miss: with an empty tempdir as the cache, the same render
 //!   exits 2 with a stderr message pointing at `ferrocv themes install`.
-//! - Inline-import regression: a cached package whose Typst source
-//!   does `#import "@preview/cetz:0.2.0": *"` still fails to compile,
-//!   proving CONSTITUTION §6.1 inline-import rejection survives
-//!   Stage C's pre-`World` resolver.
+//! - Uncached-transitive regression (issue #114 retighten): a cached
+//!   package whose Typst source does `#import "@preview/cetz:0.2.0"`,
+//!   where `cetz` is **not** in the cache, exits 2 with an install
+//!   hint. CONSTITUTION §6.1 rejection narrowed to "package not in
+//!   cache" instead of "any package import"; cached transitives now
+//!   resolve via the World branch added in #114.
+//! - Cached transitive resolution (issue #114): a primary whose source
+//!   has a real `#import "@preview/helper:1.0.0"` resolves the helper
+//!   from cache and the rendered output reflects the helper's exports.
 
 #![cfg(feature = "install")]
 
@@ -214,14 +219,19 @@ fn render_preview_cache_miss_exits_two_with_install_hint() {
     );
 }
 
-/// CONSTITUTION §6.1 inline-import regression: even with the
-/// surrounding theme resolved from the offline cache, an inline
-/// `#import "@preview/..."` inside that theme's source still triggers
-/// `FerrocvWorld::source` / `file` package rejection. The render
-/// fails to compile (exit 2) with a diagnostic that names the
-/// rejected package and signals a package-resolution failure.
+/// Issue #114 retightened regression: post-#114, render-time
+/// `@preview/...` imports resolve from the local cache when the
+/// requested package is present. The §6.1 rejection survives, just
+/// narrower: imports of packages **not in cache** still fail with a
+/// structured "package not found" diagnostic plus an install hint that
+/// names the missing spec.
+///
+/// This pins (a) that the World does not invent a network fetch path
+/// on cache miss, and (b) that the rendered diagnostic carries the
+/// actionable `ferrocv themes install @preview/<name>:<ver>` follow-up
+/// the resolver-time path already surfaces for the *primary* spec.
 #[test]
-fn preview_import_in_cached_theme_source_still_rejected() {
+fn uncached_preview_import_in_cached_theme_source_still_rejected() {
     let cache = tempfile::TempDir::new().expect("tempdir cache");
     stage_cached_package(
         cache.path(),
@@ -232,15 +242,11 @@ fn preview_import_in_cached_theme_source_still_rejected() {
     let out = cache.path().join("out.pdf");
 
     // The fixture's `src/lib.typ` does `#import "@preview/cetz:0.2.0":
-    // *"`. The diagnostic from `FerrocvWorld`'s package rejection
-    // path must (a) name `cetz` (the rejected import — deterministic
-    // per the fixture) AND (b) carry a package-resolution signal
-    // ("package" or "not found"). The conjunction is strictly
-    // narrower than the previous OR-over-loose-phrases predicate,
-    // which any compile error could satisfy — a regression that
-    // broke World-layer rejection but still failed for some other
-    // reason (Typst syntax error in the fixture, unrelated panic)
-    // would have passed silently.
+    // *"`. `cetz` is intentionally NOT staged in the cache, so the new
+    // World branch falls through to the same `Package(NotFound)`
+    // rejection. The diagnostic must (a) name the missing spec, (b)
+    // carry the "package not found" signal, and (c) include the
+    // install hint added by the render-diagnostic formatter.
     ferrocv()
         .env("FERROCV_CACHE_DIR", cache.path())
         .arg("render")
@@ -253,12 +259,90 @@ fn preview_import_in_cached_theme_source_still_rejected() {
         .arg(&out)
         .assert()
         .code(2)
-        .stderr(predicate::str::contains("cetz"))
-        .stderr(predicate::str::contains("package").or(predicate::str::contains("not found")));
+        .stderr(predicate::str::contains("@preview/cetz:0.2.0"))
+        .stderr(predicate::str::contains("package not found"))
+        .stderr(predicate::str::contains(
+            "ferrocv themes install @preview/cetz:0.2.0",
+        ));
 
     assert!(
         !out.exists(),
-        "no output file should be written on inline-import rejection"
+        "no output file should be written on uncached-import rejection"
+    );
+}
+
+/// Issue #114 positive scenario: a cached primary whose source does a
+/// real `#import "@preview/transitive:1.0.0"` resolves the helper from
+/// the same offline cache, the import succeeds, and the rendered text
+/// reflects the helper's exported symbol.
+///
+/// Pre-stages both packages directly (no install round-trip) so the
+/// test stays focused on the render-time World branch. The companion
+/// `render_against_recursively_installed_primary_uses_real_import`
+/// scenario below covers the install → render flow end-to-end.
+#[test]
+fn cached_preview_transitive_import_resolves_from_cache() {
+    let cache = tempfile::TempDir::new().expect("tempdir cache");
+
+    // Helper: exports a single string symbol the primary's source
+    // splices into the rendered output, so the assertion can prove the
+    // import actually executed (rather than the primary having silently
+    // skipped it).
+    let helper_root = cache.path().join("packages/preview/cv-helper/1.0.0");
+    std::fs::create_dir_all(helper_root.join("src")).expect("mkdir helper");
+    std::fs::write(
+        helper_root.join("typst.toml"),
+        "[package]\nname = \"cv-helper\"\nversion = \"1.0.0\"\nentrypoint = \"src/lib.typ\"\n",
+    )
+    .expect("write helper manifest");
+    std::fs::write(
+        helper_root.join("src/lib.typ"),
+        "#let banner = \"HELPER-EXPORT-OK\"\n",
+    )
+    .expect("write helper lib");
+
+    // Primary: imports the helper and emits the banner alongside the
+    // resume name.
+    let primary_root = cache.path().join("packages/preview/cv-with-helper/1.0.0");
+    std::fs::create_dir_all(primary_root.join("src")).expect("mkdir primary");
+    std::fs::write(
+        primary_root.join("typst.toml"),
+        "[package]\nname = \"cv-with-helper\"\nversion = \"1.0.0\"\nentrypoint = \"src/lib.typ\"\n",
+    )
+    .expect("write primary manifest");
+    std::fs::write(
+        primary_root.join("src/lib.typ"),
+        "#import \"@preview/cv-helper:1.0.0\": banner\n\
+         #let resume = json(\"/resume.json\")\n\
+         = #resume.basics.name\n\
+         #banner\n",
+    )
+    .expect("write primary lib");
+
+    let out = cache.path().join("out.txt");
+    ferrocv()
+        .env("FERROCV_CACHE_DIR", cache.path())
+        .arg("render")
+        .arg(fixture("render_full"))
+        .arg("--theme")
+        .arg("@preview/cv-with-helper:1.0.0")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+
+    assert!(out.exists(), "output file must exist at {}", out.display());
+    let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
+    assert!(
+        body.contains("HELPER-EXPORT-OK"),
+        "rendered text must contain the helper's exported banner; got: {body:?}"
+    );
+    assert!(
+        body.contains("Ada Lovelace"),
+        "rendered text must contain the resume name; got: {body:?}"
     );
 }
 
@@ -343,28 +427,28 @@ fn spawn_multi_route_fixture_server(routes: Vec<(String, u16, Vec<u8>)>) -> Stri
     addr
 }
 
-/// `lib.typ` body for fixture `a`. Contains a `_annotation_b` string
-/// literal that the install-time `imports.rs` scanner picks up as a
-/// transitive `@preview/b:2.0.0` reference, but does NOT use a real
-/// `#import "@preview/..."` directive — `FerrocvWorld` rejects those
-/// at render time per CONSTITUTION §6.1, and the existing
-/// `cached_preview_malicious_inline_import_is_still_rejected`
-/// regression test in this file pins that behavior down. The decoy is
-/// the smallest construct that exercises the install-time scanner
-/// without entangling with the World's render-time rejection. A
-/// minimal `#show` rule reads the JSON Resume `name` field so the
-/// renderer has something observable to emit.
+/// `lib.typ` body for fixture `a`. Issue #114 unlocked render-time
+/// resolution of `@preview/...` imports from the offline cache, so
+/// this fixture now uses a **real** `#import` rather than a
+/// string-literal decoy. The install-time `imports.rs` scanner still
+/// picks it up (it parses `#import "@preview/..."` directives, not
+/// just string literals); the render-time `FerrocvWorld` branch added
+/// in #114 resolves the import from cache once `b` has been hydrated
+/// by `themes install`. The exported `b_banner` symbol gives the
+/// scenario test something concrete to assert against.
 const A_LIB_TYP: &str = r##"// auto-generated test fixture for ferrocv recursive-install scenario
-#let _annotation_b = "@preview/b:2.0.0"
+#import "@preview/b:2.0.0": b_banner
 #let resume = json("/resume.json")
 = #resume.basics.name
+#b_banner
 "##;
 
-/// `lib.typ` body for fixture `b`: leaf, declares no further imports.
-/// `b` is never compiled at render time in this scenario — its
-/// presence in the cache is the only thing being exercised.
+/// `lib.typ` body for fixture `b`: leaf, no further imports. Exports a
+/// banner string the primary splices into the rendered output so the
+/// install → render assertion can prove the transitive import actually
+/// executed (rather than the primary having silently elided it).
 const B_LIB_TYP: &str = r##"// auto-generated test fixture for ferrocv recursive-install scenario
-= Leaf placeholder
+#let b_banner = "TRANSITIVE-INSTALL-RENDER-OK"
 "##;
 
 fn fixture_tarball_with_lib(name: &str, version: &str, lib_body: &str) -> Vec<u8> {
@@ -377,33 +461,28 @@ fn fixture_tarball_with_lib(name: &str, version: &str, lib_body: &str) -> Vec<u8
     ])
 }
 
-/// Offline `render` succeeds against the *primary* of a recursively
-/// installed `@preview/...` package. Proves what issue #102 actually
-/// delivers: install populates the cache with the primary AND its
-/// transitives via the network-permitted entry point, and then
-/// `render` can find the primary in the offline cache and compile it
-/// without re-fetching.
+/// Offline `render` succeeds against a recursively installed primary
+/// that imports a transitive helper at render time. Issue #114 broadened
+/// the user-facing benefit of recursive install: the install step
+/// hydrates primary + transitives in one network-permitted invocation,
+/// and the render-time World resolves the real `@preview/...` import
+/// from cache — no re-fetch, no separate user step per dep.
 ///
-/// **Scope intentionally narrow.** This does NOT prove that render-time
-/// `#import "@preview/<name>:<version>"` from theme source resolves
-/// out of the cache — that path is still rejected by `FerrocvWorld`
-/// per CONSTITUTION §6.1, and the
-/// `cached_preview_malicious_inline_import_is_still_rejected` test
-/// elsewhere in this file is the regression for that rejection. The
-/// transitive package (`b`) is referenced only as a string-literal
-/// decoy so the install-time scanner picks it up; it is never compiled
-/// against at render time. The user-facing benefit of recursive install
-/// is therefore one-shot cache hydration plus future-proofing, not
-/// chained imports at compile time.
+/// The fixture `a` does a **real** `#import "@preview/b:2.0.0": b_banner`
+/// (post-#114, no longer a string-literal decoy) and emits `b_banner`
+/// inline. The assertion proves both the cache hydration **and** the
+/// render-time import resolution: if either failed, the banner would be
+/// absent from the rendered text.
 ///
 /// Two phases:
 ///
 /// 1. `ferrocv themes install @preview/a:1.0.0` against a multi-route
 ///    fixture server. Exits 0; both `a` and `b` cached on disk.
 /// 2. `ferrocv render --theme @preview/a:1.0.0` with NO registry
-///    pointer set. Must succeed using only the local cache.
+///    pointer set. Must succeed using only the local cache, with the
+///    rendered text containing the helper's exported banner.
 #[test]
-fn render_against_recursively_installed_primary_works_offline() {
+fn render_against_recursively_installed_primary_uses_real_import() {
     let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let cache_dir = tempfile::TempDir::new().expect("temp cache");
 
@@ -467,8 +546,8 @@ fn render_against_recursively_installed_primary_works_offline() {
     );
     let body = std::fs::read_to_string(&out).expect("text output must be UTF-8");
     assert!(
-        !body.is_empty(),
-        "offline render output must be non-empty; got {body:?}",
+        body.contains("TRANSITIVE-INSTALL-RENDER-OK"),
+        "render-time @preview/b:2.0.0 import must resolve from cache and surface b_banner in output; got: {body:?}",
     );
 }
 


### PR DESCRIPTION
## Summary

- `FerrocvWorld::source` / `::file` now resolve `@preview/...` `FileId`s from the local installer cache when the `install` feature is on (issue #114). Cache misses still reject with a structured "package not found" diagnostic plus an actionable `ferrocv themes install <spec>` hint.
- Default-features builds keep the historical blanket rejection — the cache reader is `#[cfg(feature = "install")]`-gated and the no-install fallback in `resolve_package_file` rejects unconditionally. New `tests/install_boundary.rs` assertion pins this.
- CONSTITUTION §6.1 amended in place with same-class-extension language; `docs/adapters.md` updated to document the third adapter shape (in-tree shim adapter) this change unlocks.

## What this unlocks

Two adapter shapes that issue #102's recursive install already hydrated the cache for:

1. **Install-based passthrough** for upstreams with `@preview/...` helpers (icons, fontawesome, etc.) — previously this errored at render even after a successful `themes install`.
2. **In-tree shim adapters** — a small ferrocv-authored `Theme` whose entrypoint `#import`s `@preview/<name>:<ver>` and maps JSON Resume fields into the upstream's API. Issue #103's original premise.

The recursive-install scenario test (`render_against_recursively_installed_primary_uses_real_import`) was converted from a string-literal decoy to a real `#import "@preview/b:2.0.0": b_banner` and now asserts the helper's exported banner appears in the rendered output — proving the full install → render flow including transitive resolution.

## Implementation notes

- New pure helper `package_file_path(&PackageSpec, &VirtualPath) -> Option<PathBuf>` in `src/package_cache.rs` maps a typst `FileId` to a filesystem path under the cache, with path-traversal defense.
- The World's new branch calls that helper, then `std::fs::read(...)`. Stateless reads per `FerrocvWorld` (CONSTITUTION §5: simple now, iterate later) — Typst calls `source`/`file` a handful of times per FileId per compile, no per-World cache layer needed yet.
- Render-diagnostic formatter detects Typst's canonical `package not found (searched for @preview/...)` message and appends the install hint. Failing open (no hint emitted) if upstream ever rewords the message.

## Test plan

- [x] `make preflight` clean (fmt-check, clippy, all-features test suite, deny, audit, typos, no-network-default boundary spot-check).
- [x] New unit tests cover `package_file_path` (happy path, root-vpath, non-preview namespace rejection, cache-root-unresolved) and the diagnostic extractor.
- [x] New scenario test `cached_preview_transitive_import_resolves_from_cache` asserts a primary's real `#import "@preview/cv-helper:1.0.0"` resolves out of cache and surfaces the helper's exported symbol in rendered output.
- [x] Retightened `uncached_preview_import_in_cached_theme_source_still_rejected` proves uncached imports still reject with the install hint.
- [x] Default-features assertion in `tests/install_boundary.rs` pins that the new World branch is feature-gated out.

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview packages can now be resolved from a local cache during rendering.

* **Documentation**
  * Clarified offline guarantees and preview package import handling.
  * Added guidance on in-tree adapter workflows.
  * Enhanced error messages with installation hints for missing packages.

* **Tests**
  * Added coverage for offline preview package rendering scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/ferrocv/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->