### PR TITLE
Record the cargo-audit CI action decision inline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
     # Uses taiki-e/install-action (prebuilt binary) instead of
     # rustsec/audit-check, which compiles cargo-audit from source
     # on every run (~3min vs ~20s).
+    #
+    # Trust-vs-speed tradeoff evaluated and decided in #21: stay on
+    # taiki-e/install-action. It's a personal account, but already
+    # load-bearing in fuzz.yml, and Swatinem/rust-cache (same trust
+    # class) is already used in clippy/test/verify-no-network-default —
+    # so switching only this job would cost speed without shrinking the
+    # trust surface. SHA-pinning + Dependabot is the mitigation. Revisit
+    # if taiki-e/install-action has a security or maintenance incident.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: detect


### PR DESCRIPTION
## What

Adds an inline comment to the `audit` job in `ci.yml` documenting the trust-vs-speed decision tracked in #21: **stay on `taiki-e/install-action`** (SHA-pinned), no workflow behavior change.

## Why

The original issue weighed switching to a higher-trust install path. On inspection the trust framing is largely moot:

- `taiki-e/install-action` is already load-bearing in `fuzz.yml`, so dropping it from this one job wouldn't remove it from the trust surface.
- `Swatinem/rust-cache` (same personal-account trust class) is already used in `clippy`, `test`, and `verify-no-network-default` — so the "move back to rustsec + rust-cache" option adds no net trust improvement.
- Rolling our own removes the third-party action here but reintroduces compile-from-source slowness, and `taiki-e` still remains via `fuzz.yml`.

Net: switching this job alone costs speed without shrinking the trust surface. SHA-pinning + Dependabot is the real mitigation. Revisit only if `taiki-e/install-action` has a security or maintenance incident.

The decision rationale was also posted on the issue, which is now closed. This PR captures it in-repo so a future reader doesn't re-litigate it.

## Notes

- Comment-only YAML change; `uses:`/`with:`/`run:` untouched.
- `actionlint` clean; `make preflight` green.
- Related to #21 (already closed as decided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow documentation with rationale for infrastructure tooling decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->