### PR TITLE
Cross-reference the yaml-rust tracking issue from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,8 @@ ignore = [
     # paste 1.0.15 unmaintained; transitive: typst → typst-library → hayagriva → paste.
     { id = "RUSTSEC-2024-0436", reason = "transitive via typst → hayagriva; upstream typst/hayagriva to drop" },
     # yaml-rust 0.4.5 unmaintained; transitive: typst → typst-library → syntect → yaml-rust.
-    { id = "RUSTSEC-2024-0320", reason = "transitive via typst → syntect; upstream syntect to migrate to yaml-rust2" },
+    # Tracked in #154 — drop this entry once syntect migrates to yaml-rust2.
+    { id = "RUSTSEC-2024-0320", reason = "transitive via typst → syntect; upstream syntect to migrate to yaml-rust2 (#154)" },
 ]
 
 [licenses]


### PR DESCRIPTION
Adds a pointer to #154 in the `RUSTSEC-2024-0320` (yaml-rust unmaintained) ignore entry in `deny.toml`, so the eventual cleanup is discoverable from the config itself rather than only the issue tracker.

Comment + `reason` string only — no change to which advisories are ignored. `cargo deny check advisories` stays green.

Related to #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transitive dependency security advisory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->