### PR TITLE
Amend constitution: targeted projection from a single master (§7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,10 @@ documents to PDF, HTML, and plain text via [Typst](https://typst.app/),
 embedded in-process via the `typst` crate.
 
 PDF, plain-text, and HTML rendering all work today (released as v0.3.0).
-The phased roadmap and unresolved design questions live in [GitHub
+The differentiating capability — **targeted projection** (maintain one
+master `resume.json`, emit audience-specific cuts; CONSTITUTION §7) — is
+the v0.4.0 headline and not yet built. The roadmap and unresolved design
+questions live in [GitHub
 issues](https://github.com/cacack/ferrocv/issues). `README.md` is the
 user-facing entrypoint.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -142,6 +142,42 @@ pitch is also the security story — fewer moving parts, less
 attack surface, nothing phoning home. Making trust explicit keeps us
 from quietly trading it away for convenience later.
 
+### 7. Targeted projection from a single master
+
+The point of `ferrocv` is not only to render a resume — it is to let a
+user maintain **one comprehensive master `resume.json`** (every role,
+every highlight; 5+ pages printed in full) and emit **targeted,
+audience-specific cuts** from it: a focused two-page document that is a
+*subset/projection* of the master, never a separately maintained file.
+
+- **Projection is a distinct stage upstream of rendering.** It takes
+  the master document plus a selection spec and produces a **derived
+  document that is itself still valid JSON Resume**, which then flows
+  into the existing render pipeline unchanged. The master is consumed
+  unmodified (§1); projection is an additive transform that emits a
+  valid JSON Resume subset, not a schema fork.
+- **Two layers of selection.** *Mechanical* — drop roles before a date,
+  cap highlights per role, redact PII. *Curated* — select content by
+  audience tags carried under `x-` fields (§1's extension mechanism),
+  so "the security cut" keeps the highlights tagged for it rather than
+  the first N by position. Curated selection is the headline; mechanical
+  selection is the cheap complement.
+- **Selection lives in Rust, never in themes.** The projection stage
+  preprocesses the document; themes receive an already-narrowed valid
+  JSON Resume and stay ignorant of audiences and filters. This keeps
+  the theme contract simple (§5) and the layers separable (§4).
+- **Projection selects and omits; it never rewrites or generates.** We
+  do not reword bullets, summarize, or invent content — that would make
+  this an authoring tool and require the LLM calls §6 rules out. The
+  user writes the master; `ferrocv` chooses what to show.
+
+- **Why:** plenty of tools render a JSON Resume to PDF — that capability
+  is a commodity and not, by itself, a reason for `ferrocv` to exist.
+  Maintaining a single source of truth and generating tailored cuts per
+  application is the differentiating value. A data model built around
+  "one document in, one document out" would quietly foreclose it, so we
+  state it as a principle rather than discover it as a retrofit.
+
 ## Non-goals
 
 These are deliberately out of scope. Proposals to add them belong in an
@@ -152,6 +188,9 @@ amendment PR, not a feature PR.
   HR-XML, etc.).
 - Becoming a general-purpose Typst build tool.
 - Shipping a hosted service, web UI, or SaaS wrapper.
+- Authoring or rewriting resume content. Projection (§7) selects and
+  omits from a master the user wrote; it does not generate, summarize,
+  or reword bullets, and it does not auto-fit content to a page count.
 
 ## Testing doctrine
 


### PR DESCRIPTION
## What

Adds a new core principle to `CONSTITUTION.md`:

> **§7. Targeted projection from a single master** — maintain one comprehensive master `resume.json` and emit targeted, audience-specific cuts (a focused ~2-page document drawn from a 5+ page master), as a *subset/projection* of the master.

Plus a matching non-goal: no content authoring/rewriting (projection selects and omits; it doesn't generate, summarize, or auto-fit to a page count).

## Why

This was the original intent behind `ferrocv` — and the thing that distinguishes it from the many existing JSON Resume → PDF renderers, which are a commodity. Yet that intent lived only in a Phase 5 tracking issue (#17), absent from the principles meant to state "what we're building and why." This elevates it to a non-negotiable and pins the architecture:

- Projection is a **stage upstream of rendering** that emits a **derived, still-valid JSON Resume** document → the existing render/validate/theme pipeline consumes it unchanged.
- Selection lives in **Rust preprocessing, never in themes** (§4/§5) — this also resolves #17's long-standing "preprocess vs. theme params" open question.
- Audience tags ride under **`x-` fields** (§1 extension mechanism); the master is consumed unmodified.
- Projection **selects and omits; never rewrites or generates** (§6 — no LLM calls).

## Notes

- **Additive** — no existing principle is weakened or removed (per the Amendments process).
- Appended as **§7** rather than inserted near §1 (where it fits conceptually) to preserve the 100+ `§N` references scattered across code, ADRs, and VENDORING files. Position ≠ importance.
- Companion work (separate): #17 rewritten into a projection epic and promoted to the v0.4.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified core principles for targeted projection, defining how it derives JSON Resume subsets from a master resume with audience-based selection rules
  * Updated non-goals documentation to explicitly exclude content authoring and rewriting from projection functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->