### PR TITLE
Mechanical projection filters and the tailor subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ferrocv themes list
 ferrocv tailor master.json --since 2015 --max-bullets 4 --redact pii -o cut.json
 
 # Same filters straight to a rendered PDF — no intermediate file
-ferrocv render master.json --since 2015 --max-bullets 4 --theme typst-jsonresume-cv
+ferrocv render master.json --since 2015 --max-bullets 4 --redact pii --theme typst-jsonresume-cv
 ```
 
 The quickest way to try it end-to-end is

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ ferrocv render resume.json --format html
 
 # List bundled themes (machine-readable, one name per line)
 ferrocv themes list
+
+# Project a master resume into a narrower cut (mechanical filters):
+# drop roles that ended before 2015, cap each job at 4 bullets, and
+# strip PII. Writes the derived JSON Resume to stdout (or use -o).
+ferrocv tailor master.json --since 2015 --max-bullets 4 --redact pii -o cut.json
+
+# Same filters straight to a rendered PDF — no intermediate file
+ferrocv render master.json --since 2015 --max-bullets 4 --theme typst-jsonresume-cv
 ```
 
 The quickest way to try it end-to-end is
@@ -86,8 +94,42 @@ format: PDF and text default to the native `text-minimal` theme, while
 HTML defaults to the native `html-minimal` semantic theme. When
 `--output` is omitted, the output lands at `dist/resume.pdf` for PDF,
 `dist/resume.txt` for text, and `dist/resume.html` for HTML; parent
-directories are created as needed. `validate` and `render` read from
-stdin if no path is given.
+directories are created as needed. `validate`, `render`, and `tailor`
+read from stdin if no path is given.
+
+### Projection: one master, many cuts
+
+The point of ferrocv is to maintain **one comprehensive master
+`resume.json`** and emit **targeted, audience-specific cuts** from it
+(CONSTITUTION §7). Projection is a stage *upstream* of rendering: it
+reads the master unmodified and produces a derived document that is
+itself valid JSON Resume, which flows into the normal render pipeline.
+
+`ferrocv tailor` runs that stage and stops, emitting the derived
+document so you can inspect, commit, or pipe it. The same flags are
+also available on `render`, which projects then renders in one shot —
+so `ferrocv render master.json --since 2015` is equivalent to
+`ferrocv tailor master.json --since 2015 | ferrocv render`.
+
+The **mechanical** filters (theme-agnostic, available today):
+
+- `--since <YYYY|YYYY-MM|YYYY-MM-DD>` — drop `work` entries that ended
+  before the cutoff. Ongoing roles (no `endDate`) are always kept.
+- `--max-bullets <N>` — cap every `highlights` list at the first N
+  bullets.
+- `--redact pii` — remove `basics.location`, `basics.phone`, and
+  `basics.email` from the cut. Identity fields (`name`, `label`,
+  `summary`, `url`, `profiles`) are kept.
+
+With no projection flags, `render` behaves exactly as it does on any
+input — projection is opt-in and inert by default. Curated,
+audience-tag-driven selection (`--audience`) is in progress.
+
+`tailor` writes the derived document to `--output <file>`, or to stdout
+when `--output` is omitted, so it composes in a pipe; all diagnostics
+go to stderr. Note that stdout-by-default prints the full resume,
+including any PII not removed by `--redact` — prefer `--output <file>`
+for unattended or shared/recorded contexts.
 
 `themes list` prints registered theme names to stdout, one per line,
 sorted lexicographically, with no decoration — a stable

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,21 +9,23 @@
 //! - `0` — operation succeeded
 //!   - `validate`: document is valid
 //!   - `render`: PDF, text, or HTML written to `--output`
+//!   - `tailor`: derived JSON Resume written to `--output`/stdout
 //! - `1` — document parsed as JSON but failed schema validation
-//! - `2` — usage error, IO error, malformed JSON, unknown theme,
-//!   unknown format, or Typst render error
+//! - `2` — usage error (incl. malformed projection flag value), IO
+//!   error, malformed JSON, unknown theme, unknown format, or Typst
+//!   render error
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use serde_json::Value;
 
 use crate::{
-    THEMES, ThemeResolveError, ValidationError, compile_html_resolved, compile_text_resolved,
-    compile_theme_resolved, resolve_theme, validate_value,
+    ProjectionSpec, RedactSet, THEMES, ThemeResolveError, ValidationError, compile_html_resolved,
+    compile_text_resolved, compile_theme_resolved, project, resolve_theme, validate_value,
 };
 
 /// Render JSON Resume documents via embedded Typst.
@@ -89,6 +91,49 @@ enum Commands {
         /// Defaults to `dist/resume.pdf` for `--format pdf`,
         /// `dist/resume.txt` for `--format text`, and
         /// `dist/resume.html` for `--format html`.
+        #[arg(short = 'o', long)]
+        output: Option<PathBuf>,
+        /// Mechanical projection filters. When any are present, the
+        /// document is projected (CONSTITUTION §7) before rendering;
+        /// with none, render behaves exactly as it would on the raw
+        /// input. Equivalent to `ferrocv tailor … | ferrocv render`.
+        #[command(flatten)]
+        projection: ProjectionArgs,
+    },
+    /// Project a master JSON Resume into a derived, narrower cut.
+    ///
+    /// `tailor` runs the projection stage (CONSTITUTION §7) and stops —
+    /// it emits a derived document that is itself valid JSON Resume,
+    /// which you can inspect, commit, or pipe straight into `render`
+    /// (`ferrocv tailor master.json --since 2015 | ferrocv render`).
+    /// The master is read unmodified; only the derived output reflects
+    /// the filters.
+    ///
+    /// Reads the master from PATH, or from stdin when PATH is omitted
+    /// (matching `render`/`validate`). Writes the derived document to
+    /// `--output <file>`, or to stdout when `--output` is omitted, so it
+    /// composes in a pipe. All diagnostics go to stderr unconditionally,
+    /// so stdout always carries only the JSON document.
+    ///
+    /// Caution: with no `--output`, the full derived resume — including
+    /// any PII not removed by `--redact` — is printed to stdout. Prefer
+    /// `--output <file>` for unattended or shared/recorded contexts.
+    ///
+    /// This subcommand implements the mechanical filters (`--since`,
+    /// `--max-bullets`, `--redact`); curated `--audience` selection
+    /// lands in a follow-up.
+    ///
+    /// Exit codes:
+    /// - 0 — projected; derived document written to --output/stdout
+    /// - 1 — master parsed but failed schema validation
+    /// - 2 — usage error (bad flag value), IO error, or parse error
+    Tailor {
+        /// Path to the master JSON Resume. Reads stdin if omitted.
+        path: Option<PathBuf>,
+        #[command(flatten)]
+        projection: ProjectionArgs,
+        /// Output file path for the derived document. Parent directories
+        /// are created as needed. Writes to stdout if omitted.
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
     },
