### PR TITLE
Ignore Claude Code scheduled-tasks lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock.bak
 .prompts
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Added by ggshield
 .cache_ggshield


### PR DESCRIPTION
Adds `.claude/scheduled_tasks.lock` to `.gitignore`. It's a Claude Code runtime artifact, not something to commit.

Leaves the rest of `.claude/` committable (e.g. a future `settings.json`, agents, commands) — only the local/runtime items are ignored (`settings.local.json`, `worktrees/`, and now `scheduled_tasks.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
