### PR TITLE
Migrate toml 0.8 to 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "typst",
  "typst-assets",
  "typst-html",
@@ -2659,6 +2659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,9 +3049,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3055,6 +3079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3062,10 +3095,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3073,6 +3115,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "ttf-parser"
@@ -3152,7 +3200,7 @@ dependencies = [
  "indexmap",
  "rustc-hash",
  "stacker",
- "toml",
+ "toml 0.8.23",
  "typst-library",
  "typst-macros",
  "typst-syntax",
@@ -3265,7 +3313,7 @@ dependencies = [
  "smallvec",
  "syntect",
  "time",
- "toml",
+ "toml 0.8.23",
  "ttf-parser",
  "two-face",
  "typed-arena",
@@ -3373,7 +3421,7 @@ dependencies = [
  "ecow",
  "rustc-hash",
  "serde",
- "toml",
+ "toml 0.8.23",
  "typst-timing",
  "typst-utils",
  "unicode-ident",
@@ -3903,6 +3951,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ flate2 = { version = "1", optional = true }
 # with `flate2::read::GzDecoder` to handle the registry's `.tar.gz`.
 tar = { version = "0.4", optional = true }
 # TOML parser for `typst.toml` package manifests.
-toml = { version = "0.8", optional = true }
+toml = { version = "1", optional = true }
 # Platform-specific user cache directory (XDG on Linux, Caches on
 # macOS, LocalAppData on Windows). Overridable via `FERROCV_CACHE_DIR`
 # for tests and power users.

--- a/src/install/manifest.rs
+++ b/src/install/manifest.rs
@@ -34,12 +34,14 @@ pub struct Manifest {
 
 /// Parse a `typst.toml` string into a [`Manifest`].
 pub fn parse_manifest(toml_str: &str) -> Result<Manifest, InstallError> {
+    // toml 1.x removed `FromStr for toml::Value` as a document parser
+    // (it now parses a single value), so we go through `toml::from_str`
+    // which keeps document semantics — accepting leading whitespace and
+    // multiple top-level tables the way 0.8 did.
     let value: toml::Value =
-        toml_str
-            .parse()
-            .map_err(|e: toml::de::Error| InstallError::ManifestParse {
-                reason: e.to_string(),
-            })?;
+        toml::from_str(toml_str).map_err(|e: toml::de::Error| InstallError::ManifestParse {
+            reason: e.to_string(),
+        })?;
 
     let package = value
         .get("package")


### PR DESCRIPTION
## Summary
- Bumps `toml = "0.8"` to `toml = "1"` (still behind the `install` feature, no change to default build).
- Replaces `str::parse::<toml::Value>()` in `parse_manifest` with `toml::from_str(...)`. `toml` 1.0 removed `FromStr for Value` as a document parser, so the old form started parsing a single value and rejected fixtures with leading whitespace or more than one top-level table.

Closes #116.

## What changed in the dep graph
New `install`-feature transitive crates: `serde_spanned 1.1`, `toml_datetime 1.1`, `toml_parser 1.1`, `toml_writer 1.1`, `winnow 1.0`. Default build unchanged; `cargo tree --no-default-features` still has no network-capable deps.

## Test plan
- [x] `cargo test --features install` — all green locally. The 7 tests named in the issue (`install::manifest::tests::{ignores_extra_fields, parses_minimal_manifest, rejects_absolute_entrypoint}`, `install::pipeline::tests::verify_manifest_*`, `package_cache::tests::cache_hit_assembles_owned_theme`) now pass.
- [x] `make preflight` — fmt-check, clippy, test, deny, audit, typos, no-network-deps-default all clean.
- [ ] CI matrix (Linux/macOS/Windows on stable + 1.89) — verify on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an optional TOML dependency to a newer major release to improve compatibility.
* **Bug Fixes**
  * Made manifest TOML parsing more robust, reducing errors when using the install-related functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/ferrocv/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->