### PR TITLE
Add code coverage reporting with cargo-llvm-cov and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,48 @@ jobs:
       - if: steps.detect.outputs.has_cargo == 'true'
         run: make verify-no-network-default
 
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: detect
+        run: echo "has_cargo=$([ -f Cargo.toml ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+      - if: steps.detect.outputs.has_cargo == 'true'
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+      - if: steps.detect.outputs.has_cargo == 'true'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - if: steps.detect.outputs.has_cargo == 'true'
+        uses: taiki-e/install-action@60ae4ce63c7aeb6e96d7f572c1ec7fafbb17ca80 # v2.79.10
+        with:
+          tool: cargo-llvm-cov
+      # `make coverage` is the CI-parity entry point: it generates lcov.info
+      # and enforces the coarse soft floor (--fail-under-lines). The floor is
+      # the only hard coverage gate; the Codecov upload below is informational.
+      - if: steps.detect.outputs.has_cargo == 'true'
+        run: make coverage
+      # Upload is non-blocking: a missing CODECOV_TOKEN or a Codecov outage
+      # must not turn CI red (fail_ci_if_error: false). Coverage is
+      # informational per issue #18; the soft floor in `make coverage` above
+      # is what gates.
+      - if: steps.detect.outputs.has_cargo == 'true'
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # Aggregator gate: branch protection targets this single check instead of
   # each upstream job. Add new jobs to `needs:` as they land.
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [fmt, clippy, test, deny, audit, typos, verify-no-network-default]
+    needs: [fmt, clippy, test, deny, audit, typos, verify-no-network-default, coverage]
     if: always()
     steps:
       - name: Check all jobs passed

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /dist
+/lcov.info
 Cargo.lock.bak
 .prompts
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@ strings there are kept in lockstep with `.github/workflows/ci.yml`.
   deny, audit, typos). Run before pushing.
 - `make test` / `make clippy` / `make fmt` — individual targets.
 - `make install-tools` — first-time install of the non-stock tools
-  (`cargo-deny`, `cargo-audit`, `typos-cli`).
+  (`cargo-deny`, `cargo-audit`, `typos-cli`, `cargo-llvm-cov`).
+- `make coverage` — `cargo-llvm-cov` line coverage; writes `lcov.info`
+  and enforces a coarse soft floor. Informational (uploaded to Codecov,
+  never a merge gate); kept out of `preflight` as the instrumented build
+  is slow.
 - `make fuzz` / `make fuzz-parse` / `make fuzz-validate` —
   local cargo-fuzz smoke (60s per target, nightly Rust required).
   Nightly CI runs these for 120s each; see

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help \
-        preflight fmt-check fmt clippy test deny audit typos \
+        preflight fmt-check fmt clippy test deny audit typos coverage \
         build build-release check clean doc install \
         install-tools verify-no-network-default \
         fuzz fuzz-parse fuzz-validate
@@ -63,6 +63,24 @@ audit: ## cargo-audit (CI parity)
 typos: ## typos check (CI parity)
 	typos
 
+# --- Coverage (not part of preflight: instrumented build is slow) -------------
+#
+# Coverage is informational, not a fine-grained merge gate (issue #18;
+# CONSTITUTION testing doctrine). Codecov reports per-component coverage
+# (see codecov.yml); the only hard gate is the coarse soft floor below,
+# which fails CI only on a large drop.
+#
+# COVERAGE_MIN is the soft floor (% lines). Baseline at introduction was
+# 85.67% total lines (cargo-llvm-cov, --all-features --workspace); the floor
+# sits ~10pp below so routine churn doesn't trip it. Raise it deliberately if
+# coverage climbs and you want to lock in the gain.
+COVERAGE_MIN ?= 75
+
+coverage: ## cargo-llvm-cov: write lcov.info + enforce soft floor (informational)
+	cargo llvm-cov --all-features --workspace --no-report
+	cargo llvm-cov report --lcov --output-path lcov.info
+	cargo llvm-cov report --fail-under-lines $(COVERAGE_MIN)
+
 # --- Fuzzing (nightly-only; not part of preflight) ---------------------------
 
 fuzz-parse: ## Run cargo-fuzz parse target for 60s (nightly required)
@@ -95,5 +113,6 @@ install: ## Install ferrocv binary from this checkout
 
 # --- Tooling -----------------------------------------------------------------
 
