### PR TITLE
Refresh stale version references in CLAUDE.md Project section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,12 @@ in this repository.
 documents to PDF, HTML, and plain text via [Typst](https://typst.app/),
 embedded in-process via the `typst` crate.
 
-PDF, plain-text, and HTML rendering all work today (released as v0.3.0).
-The differentiating capability — **targeted projection** (maintain one
-master `resume.json`, emit audience-specific cuts; CONSTITUTION §7) — is
-the v0.4.0 headline and not yet built. The roadmap and unresolved design
-questions live in [GitHub
+PDF, plain-text, and HTML rendering all ship today (current release
+v0.6.0). The differentiating capability — **targeted projection**
+(maintain one master `resume.json`, emit audience-specific cuts;
+CONSTITUTION §7) — is the next headline feature, tracked under the
+`v0.8.0` milestone, and not yet built. The roadmap and unresolved
+design questions live in [GitHub
 issues](https://github.com/cacack/ferrocv/issues). `README.md` is the
 user-facing entrypoint.
 


### PR DESCRIPTION
The Project section in `CLAUDE.md` had drifted three minor versions behind reality: it claimed the current release was `v0.3.0` (actually `v0.6.0`) and called targeted projection the `v0.4.0` headline, though `v0.4.0`–`v0.6.0` have all shipped since.

This updates the prose to:
- state the current release as `v0.6.0`, and
- point at the **`v0.8.0` milestone** for the projection headline rather than a hardcoded next-version number — so the prose stops drifting as release-please cuts routine releases.

Companion to a milestone/issue reorg done alongside this change: milestones renamed forward (`v0.4.0`→`v0.8.0` for projection, `v0.5.0`→`v0.9.0` for theme breadth), the projection epic #17 reopened with its children filed (#146–#151), and a `feature:projection` label added.

CONSTITUTION.md needed no changes — it carries no version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release status and roadmap milestones in guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->