### PR TITLE
Auto-merge Dependabot github-actions updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: dependabot-auto-merge
+
+# Enable GitHub's native auto-merge on Dependabot github-actions PRs so
+# routine action bumps land without manual review once CI is green.
+# Dependabot keeps its own branches rebased against main, so auto-merge
+# satisfies the "require branches up to date" protection rule on its own.
+# Scoped to the github-actions ecosystem only; cargo updates still merge
+# by hand.
+
+on: pull_request_target
+
+# pull_request_target runs in the base-repo context (with a writable
+# token) and never checks out the PR head, so the untrusted-code risk of
+# pull_request_target does not apply here.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for github-actions updates
+        if: steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`, which enables GitHub's native auto-merge on Dependabot PRs scoped to the **github-actions** ecosystem.

## Why

Routine action bumps (the five just merged in #162–#166) each forced a full CI rerun and a manual merge, made worse by the `workflow` token-scope requirement. Auto-merge lets these land hands-off once CI is green.

## How it works

- Triggers on `pull_request_target`; runs only when the actor is `dependabot[bot]`.
- `dependabot/fetch-metadata` (pinned to v3.1.0 SHA) reads the update's ecosystem.
- For `github_actions` updates only, it runs `gh pr merge --auto --merge`.
- Dependabot keeps its own branches rebased against `main`, so auto-merge satisfies the "require branches up to date" protection rule without extra tooling. Required checks still gate the merge.
- Cargo updates are deliberately excluded and remain manual-review.

Notes:
- Uses the default `GITHUB_TOKEN` (sufficient to enable auto-merge); no App token needed since this doesn't need to re-trigger downstream CI.
- `pull_request_target` is safe here — the workflow never checks out PR head code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to enable native auto-merge for eligible dependency update pull requests, reducing manual effort while improving merge consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->