-install-tools: ## Install cargo-deny, cargo-audit, typos-cli
-	cargo install --locked cargo-deny cargo-audit typos-cli
+install-tools: ## Install cargo-deny, cargo-audit, typos-cli, cargo-llvm-cov
+	cargo install --locked cargo-deny cargo-audit typos-cli cargo-llvm-cov
+	rustup component add llvm-tools-preview

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ferrocv
 
 [![CI](https://github.com/cacack/ferrocv/actions/workflows/ci.yml/badge.svg)](https://github.com/cacack/ferrocv/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cacack/ferrocv/branch/main/graph/badge.svg)](https://codecov.io/gh/cacack/ferrocv)
 [![CodeQL](https://github.com/cacack/ferrocv/actions/workflows/codeql.yml/badge.svg)](https://github.com/cacack/ferrocv/actions/workflows/codeql.yml)
 [![crates.io](https://img.shields.io/crates/v/ferrocv.svg)](https://crates.io/crates/ferrocv)
 [![docs.rs](https://img.shields.io/docsrs/ferrocv)](https://docs.rs/ferrocv)
@@ -215,6 +216,16 @@ First-time setup installs the non-cargo-stock tools:
 
 ```sh
 make install-tools
+```
+
+Test coverage is tracked with `cargo-llvm-cov` and uploaded to
+[Codecov](https://codecov.io/gh/cacack/ferrocv). Coverage is informational
+(it never blocks a PR); `make coverage` enforces only a coarse soft floor
+that fails on a large drop. It is kept out of `make preflight` because the
+instrumented build is slow.
+
+```sh
+make coverage
 ```
 
 ## Non-goals

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,66 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecovyml-reference
+#
+# Coverage is informational, not a merge gate (issue #18; CONSTITUTION
+# testing doctrine: "coverage percentages are not a goal"). Codecov posts
+# per-component breakdowns and PR comments but never blocks a PR. The only
+# hard coverage gate lives in CI as a coarse soft floor (`make coverage`'s
+# `--fail-under-lines`), which fails only on a large drop.
+#
+# This is the Rust/Codecov translation of the sibling `my-family` repo's
+# `.testcoverage.yml` per-package-threshold-with-documented-overrides pattern.
+# ferrocv is a single crate (the `fuzz/` package is a separate workspace), so
+# "per-package" maps to per-source-area Codecov components below.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # Tolerate a 2% dip so new features with hard-to-cover paths
+        # (network, Typst compile errors) don't light up red.
+        threshold: 2%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Per-source-area components. Each is the analogue of a `.testcoverage.yml`
+# `override:` entry; lower-coverage areas are documented inline rather than
+# hidden inside one global number. All are informational (see `coverage`
+# above) — these set expectations and group the report, they do not gate.
+component_management:
+  individual_components:
+    # Core in-process Typst compilation (PDF/text/HTML exporters).
+    - component_id: render
+      paths:
+        - src/render.rs
+    # Theme registry + `--theme` resolution (bundled / local / @preview).
+    - component_id: theme
+      paths:
+        - src/theme.rs
+    # Schema validation against the vendored JSON Resume schema.
+    - component_id: validate
+      paths:
+        - src/validate.rs
+    # CLI surface. Mostly arg parsing + dispatch glue, so a chunk is
+    # exercised only through the spawn-the-binary scenario tests; expect a
+    # lower line ratio here than in the library modules.
+    - component_id: cli
+      paths:
+        - src/cli.rs
+    # `themes install` network pipeline (feature-gated). Many error paths
+    # (HTTP failures, malformed tarballs) are hard to unit-cover without a
+    # live registry, so this area is expected to trend lower.
+    - component_id: install
+      paths:
+        - src/install/**
+        - src/package_cache.rs
+
+# Exclude code that does not need coverage tracking.
+ignore:
+  - "fuzz/**"   # separate workspace; fuzz harnesses, not unit-under-test
+  - "tests/**"  # the tests themselves
+
+comment:
+  layout: "reach,diff,components"
+  require_changes: true


### PR DESCRIPTION
## Summary

Adds line-coverage measurement via `cargo-llvm-cov`, uploaded to
[Codecov](https://codecov.io/) for trend visibility and a per-component
breakdown. Closes #18.

Per issue #18 and the CONSTITUTION testing doctrine ("coverage percentages
are not a goal"), coverage is **informational, not a fine-grained merge
gate**. The chosen model is *soft floor + informational*:

- Codecov project/patch status and per-area components are **non-blocking**.
- The only hard gate is a coarse **soft floor** (`--fail-under-lines`) in
  `make coverage` that fails CI only on a large drop.

## What changed

- **`Makefile`** — `coverage` target (collect once, report LCOV + soft
  floor); `COVERAGE_MIN ?= 75` (baseline measured **85.67%** lines, leaving
  ~10pp headroom); `cargo-llvm-cov` + `llvm-tools-preview` added to
  `install-tools`. Deliberately kept **out of `preflight`** — the
  instrumented build is slow.
- **`.github/workflows/ci.yml`** — new `coverage` job (`llvm-tools-preview`
  → `taiki-e/install-action` for `cargo-llvm-cov` → `make coverage` →
  SHA-pinned `codecov/codecov-action`, non-blocking upload). Added to the
  `ci-success` aggregator gate.
- **`codecov.yml`** *(new)* — informational project/patch status +
  per-source-area components (render, theme, validate, cli, install) with
  documented overrides. Translates the sibling `my-family` repo's
  `.testcoverage.yml` override pattern into the Rust/Codecov idiom (single
  crate → per-area components). Validated by Codecov's config validator.
- **`README.md` / `CLAUDE.md` / `.gitignore`** — Codecov badge, `make
  coverage` docs, ignore `lcov.info`.

## Required external setup (one-time, before the upload works)

Enable `cacack/ferrocv` on codecov.io and add a **`CODECOV_TOKEN`** repo
secret. The upload step uses `fail_ci_if_error: false`, so until then CI
stays green (the soft floor still runs) and the badge reads "unknown".

## Verification

- `make coverage` → exit 0, writes `lcov.info`, passes the floor (85.67% ≥ 75).
- Floor genuinely gates: `make coverage COVERAGE_MIN=95` → exit 2.
- `make preflight` passes (fmt, clippy, test, deny, audit, typos,
  verify-no-network-default).
- `codecov.yml` validated "Valid!" by Codecov; `ci.yml` parses as valid YAML.
- `codecov/codecov-action` SHA-pinned (`e79a696` # v6.0.1); Dependabot's
  github-actions ecosystem will track it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
