### PR TITLE
Add label sync workflow and JSON source of truth

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,39 @@
+[
+  { "name": "bug", "color": "d73a4a", "description": "Something isn't working" },
+  { "name": "documentation", "color": "0075ca", "description": "Improvements or additions to documentation" },
+  { "name": "duplicate", "color": "cfd3d7", "description": "This issue or pull request already exists" },
+  { "name": "enhancement", "color": "a2eeef", "description": "New feature or request" },
+  { "name": "good first issue", "color": "7057ff", "description": "Good for newcomers" },
+  { "name": "help wanted", "color": "008672", "description": "Extra attention is needed" },
+  { "name": "invalid", "color": "e4e669", "description": "This doesn't seem right" },
+  { "name": "question", "color": "d876e3", "description": "Further information is requested" },
+  { "name": "wontfix", "color": "ffffff", "description": "This will not be worked on" },
+
+  { "name": "chore", "color": "c2e0c6", "description": "Non-user-facing tooling/build work" },
+  { "name": "tracking", "color": "bfd4f2", "description": "Meta/planning issue for future phase breakdown" },
+
+  { "name": "area:ci", "color": "1d76db", "description": "CI, release automation, build infra" },
+  { "name": "area:cli", "color": "1d76db", "description": "CLI surface, subcommands, flags" },
+  { "name": "area:rendering", "color": "1d76db", "description": "Typst embedding and output generation" },
+  { "name": "area:schema", "color": "1d76db", "description": "JSON Resume schema and validation" },
+  { "name": "area:themes", "color": "1d76db", "description": "Theme adapters and native theme contract" },
+
+  { "name": "value:high", "color": "d93f0b", "description": "High user/project value" },
+  { "name": "value:medium", "color": "fbca04", "description": "Medium user/project value" },
+  { "name": "value:low", "color": "fef2c0", "description": "Low user/project value" },
+
+  { "name": "effort:high", "color": "0052cc", "description": "High implementation effort" },
+  { "name": "effort:medium", "color": "5319e7", "description": "Medium implementation effort" },
+  { "name": "effort:low", "color": "c5def5", "description": "Low implementation effort" },
+
+  { "name": "priority:high", "color": "b60205", "description": "High priority (derived from value/effort)" },
+  { "name": "priority:medium", "color": "fbca04", "description": "Medium priority (derived from value/effort)" },
+  { "name": "priority:low", "color": "0e8a16", "description": "Low priority (derived from value/effort)" },
+
+  { "name": "autorelease: pending", "color": "ededed", "description": "Managed by release-please" },
+  { "name": "autorelease: tagged", "color": "ededed", "description": "Managed by release-please" },
+  { "name": "dependencies", "color": "0366d6", "description": "Pull requests that update a dependency file" },
+  { "name": "github_actions", "color": "000000", "description": "Pull requests that update GitHub Actions code" },
+  { "name": "rust", "color": "000000", "description": "Pull requests that update rust code" },
+  { "name": "fuzz-failure", "color": "ededed", "description": "Fuzzing run produced a crash" }
+]

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,54 @@
+name: Sync labels
+
+# Sync repo labels from .github/labels.json. Creates missing labels and
+# updates color/description on existing ones. Never deletes — orphaned
+# labels are reported as warnings for manual cleanup.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.json'
+      - '.github/workflows/labels-sync.yml'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync labels from .github/labels.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          jq empty .github/labels.json
+
+          existing=$(gh label list --limit 200 --json name,color,description)
+
+          jq -c '.[]' .github/labels.json | while read -r label; do
+            name=$(jq -r '.name' <<<"$label")
+            color=$(jq -r '.color' <<<"$label")
+            desc=$(jq -r '.description // ""' <<<"$label")
+            if jq -e --arg n "$name" '.[] | select(.name == $n)' <<<"$existing" >/dev/null; then
+              echo "Updating: $name"
+              gh label edit "$name" --color "$color" --description "$desc"
+            else
+              echo "Creating: $name"
+              gh label create "$name" --color "$color" --description "$desc"
+            fi
+          done
+
+          jq -r '.[].name' <<<"$existing" | sort > /tmp/existing.txt
+          jq -r '.[].name' .github/labels.json | sort > /tmp/desired.txt
+          orphans=$(comm -23 /tmp/existing.txt /tmp/desired.txt || true)
+          if [ -n "$orphans" ]; then
+            echo "::warning::Labels on GitHub but not tracked in labels.json (not deleted):"
+            printf '%s\n' "$orphans"
+          fi


### PR DESCRIPTION
## Summary

- Add `.github/labels.json` capturing the full repo label set (31 labels) as a checked-in source of truth, including the three new `priority:{high,medium,low}` labels created during the issue triage pass.
- Add `.github/workflows/labels-sync.yml` that creates missing labels and updates color/description on existing ones to match `labels.json`. Triggers on `workflow_dispatch` and on push to `main` when either file changes.
- Workflow never deletes labels — orphans (labels on GitHub not in the file) are surfaced as `::warning::` annotations so they can be cleaned up by hand.

## Why

Until now, labels lived only on GitHub. Creating, renaming, or recoloring them was an out-of-band action with no audit trail. Making `labels.json` the source of truth lets future label changes go through the same review path as code, and lets a fresh fork bootstrap its label set.

## Dry-run against current GitHub state

- 31 labels in JSON, 31 already exist on GitHub.
- No orphans.
- The only changes the first run will apply: filling in three empty descriptions (`autorelease: pending`, `autorelease: tagged`, `fuzz-failure`).

## Test plan

- [ ] CI passes on this PR (workflow itself is `push`-triggered to main; the PR only validates that the JSON parses and YAML lints).
- [ ] After merge, the `Sync labels` workflow runs once on push to `main` and applies the three description updates without creating/deleting anything.
- [ ] Manual `workflow_dispatch` from the Actions tab re-runs cleanly (idempotent — should produce zero diffs on the second run).