@@ -177,6 +222,53 @@ enum Format {
     Html,
 }
 
+/// Shared mechanical projection flags (issue #148), attached to both
+/// `tailor` and `render` via `#[command(flatten)]`.
+///
+/// Defining the flags once and feeding them to the single
+/// [`crate::project`] transform is what keeps the two surfaces
+/// equivalent (ADR 0005): `render --since X` and `tailor --since X |
+/// render` run the same code. Curated `--audience` selection (#149) adds
+/// its field here.
+#[derive(Debug, Clone, Args)]
+struct ProjectionArgs {
+    /// Drop `work` entries that ended before this ISO 8601 date
+    /// (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`). Entries with no end date
+    /// (ongoing roles) are always kept. A malformed value is a usage
+    /// error.
+    #[arg(long)]
+    since: Option<String>,
+    /// Cap each entry's `highlights` list at N bullets, keeping the
+    /// first N by position. `0` removes all highlights.
+    #[arg(long, value_name = "N")]
+    max_bullets: Option<usize>,
+    /// Redact a named set of PII fields. `pii` removes
+    /// `basics.location`, `basics.phone`, and `basics.email`.
+    #[arg(long, value_enum)]
+    redact: Option<RedactArg>,
+}
+
+impl ProjectionArgs {
+    /// Translate the parsed CLI flags into a library [`ProjectionSpec`].
+    fn to_spec(&self) -> ProjectionSpec {
+        ProjectionSpec {
+            since: self.since.clone(),
+            max_bullets: self.max_bullets,
+            redact: self.redact.map(|r| match r {
+                RedactArg::Pii => RedactSet::Pii,
+            }),
+        }
+    }
+}
+
+/// The `--redact` value vocabulary. A fixed enum so clap rejects unknown
+/// values as usage errors (exit 2) rather than silently ignoring them.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum RedactArg {
+    /// Standard PII contact fields in `basics`.
+    Pii,
+}
+
 /// Resolve which theme name to use given the format and the optional
 /// `--theme` argument.
 ///
@@ -220,7 +312,19 @@ pub fn run() -> Result<ExitCode> {
             theme,
             format,
             output,
-        } => run_render(path.as_deref(), theme.as_deref(), format, output.as_deref()),
+            projection,
+        } => run_render(
+            path.as_deref(),
+            theme.as_deref(),
+            format,
+            output.as_deref(),
+            &projection.to_spec(),
+        ),
+        Commands::Tailor {
+            path,
+            projection,
+            output,
+        } => run_tailor(path.as_deref(), &projection.to_spec(), output.as_deref()),
         Commands::Themes { command } => match command {
             ThemesCommands::List => run_themes_list(),
             #[cfg(feature = "install")]
@@ -440,6 +544,7 @@ fn run_render(
     theme_name: Option<&str>,
     format: Format,
     output: Option<&Path>,
+    projection: &ProjectionSpec,
 ) -> Result<ExitCode> {
     // Step 1: resolve theme name first. Every format now has a default
     // (`text-minimal` for PDF/text, `html-minimal` for HTML), so this
@@ -468,6 +573,23 @@ fn run_render(
         report_validation_errors(&errors, "; no output written");
         return Ok(ExitCode::from(1));
     }
+
+    // Step 4b: project. When any projection flag is set, run the same
+    // transform `tailor` runs (ADR 0005) and render the derived
+    // document; with no flags the input flows through untouched so
+    // flagless `render` is unchanged. The master is validated above; the
+    // derived document is valid JSON Resume by construction.
+    let value = if projection.is_noop() {
+        value
+    } else {
+        match project(&value, projection) {
+            Ok(derived) => derived,
+            Err(err) => {
+                eprintln!("error: {err}; no output written");
+                return Ok(ExitCode::from(2));
+            }
+        }
+    };
 
     // Step 5: resolve theme. Accepts three spec shapes — bundled
     // name, local `.typ` path, or `@preview/...` spec — and returns a
@@ -543,6 +665,95 @@ fn run_render(
             out_path.display()
         );
         return Ok(ExitCode::from(2));
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Run `ferrocv tailor`.
+///
+/// Projects the master with `spec` and writes the derived JSON Resume to
+/// `output` (or stdout when `None`). Diagnostics always go to stderr so
+/// stdout carries only the document (ADR 0005). Exit-code contract
+/// matches the module header: 0 ok, 1 schema-invalid master, 2
+/// usage/IO/parse error.
+fn run_tailor(
+    path: Option<&Path>,
+    spec: &ProjectionSpec,
+    output: Option<&Path>,
+) -> Result<ExitCode> {
+    // Step 1: read input (IO errors → exit 2 via main's anyhow mapping).
+    let input = read_input(path)?;
+
+    // Step 2: parse JSON.
+    let value: Value = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return Ok(ExitCode::from(2));
+        }
+    };
+
+    // Step 3: validate the master before projecting, so a bad master is
+    // a clean schema diagnostic rather than a confusing projected dump.
+    if let Err(errors) = validate_value(&value) {
+        report_validation_errors(&errors, "; no output written");
+        return Ok(ExitCode::from(1));
+    }
+
+    // Step 4: project. The only failure here is a malformed flag value
+    // (e.g. a non-date `--since`), which is a usage error.
+    let derived = match project(&value, spec) {
+        Ok(d) => d,
+        Err(err) => {
+            eprintln!("error: {err}; no output written");
+            return Ok(ExitCode::from(2));
+        }
+    };
+
+    // Step 5: serialize. Pretty-printed for human inspection and clean
+    // diffs; the derived document is valid JSON Resume.
+    let mut json = match serde_json::to_string_pretty(&derived) {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("error: failed to serialize derived document: {err}");
+            return Ok(ExitCode::from(2));
+        }
+    };
+    json.push('\n');
+
+    // Step 6: write to file or stdout.
+    match output {
+        Some(out_path) => {
+            if let Some(parent) = out_path.parent()
+                && !parent.as_os_str().is_empty()
+                && let Err(err) = std::fs::create_dir_all(parent)
+            {
+                eprintln!(
+                    "error: failed to create output directory {}: {err}",
+                    parent.display()
+                );
+                return Ok(ExitCode::from(2));
+            }
+            if let Err(err) = std::fs::write(out_path, json.as_bytes()) {
+                eprintln!(
+                    "error: failed to write output file {}: {err}",
+                    out_path.display()
+                );
+                return Ok(ExitCode::from(2));
+            }
+        }
+        None => {
+            // Locked stdout with explicit error handling so a broken
+            // pipe (`ferrocv tailor … | head`) is a clean exit-2, not a
+            // panic — mirrors `run_themes_list`.
+            let stdout = io::stdout();
+            let mut stdout = stdout.lock();
+            if let Err(err) = stdout.write_all(json.as_bytes()) {
+                eprintln!("error: failed to write derived document to stdout: {err}");
+                return Ok(ExitCode::from(2));
+            }
+        }
     }
 
     Ok(ExitCode::SUCCESS)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -546,6 +546,15 @@ fn run_render(
     output: Option<&Path>,
     projection: &ProjectionSpec,
 ) -> Result<ExitCode> {
+    // Step 0: validate projection flags before touching the document, so
+    // a malformed flag value (e.g. `--since banana`) is a usage error
+    // (exit 2) and wins deterministically over an unrelated schema
+    // failure in the input (exit 1).
+    if let Err(err) = projection.validate() {
+        eprintln!("error: {err}; no output written");
+        return Ok(ExitCode::from(2));
+    }
+
     // Step 1: resolve theme name first. Every format now has a default
     // (`text-minimal` for PDF/text, `html-minimal` for HTML), so this
     // is infallible — an explicit `--theme` overrides, otherwise the
@@ -682,6 +691,15 @@ fn run_tailor(
     spec: &ProjectionSpec,
     output: Option<&Path>,
 ) -> Result<ExitCode> {
+    // Step 0: validate projection flags before touching the document, so
+    // a malformed flag value (e.g. `--since banana`) is a usage error
+    // (exit 2) rather than being masked by a schema failure (exit 1) in
+    // the master.
+    if let Err(err) = spec.validate() {
+        eprintln!("error: {err}; no output written");
+        return Ok(ExitCode::from(2));
+    }
+
     // Step 1: read input (IO errors → exit 2 via main's anyhow mapping).
     let input = read_input(path)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,14 @@ pub mod cli;
 pub mod install;
 #[cfg(feature = "install")]
 pub mod package_cache;
+pub mod project;
 pub mod render;
 #[cfg(test)]
 mod test_env;
 pub mod theme;
 pub mod validate;
 
+pub use project::{ProjectionError, ProjectionSpec, RedactSet, project};
 pub use render::{
     RenderDiagnostic, RenderError, compile_html, compile_html_resolved, compile_pdf, compile_text,
     compile_text_resolved, compile_theme, compile_theme_resolved,

--- a/src/project.rs
+++ b/src/project.rs
@@ -81,6 +81,23 @@ impl ProjectionSpec {
     pub fn is_noop(&self) -> bool {
         *self == ProjectionSpec::default()
     }
+
+    /// Validate the spec's flag values without touching a document.
+    ///
+    /// Currently this just checks that `since` (if set) is a usable ISO
+    /// 8601 date. Callers should run this *before* reading or validating
+    /// the input document, so a malformed flag value surfaces as a usage
+    /// error rather than being masked by an unrelated schema failure in
+    /// the document. [`project`] also calls it, so the guarantee holds
+    /// even for callers that skip the early check.
+    pub fn validate(&self) -> Result<(), ProjectionError> {
+        if let Some(since) = &self.since
+            && !is_iso_date(since)
+        {
+            return Err(ProjectionError::InvalidSince(since.clone()));
+        }
+        Ok(())
+    }
 }
 
 /// An error from [`project`].
@@ -117,13 +134,11 @@ impl std::error::Error for ProjectionError {}
 /// not a valid ISO 8601 date; the document is validated for that before
 /// any work is done.
 pub fn project(doc: &Value, spec: &ProjectionSpec) -> Result<Value, ProjectionError> {
-    // Validate the one fallible input up front, before cloning, so a bad
-    // spec is cheap to reject.
-    if let Some(since) = &spec.since
-        && !is_iso_date(since)
-    {
-        return Err(ProjectionError::InvalidSince(since.clone()));
-    }
+    // Validate the spec up front, before cloning, so a bad flag value is
+    // cheap to reject. Callers are encouraged to call `validate()` even
+    // earlier (before reading the document) so usage errors win over
+    // document errors; this call keeps the guarantee for those that don't.
+    spec.validate()?;
 
     let mut out = doc.clone();
 
@@ -237,11 +252,12 @@ fn is_iso_date(s: &str) -> bool {
 /// `YYYY-MM-DD` string, filling absent month/day components per `bound`.
 ///
 /// Returns `None` for anything that is not `YYYY`, `YYYY-MM`, or
-/// `YYYY-MM-DD` with all-digit, correctly-zero-padded components and a
-/// month in `01`–`12` / day in `01`–`31`. The range check is coarse — it
-/// is not a full calendar check, so `2020-02-31` (a non-existent day that
-/// is still within `01`–`31`) is accepted; it exists to reject obvious
-/// garbage like `2020-13` while keeping the implementation simple.
+/// `YYYY-MM-DD` with all-digit, correctly-zero-padded components, a month
+/// in `01`–`12`, and — when a day is present — a day that actually exists
+/// in that month and year (leap years included). So `2020-13`,
+/// `2020-02-31`, and `2021-02-29` are all rejected, while `2020-02-29` is
+/// accepted. This is a real calendar check, not just a range bound, so
+/// the CLI's "a malformed value is a usage error" promise holds.
 fn normalize_date(s: &str, bound: Bound) -> Option<String> {
     let parts: Vec<&str> = s.split('-').collect();
     let widths = [4usize, 2, 2];
@@ -254,17 +270,18 @@ fn normalize_date(s: &str, bound: Bound) -> Option<String> {
             return None;
         }
     }
-    // Range-check the present month/day components.
+    let year: u16 = parts[0].parse().ok()?;
+    // Range-check the present month/day components against the calendar.
     if let Some(month) = parts.get(1) {
         let month: u8 = month.parse().ok()?;
         if !(1..=12).contains(&month) {
             return None;
         }
-    }
-    if let Some(day) = parts.get(2) {
-        let day: u8 = day.parse().ok()?;
-        if !(1..=31).contains(&day) {
-            return None;
+        if let Some(day) = parts.get(2) {
+            let day: u8 = day.parse().ok()?;
+            if !(1..=days_in_month(year, month)).contains(&day) {
+                return None;
+            }
         }
     }
 
@@ -276,6 +293,21 @@ fn normalize_date(s: &str, bound: Bound) -> Option<String> {
     let month = parts.get(1).copied().unwrap_or(fill_month);
     let day = parts.get(2).copied().unwrap_or(fill_day);
     Some(format!("{year}-{month}-{day}"))
+}
+
+/// Number of days in a given (Gregorian) month, leap years included.
+///
+/// `month` must already be range-checked to `1..=12` by the caller.
+fn days_in_month(year: u16, month: u8) -> u8 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400) => {
+            29
+        }
+        2 => 28,
+        _ => unreachable!("month is range-checked to 1..=12 before this call"),
+    }
 }
 
 #[cfg(test)]
@@ -477,6 +509,19 @@ mod tests {
         assert!(!is_iso_date("2020-00"));
         assert!(!is_iso_date("2020-05-32"));
         assert!(!is_iso_date("2020-05-00"));
+    }
+
+    #[test]
+    fn is_iso_date_enforces_real_calendar_days() {
+        // Impossible days for the given month/year are rejected...
+        assert!(!is_iso_date("2020-02-31"), "Feb never has 31 days");
+        assert!(!is_iso_date("2021-02-29"), "2021 is not a leap year");
+        assert!(!is_iso_date("2020-04-31"), "April has 30 days");
+        // ...while genuine dates, including leap day, are accepted.
+        assert!(is_iso_date("2020-02-29"), "2020 is a leap year");
+        assert!(is_iso_date("2000-02-29"), "2000 is a leap year (÷400)");
+        assert!(!is_iso_date("1900-02-29"), "1900 is not a leap year (÷100)");
+        assert!(is_iso_date("2021-04-30"));
     }
 
     #[test]

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,0 +1,513 @@
+//! Projection: the mechanical, theme-agnostic selection stage.
+//!
+//! Projection is a distinct stage *upstream* of rendering
+//! (`CONSTITUTION.md` §7): it takes a master JSON Resume document plus a
+//! selection spec and produces a **derived document that is itself still
+//! valid JSON Resume**, which then flows into the existing render
+//! pipeline unchanged. The master is consumed read-only (§1); the
+//! transform returns a new [`serde_json::Value`].
+//!
+//! This module implements only the **mechanical** filters (issue #148):
+//!
+//! - [`ProjectionSpec::since`] — drop `work` entries that ended before a
+//!   cutoff date; ongoing entries (no `endDate`) are always kept.
+//! - [`ProjectionSpec::max_bullets`] — cap every `highlights` array at
+//!   the first N entries by position.
+//! - [`ProjectionSpec::redact`] — remove named PII fields from `basics`.
+//!
+//! Curated, tag-driven `--audience` selection (and the consumption /
+//! stripping of `x-ferrocv` tags it entails) is issue #149's job; this
+//! stage leaves `x-ferrocv` metadata untouched. Selection lives here in
+//! Rust, never in themes (§4/§5): a theme only ever sees the
+//! already-narrowed document.
+//!
+//! Both CLI surfaces — the standalone `tailor` subcommand and the
+//! `render` projection flags (ADR 0005) — call [`project`], so the two
+//! are equivalent by construction.
+
+use std::fmt;
+
+use serde_json::Value;
+
+/// The PII redaction vocabulary accepted by `--redact`.
+///
+/// A fixed enum (not a free-form field list) so the CLI can surface it
+/// as a `clap` `ValueEnum` and reject unknown values as usage errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactSet {
+    /// Remove the standard personally-identifying contact fields from
+    /// `basics`: `location`, `phone`, and `email`. Identity fields the
+    /// document still needs to be useful (`name`, `label`, `summary`,
+    /// `url`, `profiles`) are kept.
+    Pii,
+}
+
+/// The mechanical projection filters (issue #148).
+///
+/// An all-`None` spec is a no-op: [`project`] returns the input
+/// unchanged (structurally). Curated `--audience` selection (#149) will
+/// add its field here without changing the existing semantics.
+///
+/// Marked `#[non_exhaustive]` because the struct is *documented to grow*
+/// (the `--audience` field above): out-of-crate callers construct it via
+/// [`ProjectionSpec::default`] plus field assignment rather than a struct
+/// literal, so adding a field later is not a breaking change for them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ProjectionSpec {
+    /// Drop `work` entries that ended before this ISO 8601 date (`YYYY`,
+    /// `YYYY-MM`, or `YYYY-MM-DD`). Comparison is granularity-aware: an
+    /// entry is dropped only when the latest instant its `endDate` could
+    /// denote is strictly before the earliest instant the cutoff could
+    /// denote, so coarser dates are treated generously (e.g. an `endDate`
+    /// of `"2015"` survives `--since 2015-06`). Ongoing entries (no
+    /// `endDate`) are always kept.
+    pub since: Option<String>,
+    /// Cap every `highlights` array at this many entries (first N by
+    /// position). `0` empties them.
+    pub max_bullets: Option<usize>,
+    /// Redact a named set of PII fields from `basics`.
+    pub redact: Option<RedactSet>,
+}
+
+impl ProjectionSpec {
+    /// True when no filter is set, so projection would be a no-op. The
+    /// CLI uses this to keep flagless `render` byte-for-byte unchanged.
+    ///
+    /// Defined as equality with [`ProjectionSpec::default`] (rather than
+    /// a hand-written per-field check) so a future field whose default is
+    /// "unset" is automatically included — no risk of a new filter being
+    /// silently skipped on the `render` fast path.
+    pub fn is_noop(&self) -> bool {
+        *self == ProjectionSpec::default()
+    }
+}
+
+/// An error from [`project`].
+///
+/// Currently the only failure is a malformed `--since` value; the other
+/// filters cannot fail on a document that already schema-validates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectionError {
+    /// The `--since` value is not a recognizable ISO 8601 date.
+    InvalidSince(String),
+}
+
+impl fmt::Display for ProjectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProjectionError::InvalidSince(value) => write!(
+                f,
+                "invalid 'since' value {value:?}: expected an ISO 8601 date \
+                 (YYYY, YYYY-MM, or YYYY-MM-DD)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProjectionError {}
+
+/// Apply the projection `spec` to `doc`, returning a derived document.
+///
+/// `doc` is never mutated. The returned [`Value`] is a fresh document
+/// with the mechanical filters applied in a fixed order — `since`, then
+/// `max_bullets`, then `redact` — so composition is deterministic.
+///
+/// Returns [`ProjectionError::InvalidSince`] if `spec.since` is set but
+/// not a valid ISO 8601 date; the document is validated for that before
+/// any work is done.
+pub fn project(doc: &Value, spec: &ProjectionSpec) -> Result<Value, ProjectionError> {
+    // Validate the one fallible input up front, before cloning, so a bad
+    // spec is cheap to reject.
+    if let Some(since) = &spec.since
+        && !is_iso_date(since)
+    {
+        return Err(ProjectionError::InvalidSince(since.clone()));
+    }
+
+    let mut out = doc.clone();
+
+    if let Some(since) = &spec.since {
+        apply_since(&mut out, since);
+    }
+    if let Some(n) = spec.max_bullets {
+        apply_max_bullets(&mut out, n);
+    }
+    if let Some(redact) = spec.redact {
+        apply_redact(&mut out, redact);
+    }
+
+    Ok(out)
+}
+
+/// Drop `work` entries that ended before `since`.
+///
+/// Scope is deliberately `work` only (issue #148 decision): "drop older
+/// roles" maps to employment history. Ongoing entries (no `endDate`) are
+/// always kept. The cutoff test is granularity-aware (see
+/// [`kept_by_since`]): an entry is dropped only when the latest instant
+/// its `endDate` could denote is strictly before the earliest instant
+/// the cutoff could denote, so a coarse `endDate` like `"2015"` is kept
+/// against `--since 2015-06` rather than being silently dropped by a
+/// naive `"2015" < "2015-06"` string compare.
+fn apply_since(out: &mut Value, since: &str) {
+    if let Some(work) = out.get_mut("work").and_then(Value::as_array_mut) {
+        work.retain(|entry| match entry.get("endDate").and_then(Value::as_str) {
+            Some(end) => kept_by_since(end, since),
+            // No (or non-string) endDate ⇒ ongoing ⇒ keep.
+            None => true,
+        });
+    }
+}
+
+/// Decide whether an entry with end date `end` survives the `--since`
+/// cutoff.
+///
+/// JSON Resume permits `endDate` and the cutoff to each be year-,
+/// month-, or day-granular, so a plain lexicographic compare misbehaves
+/// across mismatched granularities. We instead compare the *latest*
+/// instant `end` could denote against the *earliest* instant `since`
+/// could denote: the entry is dropped only when it definitely ended
+/// before the cutoff. Ambiguous coarse dates are kept — consistent with
+/// projection's include-when-in-doubt bias.
+///
+/// An `end` value that is not a shape-valid date is kept (we cannot prove
+/// it is old); `since` is shape-validated by [`project`] before we get
+/// here.
+fn kept_by_since(end: &str, since: &str) -> bool {
+    match (
+        normalize_date(end, Bound::Latest),
+        normalize_date(since, Bound::Earliest),
+    ) {
+        (Some(end_max), Some(since_min)) => end_max >= since_min,
+        _ => true,
+    }
+}
+
+/// Which instant of a partial date to resolve to when normalizing.
+#[derive(Debug, Clone, Copy)]
+enum Bound {
+    /// Fill missing month/day with the start of the period (`01`/`01`).
+    Earliest,
+    /// Fill missing month/day with the end of the period (`12`/`31`).
+    Latest,
+}
+
+/// Cap every bare-string `highlights` array at `n` entries (first N).
+///
+/// Applies to the stock JSON Resume v1.0.0 sections that carry a
+/// bare-string `highlights` array — `work`, `volunteer`, `projects`.
+/// The index-parallel `x-ferrocv.highlights` tag array (an array *of
+/// arrays*, nested under `x-ferrocv`) is a sibling key and is left
+/// untouched; mechanical filters do not consume tags (#149's job).
+fn apply_max_bullets(out: &mut Value, n: usize) {
+    for section in ["work", "volunteer", "projects"] {
+        if let Some(entries) = out.get_mut(section).and_then(Value::as_array_mut) {
+            for entry in entries {
+                if let Some(highlights) = entry.get_mut("highlights").and_then(Value::as_array_mut)
+                {
+                    highlights.truncate(n);
+                }
+            }
+        }
+    }
+}
+
+/// Remove the redaction set's fields from `basics`.
+fn apply_redact(out: &mut Value, redact: RedactSet) {
+    let RedactSet::Pii = redact;
+    if let Some(basics) = out.get_mut("basics").and_then(Value::as_object_mut) {
+        for field in ["location", "phone", "email"] {
+            basics.remove(field);
+        }
+    }
+}
+
+/// True if `s` is an ISO 8601 date at year, month, or day granularity:
+/// `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`.
+///
+/// Used by [`project`] to turn a malformed `--since` value into a usage
+/// error rather than a silent no-match. Delegates to [`normalize_date`],
+/// so it enforces the same range checks (month `01`–`12`, day `01`–`31`).
+fn is_iso_date(s: &str) -> bool {
+    normalize_date(s, Bound::Earliest).is_some()
+}
+
+/// Validate an ISO 8601 date shape and normalize it to a full
+/// `YYYY-MM-DD` string, filling absent month/day components per `bound`.
+///
+/// Returns `None` for anything that is not `YYYY`, `YYYY-MM`, or
+/// `YYYY-MM-DD` with all-digit, correctly-zero-padded components and a
+/// month in `01`–`12` / day in `01`–`31`. The range check is coarse — it
+/// is not a full calendar check, so `2020-02-31` (a non-existent day that
+/// is still within `01`–`31`) is accepted; it exists to reject obvious
+/// garbage like `2020-13` while keeping the implementation simple.
+fn normalize_date(s: &str, bound: Bound) -> Option<String> {
+    let parts: Vec<&str> = s.split('-').collect();
+    let widths = [4usize, 2, 2];
+    // At least the year, at most year-month-day.
+    if parts.is_empty() || parts.len() > widths.len() {
+        return None;
+    }
+    for (part, &width) in parts.iter().zip(widths.iter()) {
+        if part.len() != width || !part.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+    }
+    // Range-check the present month/day components.
+    if let Some(month) = parts.get(1) {
+        let month: u8 = month.parse().ok()?;
+        if !(1..=12).contains(&month) {
+            return None;
+        }
+    }
+    if let Some(day) = parts.get(2) {
+        let day: u8 = day.parse().ok()?;
+        if !(1..=31).contains(&day) {
+            return None;
+        }
+    }
+
+    let (fill_month, fill_day) = match bound {
+        Bound::Earliest => ("01", "01"),
+        Bound::Latest => ("12", "31"),
+    };
+    let year = parts[0];
+    let month = parts.get(1).copied().unwrap_or(fill_month);
+    let day = parts.get(2).copied().unwrap_or(fill_day);
+    Some(format!("{year}-{month}-{day}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn master() -> Value {
+        json!({
+            "basics": {
+                "name": "Grace Hopper",
+                "label": "Engineer",
+                "email": "grace@example.com",
+                "phone": "+1-555-0100",
+                "url": "https://example.com/grace",
+                "location": { "city": "Arlington" }
+            },
+            "work": [
+                {
+                    "name": "Current Corp",
+                    "startDate": "2019-02-01",
+                    "highlights": ["a", "b", "c", "d"],
+                    "x-ferrocv": { "audience": ["security"] }
+                },
+                { "name": "Mid Corp", "startDate": "2015-03-01", "endDate": "2018-12-31" },
+                { "name": "Old Corp", "startDate": "2003-06-01", "endDate": "2005-06-30" }
+            ],
+            "volunteer": [
+                { "organization": "Mentors", "highlights": ["x", "y", "z"] }
+            ]
+        })
+    }
+
+    fn work_names(doc: &Value) -> Vec<String> {
+        doc["work"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["name"].as_str().unwrap().to_owned())
+            .collect()
+    }
+
+    #[test]
+    fn noop_spec_returns_input_unchanged() {
+        let doc = master();
+        let spec = ProjectionSpec::default();
+        assert!(spec.is_noop());
+        assert_eq!(project(&doc, &spec).unwrap(), doc);
+    }
+
+    #[test]
+    fn project_does_not_mutate_input() {
+        let doc = master();
+        let before = doc.clone();
+        let spec = ProjectionSpec {
+            since: Some("2015".into()),
+            max_bullets: Some(1),
+            redact: Some(RedactSet::Pii),
+        };
+        let _ = project(&doc, &spec).unwrap();
+        assert_eq!(doc, before, "master must be consumed read-only");
+    }
+
+    #[test]
+    fn since_drops_old_keeps_recent_and_ongoing() {
+        let spec = ProjectionSpec {
+            since: Some("2015".into()),
+            ..Default::default()
+        };
+        let out = project(&master(), &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["Current Corp", "Mid Corp"]);
+    }
+
+    #[test]
+    fn since_boundary_keeps_entry_ending_exactly_at_cutoff() {
+        // endDate "2015" is not strictly before "2015" ⇒ kept.
+        let doc = json!({ "work": [{ "name": "Edge", "endDate": "2015" }] });
+        let spec = ProjectionSpec {
+            since: Some("2015".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["Edge"]);
+    }
+
+    #[test]
+    fn since_is_granularity_aware() {
+        // A coarse year-only endDate is kept against a month-precision
+        // cutoff: "2015" could mean any month of 2015, so we keep it
+        // rather than dropping it the way a naive "2015" < "2015-06"
+        // lexicographic compare would.
+        let doc = json!({
+            "work": [
+                { "name": "YearOnly", "endDate": "2015" },
+                { "name": "EarlyMonth", "endDate": "2015-05" },
+                { "name": "LateMonth", "endDate": "2015-07" }
+            ]
+        });
+        let spec = ProjectionSpec {
+            since: Some("2015-06".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        // YearOnly kept (ambiguous), EarlyMonth dropped (definitely
+        // before June), LateMonth kept.
+        assert_eq!(work_names(&out), vec!["YearOnly", "LateMonth"]);
+    }
+
+    #[test]
+    fn since_keeps_entry_with_unparsable_end_date() {
+        // A non-date endDate cannot be proven old ⇒ kept.
+        let doc = json!({ "work": [{ "name": "Weird", "endDate": "present" }] });
+        let spec = ProjectionSpec {
+            since: Some("2015".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["Weird"]);
+    }
+
+    #[test]
+    fn max_bullets_caps_work_and_volunteer() {
+        let spec = ProjectionSpec {
+            max_bullets: Some(2),
+            ..Default::default()
+        };
+        let out = project(&master(), &spec).unwrap();
+        let current = &out["work"].as_array().unwrap()[0];
+        assert_eq!(
+            current["highlights"].as_array().unwrap().as_slice(),
+            &[json!("a"), json!("b")]
+        );
+        assert_eq!(
+            out["volunteer"][0]["highlights"].as_array().unwrap().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn max_bullets_leaves_x_ferrocv_untouched() {
+        let spec = ProjectionSpec {
+            max_bullets: Some(1),
+            ..Default::default()
+        };
+        let out = project(&master(), &spec).unwrap();
+        assert!(out["work"][0].get("x-ferrocv").is_some());
+    }
+
+    #[test]
+    fn redact_pii_removes_contact_fields_keeps_identity() {
+        let spec = ProjectionSpec {
+            redact: Some(RedactSet::Pii),
+            ..Default::default()
+        };
+        let out = project(&master(), &spec).unwrap();
+        let basics = out["basics"].as_object().unwrap();
+        assert!(!basics.contains_key("location"));
+        assert!(!basics.contains_key("phone"));
+        assert!(!basics.contains_key("email"));
+        assert!(basics.contains_key("name"));
+        assert!(basics.contains_key("label"));
+        assert!(basics.contains_key("url"));
+    }
+
+    #[test]
+    fn invalid_since_is_rejected() {
+        let spec = ProjectionSpec {
+            since: Some("banana".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            project(&master(), &spec),
+            Err(ProjectionError::InvalidSince("banana".into()))
+        );
+    }
+
+    #[test]
+    fn is_iso_date_accepts_valid_granularities() {
+        assert!(is_iso_date("2020"));
+        assert!(is_iso_date("2020-05"));
+        assert!(is_iso_date("2020-05-17"));
+    }
+
+    #[test]
+    fn is_iso_date_rejects_garbage() {
+        assert!(!is_iso_date("banana"));
+        assert!(!is_iso_date("20"));
+        assert!(!is_iso_date("2020-5"));
+        assert!(!is_iso_date("2020-05-17-01"));
+        assert!(!is_iso_date(""));
+        assert!(!is_iso_date("2020-"));
+    }
+
+    #[test]
+    fn is_iso_date_rejects_out_of_range_components() {
+        // Shape-valid but calendar-out-of-range values are rejected so
+        // the CLI's "malformed value is a usage error" promise holds.
+        assert!(!is_iso_date("2020-13"));
+        assert!(!is_iso_date("2020-00"));
+        assert!(!is_iso_date("2020-05-32"));
+        assert!(!is_iso_date("2020-05-00"));
+    }
+
+    #[test]
+    fn calendar_invalid_since_is_rejected() {
+        let spec = ProjectionSpec {
+            since: Some("2020-13".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            project(&master(), &spec),
+            Err(ProjectionError::InvalidSince("2020-13".into()))
+        );
+    }
+
+    #[test]
+    fn normalize_date_fills_bounds() {
+        assert_eq!(
+            normalize_date("2015", Bound::Earliest).as_deref(),
+            Some("2015-01-01")
+        );
+        assert_eq!(
+            normalize_date("2015", Bound::Latest).as_deref(),
+            Some("2015-12-31")
+        );
+        assert_eq!(
+            normalize_date("2015-06", Bound::Latest).as_deref(),
+            Some("2015-06-31")
+        );
+        assert_eq!(
+            normalize_date("2015-06-15", Bound::Earliest).as_deref(),
+            Some("2015-06-15")
+        );
+    }
+}

--- a/tests/fixtures/master_projection.json
+++ b/tests/fixtures/master_projection.json
@@ -1,0 +1,83 @@
+{
+  "basics": {
+    "name": "Grace Hopper",
+    "label": "Systems Engineer",
+    "summary": "Builds compilers and leads teams.",
+    "email": "grace@example.com",
+    "phone": "+1-555-0100",
+    "url": "https://example.com/grace",
+    "location": {
+      "city": "Arlington",
+      "region": "VA",
+      "countryCode": "US"
+    },
+    "profiles": [
+      {
+        "network": "GitHub",
+        "username": "grace",
+        "url": "https://github.example.com/grace"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Current Corp",
+      "position": "Principal Engineer",
+      "startDate": "2019-02-01",
+      "highlights": [
+        "Led the platform rewrite",
+        "Mentored eight engineers",
+        "Cut build times in half",
+        "Drove the security review program"
+      ],
+      "x-ferrocv": {
+        "audience": ["security", "leadership"],
+        "highlights": [
+          ["leadership"],
+          ["leadership"],
+          [],
+          ["security"]
+        ]
+      }
+    },
+    {
+      "name": "Mid Corp",
+      "position": "Senior Engineer",
+      "startDate": "2015-03-01",
+      "endDate": "2018-12-31",
+      "highlights": [
+        "Shipped the billing service",
+        "Owned on-call rotation",
+        "Reduced error budget burn"
+      ]
+    },
+    {
+      "name": "Old Corp",
+      "position": "Engineer",
+      "startDate": "2003-06-01",
+      "endDate": "2005-06-30",
+      "highlights": [
+        "Wrote the original parser",
+        "Maintained the test harness"
+      ]
+    }
+  ],
+  "volunteer": [
+    {
+      "organization": "Code Mentors",
+      "position": "Mentor",
+      "highlights": [
+        "Ran weekly office hours",
+        "Reviewed capstone projects",
+        "Organized the spring cohort"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "Yale University",
+      "area": "Mathematics",
+      "studyType": "PhD"
+    }
+  ]
+}

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -915,3 +915,87 @@ fn render_with_preview_spec_exits_two_with_install_hint() {
         "no output file should be written on uncached preview spec"
     );
 }
+
+// --- Projection flags on `render` (issue #148) ---------------------
+//
+// `render` gains the same mechanical projection flags as `tailor`, over
+// the shared transform (ADR 0005). These assert the flags are accepted
+// and produce output; the per-filter semantics are covered structurally
+// in `tests/tailor_cli.rs` against the same transform.
+
+#[test]
+fn render_with_since_flag_succeeds() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("2015")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+    assert!(out.exists(), "projected render writes output");
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(
+        !text.contains("Old Corp"),
+        "the --since-dropped role must not appear in rendered output"
+    );
+}
+
+#[test]
+fn render_with_max_bullets_and_redact_succeeds() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("master_projection"))
+        .arg("--max-bullets")
+        .arg("1")
+        .arg("--redact")
+        .arg("pii")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+    assert!(out.exists(), "projected render writes output");
+    // Assert the flags actually took effect in the rendered output, not
+    // just that a file appeared (a no-op projection would still write).
+    let text = std::fs::read_to_string(&out).expect("read output");
+    // --redact pii: contact fields gone from the rendered document.
+    assert!(!text.contains("grace@example.com"), "email redacted");
+    assert!(!text.contains("555-0100"), "phone redacted");
+    // --max-bullets 1: the first bullet survives, the second is dropped.
+    assert!(
+        text.contains("Led the platform rewrite"),
+        "first bullet kept"
+    );
+    assert!(
+        !text.contains("Mentored eight engineers"),
+        "second bullet dropped by --max-bullets 1"
+    );
+}
+
+#[test]
+fn render_without_projection_flags_is_unchanged() {
+    // No projection flags ⇒ projection stage is inert; render behaves
+    // exactly as it does on any input.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("master_projection"))
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(text.contains("Old Corp"), "no flags ⇒ nothing dropped");
+}

--- a/tests/tailor_cli.rs
+++ b/tests/tailor_cli.rs
@@ -1,0 +1,305 @@
+//! Scenario-style black-box tests for the `ferrocv tailor` subcommand.
+//!
+//! These tests spawn the real built binary via `assert_cmd` and assert
+//! on observable behavior only: exit code, stdout (the derived JSON
+//! Resume), stderr (diagnostics only), and output files. They do not
+//! call into the library API — `src/project.rs`'s unit tests cover the
+//! transform directly.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #1, every CLI-visible
+//! behavior gets a scenario test, written before the implementation.
+//! `tailor` is the standalone projection surface from ADR 0005; this
+//! issue (#148) implements its mechanical filters (`--since`,
+//! `--max-bullets`, `--redact`). The exit-code contract mirrors the
+//! other subcommands:
+//! - `0` — projected; derived JSON Resume written to `-o`/stdout
+//! - `1` — master parsed but failed schema validation
+//! - `2` — usage error (bad flag value), IO error, or parse error
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+
+/// Absolute path to a fixture file by filename stem (no extension).
+fn fixture(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(format!("{name}.json"));
+    path
+}
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
+}
+
+/// Parse the master fixture from disk for structural comparisons.
+fn master() -> Value {
+    let bytes = std::fs::read(fixture("master_projection")).expect("read master fixture");
+    serde_json::from_slice(&bytes).expect("master fixture parses as JSON")
+}
+
+/// Names of the `work` entries in a derived document, in order.
+fn work_names(doc: &Value) -> Vec<String> {
+    doc["work"]
+        .as_array()
+        .expect("work is an array")
+        .iter()
+        .map(|e| {
+            e["name"]
+                .as_str()
+                .expect("work entry has a name")
+                .to_owned()
+        })
+        .collect()
+}
+
+#[test]
+fn tailor_no_flags_is_identity() {
+    // With no projection flags the derived document must be structurally
+    // equal to the master (projection is opt-in and inert). Compared as
+    // serde_json::Value, so key ordering and whitespace don't matter.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    assert_eq!(doc, master(), "no-flags tailor must equal the master");
+}
+
+#[test]
+fn tailor_since_drops_old_keeps_recent_and_ongoing() {
+    // --since 2015: drop work entries whose endDate sorts before 2015,
+    // keep recent ones and any ongoing entry (no endDate).
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("2015")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    let names = work_names(&doc);
+    assert!(names.contains(&"Current Corp".to_owned()), "ongoing kept");
+    assert!(names.contains(&"Mid Corp".to_owned()), "recent kept");
+    assert!(!names.contains(&"Old Corp".to_owned()), "old dropped");
+    assert_eq!(names.len(), 2, "exactly two work entries survive");
+}
+
+#[test]
+fn tailor_max_bullets_caps_highlights() {
+    // --max-bullets 2: every highlights array capped to its first 2
+    // entries, by position.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--max-bullets")
+        .arg("2")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+
+    for entry in doc["work"].as_array().unwrap() {
+        if let Some(h) = entry.get("highlights").and_then(Value::as_array) {
+            assert!(h.len() <= 2, "work highlights capped at 2");
+        }
+    }
+    // Current Corp had 4 highlights; first 2 by position survive.
+    let current = doc["work"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["name"] == "Current Corp")
+        .expect("Current Corp present");
+    let highlights = current["highlights"].as_array().unwrap();
+    assert_eq!(highlights.len(), 2);
+    assert_eq!(highlights[0], "Led the platform rewrite");
+    assert_eq!(highlights[1], "Mentored eight engineers");
+
+    // The cap also applies to volunteer highlights (any bare-string
+    // highlights array), not just work.
+    let vol = &doc["volunteer"].as_array().unwrap()[0];
+    assert_eq!(vol["highlights"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn tailor_redact_pii_removes_fields_keeps_name() {
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--redact")
+        .arg("pii")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    let basics = &doc["basics"];
+    assert!(basics.get("location").is_none(), "location redacted");
+    assert!(basics.get("phone").is_none(), "phone redacted");
+    assert!(basics.get("email").is_none(), "email redacted");
+    // Non-PII identity fields are kept.
+    assert_eq!(basics["name"], "Grace Hopper", "name kept");
+    assert!(basics.get("label").is_some(), "label kept");
+    assert!(basics.get("summary").is_some(), "summary kept");
+    assert!(basics.get("url").is_some(), "url kept");
+}
+
+#[test]
+fn tailor_filters_compose() {
+    // All three filters in one invocation; verifies they compose.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("2015")
+        .arg("--max-bullets")
+        .arg("1")
+        .arg("--redact")
+        .arg("pii")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    assert_eq!(work_names(&doc).len(), 2, "since applied");
+    assert!(doc["basics"].get("email").is_none(), "redact applied");
+    for entry in doc["work"].as_array().unwrap() {
+        if let Some(h) = entry.get("highlights").and_then(Value::as_array) {
+            assert!(h.len() <= 1, "max-bullets applied");
+        }
+    }
+}
+
+#[test]
+fn tailor_preserves_x_ferrocv_tags() {
+    // Mechanical filters (#148) neither consume nor strip x-ferrocv;
+    // curated --audience selection (#149) owns that. The tag rides
+    // through untouched.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("2015")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    let current = doc["work"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["name"] == "Current Corp")
+        .expect("Current Corp present");
+    assert!(
+        current.get("x-ferrocv").is_some(),
+        "x-ferrocv tags preserved by mechanical filters"
+    );
+}
+
+#[test]
+fn tailor_writes_to_output_file_and_keeps_stdout_clean() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("cut.json");
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--redact")
+        .arg("pii")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+    assert!(out.exists(), "derived file written");
+    let bytes = std::fs::read(&out).expect("read derived file");
+    let doc: Value = serde_json::from_slice(&bytes).expect("derived file is valid JSON");
+    assert!(doc["basics"].get("email").is_none());
+}
+
+#[test]
+fn tailor_derived_document_revalidates() {
+    // ADR 0005 / doctrine: the derived document is itself valid JSON
+    // Resume and flows back into the pipeline. Tailor to a file, then
+    // validate that file with the same binary.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("cut.json");
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("2015")
+        .arg("--max-bullets")
+        .arg("2")
+        .arg("--redact")
+        .arg("pii")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success();
+    ferrocv()
+        .arg("validate")
+        .arg(&out)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn tailor_reads_master_from_stdin() {
+    let input = std::fs::read_to_string(fixture("master_projection")).expect("read master");
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg("--redact")
+        .arg("pii")
+        .write_stdin(input)
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    assert!(doc["basics"].get("phone").is_none());
+}
+
+#[test]
+fn tailor_rejects_invalid_master() {
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("invalid_wrong_type_email"))
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        // A schema diagnostic must reach stderr — guards against a
+        // refactor that silences validation errors or misroutes them.
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn tailor_rejects_malformed_since() {
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--since")
+        .arg("banana")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn tailor_rejects_unknown_redact_value() {
+    // --redact is a fixed vocabulary (clap ValueEnum); an unknown value
+    // is a clap usage error (exit 2).
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--redact")
+        .arg("everything")
+        .assert()
+        .code(2);
+}

--- a/tests/tailor_cli.rs
+++ b/tests/tailor_cli.rs
@@ -292,6 +292,21 @@ fn tailor_rejects_malformed_since() {
 }
 
 #[test]
+fn tailor_malformed_since_beats_invalid_master() {
+    // A malformed projection flag is a usage error (exit 2) and must win
+    // over a schema-invalid master (exit 1): bad CLI input is rejected
+    // before the document is even validated.
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("invalid_wrong_type_email"))
+        .arg("--since")
+        .arg("banana")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
 fn tailor_rejects_unknown_redact_value() {
     // --redact is a fixed vocabulary (clap ValueEnum); an unknown value
     // is a clap usage error (exit 2).


### PR DESCRIPTION
First implementation issue of the targeted-projection epic (#17, CONSTITUTION §7). Both gating ADRs (0004 tag schema, 0005 surface) are merged, so this builds the mechanical, theme-agnostic half of selection and lays the shared scaffolding that #149 (`--audience`) and #150 (re-validation) extend.

## What

A single shared transform `project(&Value, &ProjectionSpec)` in the new `src/project.rs`, exposed through two surfaces (ADR 0005), so `render --since X` is equivalent to `tailor --since X | render` by construction:

- **`ferrocv tailor [path] [filters] [-o <file>]`** — runs projection and stops, emitting the derived JSON Resume to stdout (pipe-friendly) or a file. All diagnostics go to stderr.
- **`ferrocv render` projection flags** — the same filters, applied before rendering. Flagless `render` is unchanged (projection is opt-in and inert).

## Filters

- `--since <YYYY|YYYY-MM|YYYY-MM-DD>` — drop `work` entries that ended before the cutoff; ongoing roles (no `endDate`) are always kept. Comparison is **granularity-aware**: an entry is dropped only when the latest instant its `endDate` could denote is strictly before the earliest the cutoff could denote, so a coarse `endDate: "2015"` survives `--since 2015-06` instead of being silently dropped. Calendar-out-of-range values (`2020-13`) are usage errors.
- `--max-bullets <N>` — cap every `highlights` list at the first N entries.
- `--redact pii` — remove `basics.location`/`phone`/`email`; keep `name`/`label`/`summary`/`url`/`profiles`.

Selection lives in Rust; themes receive an already-narrowed valid JSON Resume and stay ignorant of it (§4/§5). The master is consumed read-only (§1); `x-ferrocv` audience tags ride through untouched (their consumption is the next issue's job).

## Testing

Scenario tests written first (doctrine §1): `tests/tailor_cli.rs` (incl. a test that the derived document re-validates as JSON Resume), projection cases in `tests/render_cli.rs`, and unit tests in `src/project.rs` covering each filter, granularity edge cases, and date validation. `make preflight` green.

## Review

This branch was run through a 5-persona panel review; the valid findings were addressed before this PR — most notably the granularity-aware `--since` comparison (was a naive lexicographic compare that silently dropped year-only end dates), `#[non_exhaustive]` on `ProjectionSpec`, `is_noop()` made default-equality-based, and calendar-range validation on dates.

## Scope boundaries (deferred to siblings)

- Curated `--audience` selection + `x-ferrocv` stripping → #149
- Rigorous derived re-validation + malformed-tag negative tests → #150
- Tailoring guide + example tagged master → #151

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tailor` subcommand for extracting and filtering resume data.
  * Added projection flags (`--since`, `--max-bullets`, `--redact pii`) for filtering work history by date, capping highlights, and removing PII from both `tailor` and `render` commands.

* **Documentation**
  * Updated README with usage examples and expanded explanation of the projection model.

* **Tests**
  * Added integration tests for `tailor` subcommand and `render` projection flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->