### PR TITLE
Curated audience selection for projection cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,33 @@ also available on `render`, which projects then renders in one shot —
 so `ferrocv render master.json --since 2015` is equivalent to
 `ferrocv tailor master.json --since 2015 | ferrocv render`.
 
-The **mechanical** filters (theme-agnostic, available today):
+The **curated** filter (the headline — keep what's *relevant*, not the
+first N by position):
+
+- `--audience <name>` — keep only content tagged for that audience. Tag
+  an array entry (a `work`/`volunteer`/`project`/… object) by adding an
+  `x-ferrocv` object beside its fields: `"x-ferrocv": { "audience":
+  ["security"] }`. Tag individual bullets with an index-parallel
+  `"x-ferrocv": { "highlights": [["security"], [], ["leadership"]] }`,
+  one tag-list per `highlights` entry. **Untagged content (or an empty
+  `[]` tag) is universal** — kept in every cut — so you can adopt tags
+  incrementally; only content tagged for *other* audiences is dropped.
+  The consumed `x-ferrocv` metadata is stripped from the derived
+  document. (Schema and rationale: ADR 0004.)
+
+The **mechanical** filters (theme-agnostic):
 
 - `--since <YYYY|YYYY-MM|YYYY-MM-DD>` — drop `work` entries that ended
   before the cutoff. Ongoing roles (no `endDate`) are always kept.
 - `--max-bullets <N>` — cap every `highlights` list at the first N
-  bullets.
+  bullets. Runs *after* `--audience`, so it caps the already-curated
+  set.
 - `--redact pii` — remove `basics.location`, `basics.phone`, and
   `basics.email` from the cut. Identity fields (`name`, `label`,
   `summary`, `url`, `profiles`) are kept.
 
 With no projection flags, `render` behaves exactly as it does on any
-input — projection is opt-in and inert by default. Curated,
-audience-tag-driven selection (`--audience`) is in progress.
+input — projection is opt-in and inert by default.
 
 `tailor` writes the derived document to `--output <file>`, or to stdout
 when `--output` is omitted, so it composes in a pipe; all diagnostics

--- a/docs/adr/0004-audience-tag-schema.md
+++ b/docs/adr/0004-audience-tag-schema.md
@@ -1,6 +1,6 @@
 # 0004. Carry audience tags under a single `x-ferrocv` namespace; untagged content is universal
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-31
 
 ## Context

--- a/docs/adr/0005-projection-surface.md
+++ b/docs/adr/0005-projection-surface.md
@@ -1,6 +1,6 @@
 # 0005. Ship projection as both a standalone `tailor` subcommand and `render` flags over one transform
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-31
 
 ## Context

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,13 +120,14 @@ enum Commands {
     /// any PII not removed by `--redact` — is printed to stdout. Prefer
     /// `--output <file>` for unattended or shared/recorded contexts.
     ///
-    /// This subcommand implements the mechanical filters (`--since`,
-    /// `--max-bullets`, `--redact`); curated `--audience` selection
-    /// lands in a follow-up.
+    /// Supports the curated `--audience` filter and the mechanical
+    /// `--since` / `--max-bullets` / `--redact` filters.
     ///
     /// Exit codes:
     /// - 0 — projected; derived document written to --output/stdout
-    /// - 1 — master parsed but failed schema validation
+    /// - 1 — master parsed but failed schema validation, or an
+    ///   `x-ferrocv.highlights` tag array is misaligned with its
+    ///   `highlights`
     /// - 2 — usage error (bad flag value), IO error, or parse error
     Tailor {
         /// Path to the master JSON Resume. Reads stdin if omitted.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,8 +24,9 @@ use clap::{Args, Parser, Subcommand};
 use serde_json::Value;
 
 use crate::{
-    ProjectionSpec, RedactSet, THEMES, ThemeResolveError, ValidationError, compile_html_resolved,
-    compile_text_resolved, compile_theme_resolved, project, resolve_theme, validate_value,
+    ProjectionError, ProjectionSpec, RedactSet, THEMES, ThemeResolveError, ValidationError,
+    compile_html_resolved, compile_text_resolved, compile_theme_resolved, project, resolve_theme,
+    validate_value,
 };
 
 /// Render JSON Resume documents via embedded Typst.
@@ -228,10 +229,15 @@ enum Format {
 /// Defining the flags once and feeding them to the single
 /// [`crate::project`] transform is what keeps the two surfaces
 /// equivalent (ADR 0005): `render --since X` and `tailor --since X |
-/// render` run the same code. Curated `--audience` selection (#149) adds
-/// its field here.
+/// render` run the same code.
 #[derive(Debug, Clone, Args)]
 struct ProjectionArgs {
+    /// Keep only content tagged for this audience under `x-ferrocv`
+    /// (curated selection). Untagged content is kept for every audience;
+    /// tagged content is kept only for the audiences it lists. Takes
+    /// exactly one value.
+    #[arg(long, value_name = "NAME")]
+    audience: Option<String>,
     /// Drop `work` entries that ended before this ISO 8601 date
     /// (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`). Entries with no end date
     /// (ongoing roles) are always kept. A malformed value is a usage
@@ -252,12 +258,27 @@ impl ProjectionArgs {
     /// Translate the parsed CLI flags into a library [`ProjectionSpec`].
     fn to_spec(&self) -> ProjectionSpec {
         ProjectionSpec {
+            audience: self.audience.clone(),
             since: self.since.clone(),
             max_bullets: self.max_bullets,
             redact: self.redact.map(|r| match r {
                 RedactArg::Pii => RedactSet::Pii,
             }),
         }
+    }
+}
+
+/// Map a [`ProjectionError`] to its process exit code.
+///
+/// A malformed flag *value* is a usage error (exit 2), consistent with
+/// `--since banana` and an unknown `--redact` value. A misaligned
+/// `x-ferrocv.highlights` tag array is a defect in the master *document*,
+/// not the invocation, so it shares the schema-failure exit code (1) the
+/// way a structurally-invalid master already does.
+fn projection_exit_code(err: &ProjectionError) -> u8 {
+    match err {
+        ProjectionError::InvalidSince(_) => 2,
+        ProjectionError::HighlightsTagMismatch { .. } => 1,
     }
 }
 
@@ -595,7 +616,7 @@ fn run_render(
             Ok(derived) => derived,
             Err(err) => {
                 eprintln!("error: {err}; no output written");
-                return Ok(ExitCode::from(2));
+                return Ok(ExitCode::from(projection_exit_code(&err)));
             }
         }
     };
@@ -719,13 +740,15 @@ fn run_tailor(
         return Ok(ExitCode::from(1));
     }
 
-    // Step 4: project. The only failure here is a malformed flag value
-    // (e.g. a non-date `--since`), which is a usage error.
+    // Step 4: project. A malformed flag value (e.g. a non-date `--since`)
+    // is a usage error (exit 2); a misaligned audience tag array is a
+    // defect in the master document, treated like a schema failure (exit
+    // 1). See `projection_exit_code`.
     let derived = match project(&value, spec) {
         Ok(d) => d,
         Err(err) => {
             eprintln!("error: {err}; no output written");
-            return Ok(ExitCode::from(2));
+            return Ok(ExitCode::from(projection_exit_code(&err)));
         }
     };
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -436,7 +436,8 @@ enum Bound {
 /// bare-string `highlights` array — `work`, `volunteer`, `projects`.
 /// The index-parallel `x-ferrocv.highlights` tag array (an array *of
 /// arrays*, nested under `x-ferrocv`) is a sibling key and is left
-/// untouched; mechanical filters do not consume tags (#149's job).
+/// untouched; mechanical filters do not consume tags — that is
+/// [`apply_audience`]'s job, and it runs first (see [`project`]).
 fn apply_max_bullets(out: &mut Value, n: usize) {
     for section in ["work", "volunteer", "projects"] {
         if let Some(entries) = out.get_mut(section).and_then(Value::as_array_mut) {

--- a/src/project.rs
+++ b/src/project.rs
@@ -7,19 +7,24 @@
 //! pipeline unchanged. The master is consumed read-only (§1); the
 //! transform returns a new [`serde_json::Value`].
 //!
-//! This module implements only the **mechanical** filters (issue #148):
+//! This module implements two layers of selection:
 //!
+//! - [`ProjectionSpec::audience`] — *curated*, tag-driven selection
+//!   (issue #149, ADR 0004): keep array elements that are untagged or
+//!   carry the requested audience under `x-ferrocv.audience`, and within
+//!   surviving elements keep the highlights whose index-parallel
+//!   `x-ferrocv.highlights` tag matches. The consumed `x-ferrocv` keys
+//!   are stripped from the derived document.
 //! - [`ProjectionSpec::since`] — drop `work` entries that ended before a
 //!   cutoff date; ongoing entries (no `endDate`) are always kept.
 //! - [`ProjectionSpec::max_bullets`] — cap every `highlights` array at
 //!   the first N entries by position.
 //! - [`ProjectionSpec::redact`] — remove named PII fields from `basics`.
 //!
-//! Curated, tag-driven `--audience` selection (and the consumption /
-//! stripping of `x-ferrocv` tags it entails) is issue #149's job; this
-//! stage leaves `x-ferrocv` metadata untouched. Selection lives here in
-//! Rust, never in themes (§4/§5): a theme only ever sees the
-//! already-narrowed document.
+//! Selection lives here in Rust, never in themes (§4/§5): a theme only
+//! ever sees the already-narrowed document. The mechanical filters
+//! (`since`/`max_bullets`/`redact`) do **not** touch `x-ferrocv`; only
+//! curated `audience` selection consumes and strips it.
 //!
 //! Both CLI surfaces — the standalone `tailor` subcommand and the
 //! `render` projection flags (ADR 0005) — call [`project`], so the two
@@ -42,19 +47,28 @@ pub enum RedactSet {
     Pii,
 }
 
-/// The mechanical projection filters (issue #148).
+/// The projection selection spec: the curated `audience` filter (#149)
+/// plus the mechanical `since` / `max_bullets` / `redact` filters (#148).
 ///
 /// An all-`None` spec is a no-op: [`project`] returns the input
-/// unchanged (structurally). Curated `--audience` selection (#149) will
-/// add its field here without changing the existing semantics.
+/// unchanged (structurally).
 ///
-/// Marked `#[non_exhaustive]` because the struct is *documented to grow*
-/// (the `--audience` field above): out-of-crate callers construct it via
-/// [`ProjectionSpec::default`] plus field assignment rather than a struct
-/// literal, so adding a field later is not a breaking change for them.
+/// Marked `#[non_exhaustive]` because the struct is *documented to grow*:
+/// out-of-crate callers construct it via [`ProjectionSpec::default`] plus
+/// field assignment rather than a struct literal, so adding a field later
+/// is not a breaking change for them.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ProjectionSpec {
+    /// Curated selection: keep only content tagged for this audience
+    /// under `x-ferrocv` (ADR 0004). An array element is kept when it is
+    /// untagged (no `x-ferrocv.audience`, or an empty list) or its tag
+    /// list contains this audience; it is dropped only when tagged
+    /// without it. Within surviving elements, highlights are filtered the
+    /// same way against the index-parallel `x-ferrocv.highlights`. The
+    /// consumed `x-ferrocv` keys are stripped from the derived document.
+    /// `None` runs no curated selection (every element is universal).
+    pub audience: Option<String>,
     /// Drop `work` entries that ended before this ISO 8601 date (`YYYY`,
     /// `YYYY-MM`, or `YYYY-MM-DD`). Comparison is granularity-aware: an
     /// entry is dropped only when the latest instant its `endDate` could
@@ -82,14 +96,21 @@ impl ProjectionSpec {
         *self == ProjectionSpec::default()
     }
 
-    /// Validate the spec's flag values without touching a document.
+    /// Validate the spec's flag-*value* formats without touching a
+    /// document.
     ///
-    /// Currently this just checks that `since` (if set) is a usable ISO
-    /// 8601 date. Callers should run this *before* reading or validating
-    /// the input document, so a malformed flag value surfaces as a usage
-    /// error rather than being masked by an unrelated schema failure in
-    /// the document. [`project`] also calls it, so the guarantee holds
-    /// even for callers that skip the early check.
+    /// This covers only errors detectable from the flags alone — currently
+    /// just that `since` (if set) is a usable ISO 8601 date. Callers should
+    /// run it *before* reading or validating the input document, so a
+    /// malformed flag value surfaces as a usage error rather than being
+    /// masked by an unrelated schema failure in the document. [`project`]
+    /// also calls it, so the guarantee holds even for callers that skip the
+    /// early check.
+    ///
+    /// It does **not** (and cannot) catch document-structural errors like
+    /// [`ProjectionError::HighlightsTagMismatch`], which depend on the
+    /// document itself; those still surface from [`project`] even after a
+    /// clean `validate()`.
     pub fn validate(&self) -> Result<(), ProjectionError> {
         if let Some(since) = &self.since
             && !is_iso_date(since)
@@ -102,12 +123,41 @@ impl ProjectionSpec {
 
 /// An error from [`project`].
 ///
-/// Currently the only failure is a malformed `--since` value; the other
-/// filters cannot fail on a document that already schema-validates.
+/// Two failure classes, and the CLI maps them to *different* exit codes:
+/// [`InvalidSince`](ProjectionError::InvalidSince) is a malformed flag
+/// value (a usage error), while
+/// [`HighlightsTagMismatch`](ProjectionError::HighlightsTagMismatch) is a
+/// defect in the master document (treated like a schema failure).
+///
+/// Marked `#[non_exhaustive]` because the set of failure classes is
+/// *documented to grow* (it went 1→2 with curated selection): out-of-crate
+/// callers must include a wildcard arm, so adding a variant later is not a
+/// breaking change for them.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProjectionError {
     /// The `--since` value is not a recognizable ISO 8601 date.
     InvalidSince(String),
+    /// An entry's `x-ferrocv.highlights` tag array is not aligned with
+    /// its `highlights` array — different lengths. ADR 0004 makes this a
+    /// hard error rather than a silent pad/truncate, because a positional
+    /// array that silently misattributes tags after a reordered or
+    /// inserted bullet would ship the wrong cut. Names the offending
+    /// entry so the user can fix it.
+    HighlightsTagMismatch {
+        /// The section the entry lives in (e.g. `"work"`).
+        section: String,
+        /// The entry's index within that section's array.
+        index: usize,
+        /// A human-friendly label for the entry — the first present of
+        /// `name`, `organization`, `institution`, `title`, or `position`
+        /// (see [`entry_label`]) — or `None` if it has none.
+        name: Option<String>,
+        /// Length of the entry's `highlights` array.
+        highlights_len: usize,
+        /// Length of the misaligned `x-ferrocv.highlights` array.
+        tags_len: usize,
+    },
 }
 
 impl fmt::Display for ProjectionError {
@@ -118,6 +168,28 @@ impl fmt::Display for ProjectionError {
                 "invalid 'since' value {value:?}: expected an ISO 8601 date \
                  (YYYY, YYYY-MM, or YYYY-MM-DD)"
             ),
+            ProjectionError::HighlightsTagMismatch {
+                section,
+                index,
+                name,
+                highlights_len,
+                tags_len,
+            } => {
+                let label = match name {
+                    Some(name) => format!(" {name:?}"),
+                    None => String::new(),
+                };
+                // Both `section` (a top-level JSON key from the input) and
+                // `name` are written via Debug (`{:?}`) so a crafted value
+                // with control characters can't inject newlines into the
+                // stderr stream that tooling may parse.
+                write!(
+                    f,
+                    "{section:?}[{index}]{label}: x-ferrocv.highlights has {tags_len} \
+                     tag(s) but the entry has {highlights_len} highlight(s); they \
+                     must be the same length"
+                )
+            }
         }
     }
 }
@@ -127,12 +199,17 @@ impl std::error::Error for ProjectionError {}
 /// Apply the projection `spec` to `doc`, returning a derived document.
 ///
 /// `doc` is never mutated. The returned [`Value`] is a fresh document
-/// with the mechanical filters applied in a fixed order — `since`, then
-/// `max_bullets`, then `redact` — so composition is deterministic.
+/// with the filters applied in a fixed order — `audience`, then `since`,
+/// then `max_bullets`, then `redact` — so composition is deterministic.
 ///
-/// Returns [`ProjectionError::InvalidSince`] if `spec.since` is set but
-/// not a valid ISO 8601 date; the document is validated for that before
-/// any work is done.
+/// Curated `audience` selection runs **first** so that it precedes the
+/// positional `max_bullets` cap ("keep what's relevant, *then* cap"), and
+/// so the index-parallel `x-ferrocv.highlights` tags are consumed against
+/// the entry's full, un-truncated `highlights` array.
+///
+/// Returns [`ProjectionError::InvalidSince`] if `spec.since` is malformed,
+/// or [`ProjectionError::HighlightsTagMismatch`] if an entry's audience
+/// highlight-tags are not aligned with its highlights.
 pub fn project(doc: &Value, spec: &ProjectionSpec) -> Result<Value, ProjectionError> {
     // Validate the spec up front, before cloning, so a bad flag value is
     // cheap to reject. Callers are encouraged to call `validate()` even
@@ -142,6 +219,9 @@ pub fn project(doc: &Value, spec: &ProjectionSpec) -> Result<Value, ProjectionEr
 
     let mut out = doc.clone();
 
+    if let Some(audience) = &spec.audience {
+        apply_audience(&mut out, audience)?;
+    }
     if let Some(since) = &spec.since {
         apply_since(&mut out, since);
     }
@@ -153,6 +233,148 @@ pub fn project(doc: &Value, spec: &ProjectionSpec) -> Result<Value, ProjectionEr
     }
 
     Ok(out)
+}
+
+/// Curated, tag-driven selection for `--audience` (ADR 0004).
+///
+/// For every top-level array section, drop the elements that are *tagged
+/// and exclude* `audience`, keeping universal (untagged / empty-tag) and
+/// matching elements. Within each surviving element that carries a
+/// bare-string `highlights` array, filter the highlights by the
+/// index-parallel `x-ferrocv.highlights` tags the same way. Finally strip
+/// the consumed `x-ferrocv` key from every surviving element (and from
+/// the singleton `basics` object) so the derived document is clean JSON
+/// Resume that re-validates (#150) and does not leak the user's
+/// audience-targeting topology.
+///
+/// `basics` is a singleton object, not an array, so it carries no audience
+/// tag and its resume fields are kept verbatim (PII suppression is
+/// `--redact`'s job, not audience selection — ADR 0004); only its
+/// `x-ferrocv` control metadata, if any, is stripped.
+///
+/// Returns [`ProjectionError::HighlightsTagMismatch`] if an entry's
+/// `x-ferrocv.highlights` length differs from its `highlights` length.
+fn apply_audience(out: &mut Value, audience: &str) -> Result<(), ProjectionError> {
+    let Some(root) = out.as_object_mut() else {
+        return Ok(());
+    };
+
+    for (section, value) in root.iter_mut() {
+        // `basics` is a singleton object: no audience tag, but strip its
+        // consumed `x-ferrocv` control metadata so it never leaks.
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("x-ferrocv");
+            continue;
+        }
+        let Some(entries) = value.as_array_mut() else {
+            continue;
+        };
+
+        // Rebuild the section in a single pass that carries each entry's
+        // *original* index, so a mismatch error names the entry's position
+        // in the master document — not its position after earlier entries
+        // were audience-dropped (which `retain`-then-`enumerate` would).
+        let mut kept: Vec<Value> = Vec::with_capacity(entries.len());
+        for (index, mut entry) in std::mem::take(entries).into_iter().enumerate() {
+            if !entry_matches_audience(&entry, audience) {
+                continue;
+            }
+            filter_entry_highlights(&mut entry, audience, section, index)?;
+            if let Some(obj) = entry.as_object_mut() {
+                obj.remove("x-ferrocv");
+            }
+            kept.push(entry);
+        }
+        *entries = kept;
+    }
+
+    Ok(())
+}
+
+/// Whether an array element is kept for `audience` based on its own
+/// `x-ferrocv.audience` tag.
+///
+/// Per ADR 0004's include-by-default rule, an element is kept when it is
+/// *untagged* (no `x-ferrocv.audience`, a non-array value, or an empty
+/// array — all "universal") or its tag list contains `audience`. It is
+/// dropped only when tagged with a non-empty list that omits `audience`.
+fn entry_matches_audience(entry: &Value, audience: &str) -> bool {
+    match entry.pointer("/x-ferrocv/audience") {
+        Some(Value::Array(tags)) if !tags.is_empty() => {
+            tags.iter().any(|t| t.as_str() == Some(audience))
+        }
+        // Absent, empty, or non-array ⇒ universal ⇒ kept.
+        _ => true,
+    }
+}
+
+/// Filter a surviving entry's `highlights` by its index-parallel
+/// `x-ferrocv.highlights` tags for `audience`.
+///
+/// A highlight is kept when its tag slot is universal (absent / empty /
+/// non-array) or contains `audience`. No `x-ferrocv.highlights` key ⇒
+/// every highlight is universal ⇒ nothing dropped. A present tag array
+/// whose length differs from `highlights` is a hard error (ADR 0004):
+/// silently misaligned positional tags would ship the wrong cut.
+fn filter_entry_highlights(
+    entry: &mut Value,
+    audience: &str,
+    section: &str,
+    index: usize,
+) -> Result<(), ProjectionError> {
+    // Read the tag array (cloned out) before mutating the entry.
+    let tags: Option<Vec<Value>> = entry
+        .pointer("/x-ferrocv/highlights")
+        .and_then(Value::as_array)
+        .cloned();
+    let Some(tags) = tags else {
+        return Ok(());
+    };
+
+    // Resolve the highlights length and the offending-entry label via
+    // immutable borrows up front, so the mismatch error (and the mutable
+    // retain below) don't overlapping-borrow `entry`.
+    let highlights_len = match entry.get("highlights").and_then(Value::as_array) {
+        Some(highlights) => highlights.len(),
+        // `x-ferrocv.highlights` on an entry with no `highlights` array is
+        // meaningless and ignored (ADR 0004) — nothing to align to.
+        None => return Ok(()),
+    };
+
+    if tags.len() != highlights_len {
+        return Err(ProjectionError::HighlightsTagMismatch {
+            section: section.to_owned(),
+            index,
+            name: entry_label(entry),
+            highlights_len,
+            tags_len: tags.len(),
+        });
+    }
+
+    let highlights = entry
+        .get_mut("highlights")
+        .and_then(Value::as_array_mut)
+        .expect("highlights array presence just checked above");
+    let mut keep = tags.iter().map(|slot| match slot {
+        Value::Array(audiences) if !audiences.is_empty() => {
+            audiences.iter().any(|a| a.as_str() == Some(audience))
+        }
+        // Absent (covered by length check), empty, or non-array ⇒ universal.
+        _ => true,
+    });
+    highlights.retain(|_| keep.next().unwrap_or(true));
+    Ok(())
+}
+
+/// A human-friendly label for an array entry, used in error messages.
+/// Tries the common JSON Resume identity fields in priority order.
+fn entry_label(entry: &Value) -> Option<String> {
+    for key in ["name", "organization", "institution", "title", "position"] {
+        if let Some(label) = entry.get(key).and_then(Value::as_str) {
+            return Some(label.to_owned());
+        }
+    }
+    None
 }
 
 /// Drop `work` entries that ended before `since`.
@@ -341,6 +563,45 @@ mod tests {
         })
     }
 
+    /// A master exercising audience tags at both granularities: a
+    /// security-only entry, a leadership-only entry, an untagged entry,
+    /// and per-highlight tags index-parallel to the highlights.
+    fn audience_master() -> Value {
+        json!({
+            "work": [
+                {
+                    "name": "Tagged Corp",
+                    "highlights": ["sec bullet", "lead bullet", "shared bullet"],
+                    "x-ferrocv": {
+                        "audience": ["security", "leadership"],
+                        "highlights": [["security"], ["leadership"], []]
+                    }
+                },
+                {
+                    "name": "Security Only",
+                    "x-ferrocv": { "audience": ["security"] }
+                },
+                {
+                    "name": "Leadership Only",
+                    "x-ferrocv": { "audience": ["leadership"] }
+                },
+                {
+                    "name": "Untagged Corp",
+                    "highlights": ["keep me"]
+                }
+            ]
+        })
+    }
+
+    fn highlights(entry: &Value) -> Vec<String> {
+        entry["highlights"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|h| h.as_str().unwrap().to_owned())
+            .collect()
+    }
+
     fn work_names(doc: &Value) -> Vec<String> {
         doc["work"]
             .as_array()
@@ -363,6 +624,7 @@ mod tests {
         let doc = master();
         let before = doc.clone();
         let spec = ProjectionSpec {
+            audience: Some("security".into()),
             since: Some("2015".into()),
             max_bullets: Some(1),
             redact: Some(RedactSet::Pii),
@@ -470,6 +732,219 @@ mod tests {
         assert!(basics.contains_key("name"));
         assert!(basics.contains_key("label"));
         assert!(basics.contains_key("url"));
+    }
+
+    #[test]
+    fn audience_drops_entries_tagged_for_other_audiences() {
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&audience_master(), &spec).unwrap();
+        // Tagged Corp (has security), Security Only, and Untagged Corp
+        // survive; Leadership Only is dropped.
+        assert_eq!(
+            work_names(&out),
+            vec!["Tagged Corp", "Security Only", "Untagged Corp"]
+        );
+    }
+
+    #[test]
+    fn audience_keeps_untagged_entries_as_universal() {
+        // Untagged Corp has no x-ferrocv at all ⇒ universal ⇒ kept for
+        // every audience, including one nothing is tagged for.
+        let spec = ProjectionSpec {
+            audience: Some("nobody-tagged-this".into()),
+            ..Default::default()
+        };
+        let out = project(&audience_master(), &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["Untagged Corp"]);
+    }
+
+    #[test]
+    fn audience_empty_tag_list_is_universal_not_excluded() {
+        // An explicit `audience: []` means "for everyone", never
+        // "exclude from all" (ADR 0004 pins `[]` to universal).
+        let doc = json!({
+            "work": [{ "name": "Everyone", "x-ferrocv": { "audience": [] } }]
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["Everyone"]);
+    }
+
+    #[test]
+    fn audience_filters_highlights_within_surviving_entry() {
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&audience_master(), &spec).unwrap();
+        let tagged = &out["work"].as_array().unwrap()[0];
+        // "sec bullet" (security) kept; "lead bullet" (leadership) dropped;
+        // "shared bullet" ([] ⇒ universal) kept.
+        assert_eq!(highlights(tagged), vec!["sec bullet", "shared bullet"]);
+    }
+
+    #[test]
+    fn audience_filters_non_work_sections_generically() {
+        // The audience sweep is not work-specific: every top-level array
+        // section is filtered, and surviving entries' highlights too. Here
+        // a volunteer entry tagged for leadership is dropped, while a
+        // security-tagged one survives with only its security highlights.
+        let doc = json!({
+            "volunteer": [
+                {
+                    "organization": "Sec Org",
+                    "highlights": ["sec", "lead"],
+                    "x-ferrocv": { "audience": ["security"], "highlights": [["security"], ["leadership"]] }
+                },
+                { "organization": "Lead Org", "x-ferrocv": { "audience": ["leadership"] } }
+            ]
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        let vols = out["volunteer"].as_array().unwrap();
+        assert_eq!(vols.len(), 1, "leadership-only volunteer entry dropped");
+        assert_eq!(vols[0]["organization"], "Sec Org");
+        assert_eq!(highlights(&vols[0]), vec!["sec"]);
+        assert!(vols[0].get("x-ferrocv").is_none(), "x-ferrocv stripped");
+    }
+
+    #[test]
+    fn audience_strips_x_ferrocv_from_basics() {
+        // `basics` is a singleton object (no audience tag), but its
+        // consumed x-ferrocv control metadata must still be stripped so a
+        // derived cut never leaks the targeting topology.
+        let doc = json!({
+            "basics": { "name": "Grace", "x-ferrocv": { "note": "internal" } }
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        assert_eq!(out["basics"]["name"], "Grace", "resume fields kept");
+        assert!(
+            out["basics"].get("x-ferrocv").is_none(),
+            "x-ferrocv stripped from basics"
+        );
+    }
+
+    #[test]
+    fn audience_mismatch_error_reports_original_master_index() {
+        // The mismatch error must name the entry's position in the master,
+        // not its post-filter position. Here work[0] is audience-dropped,
+        // so the misaligned work[1] must still be reported as index 1.
+        let doc = json!({
+            "work": [
+                { "name": "Dropped", "x-ferrocv": { "audience": ["leadership"] } },
+                {
+                    "name": "Misaligned",
+                    "highlights": ["a", "b"],
+                    "x-ferrocv": { "highlights": [["security"]] }
+                }
+            ]
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        match project(&doc, &spec) {
+            Err(ProjectionError::HighlightsTagMismatch { index, name, .. }) => {
+                assert_eq!(index, 1, "must report the master index, not post-filter");
+                assert_eq!(name.as_deref(), Some("Misaligned"));
+            }
+            other => panic!("expected HighlightsTagMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audience_strips_consumed_x_ferrocv_from_survivors() {
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&audience_master(), &spec).unwrap();
+        for entry in out["work"].as_array().unwrap() {
+            assert!(
+                entry.get("x-ferrocv").is_none(),
+                "x-ferrocv must be stripped from the derived document"
+            );
+        }
+    }
+
+    #[test]
+    fn audience_runs_before_max_bullets() {
+        // Curated selection precedes the positional cap: filter to the
+        // security highlights first (["sec bullet", "shared bullet"]),
+        // then --max-bullets 1 keeps only the first of those.
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            max_bullets: Some(1),
+            ..Default::default()
+        };
+        let out = project(&audience_master(), &spec).unwrap();
+        let tagged = &out["work"].as_array().unwrap()[0];
+        assert_eq!(highlights(tagged), vec!["sec bullet"]);
+    }
+
+    #[test]
+    fn audience_highlights_length_mismatch_is_an_error() {
+        let doc = json!({
+            "work": [{
+                "name": "Misaligned",
+                "highlights": ["a", "b", "c"],
+                "x-ferrocv": { "highlights": [["security"], ["security"]] }
+            }]
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            project(&doc, &spec),
+            Err(ProjectionError::HighlightsTagMismatch {
+                section: "work".into(),
+                index: 0,
+                name: Some("Misaligned".into()),
+                highlights_len: 3,
+                tags_len: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn audience_ignores_highlight_tags_on_entry_without_highlights() {
+        // x-ferrocv.highlights with nothing to align to is ignored, not a
+        // mismatch error (ADR 0004).
+        let doc = json!({
+            "work": [{ "name": "NoHl", "x-ferrocv": { "highlights": [["security"]] } }]
+        });
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let out = project(&doc, &spec).unwrap();
+        assert_eq!(work_names(&out), vec!["NoHl"]);
+    }
+
+    #[test]
+    fn audience_does_not_mutate_input() {
+        let doc = audience_master();
+        let before = doc.clone();
+        let spec = ProjectionSpec {
+            audience: Some("security".into()),
+            ..Default::default()
+        };
+        let _ = project(&doc, &spec).unwrap();
+        assert_eq!(doc, before, "master must be consumed read-only");
     }
 
     #[test]

--- a/tests/fixtures/master_audience_mismatch.json
+++ b/tests/fixtures/master_audience_mismatch.json
@@ -1,0 +1,24 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "label": "Engineer"
+  },
+  "work": [
+    {
+      "name": "Misaligned Corp",
+      "position": "Engineer",
+      "startDate": "2020-01-01",
+      "highlights": [
+        "First bullet",
+        "Second bullet",
+        "Third bullet"
+      ],
+      "x-ferrocv": {
+        "highlights": [
+          ["security"],
+          ["security"]
+        ]
+      }
+    }
+  ]
+}

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -999,3 +999,86 @@ fn render_without_projection_flags_is_unchanged() {
     let text = std::fs::read_to_string(&out).expect("read output");
     assert!(text.contains("Old Corp"), "no flags ⇒ nothing dropped");
 }
+
+// --- Curated `--audience` selection on `render` (issue #149) --------
+
+#[test]
+fn render_with_audience_flag_selects_tagged_content() {
+    // Current Corp's bullets are tagged [leadership, leadership, [],
+    // security]. --audience security keeps the universal and security
+    // bullets and drops the leadership-only ones.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = tmp.path().join("out.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("master_projection"))
+        .arg("--audience")
+        .arg("security")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(
+        text.contains("Drove the security review program"),
+        "security-tagged bullet kept"
+    );
+    assert!(
+        !text.contains("Led the platform rewrite"),
+        "leadership-only bullet dropped for --audience security"
+    );
+}
+
+#[test]
+fn render_audience_equivalent_to_tailor_then_render() {
+    // ADR 0005: `render --audience X` is equivalent to `tailor --audience
+    // X | render`. The equivalence lives on the derived JSON; we assert it
+    // transitively through the deterministic text theme — identical text
+    // output implies the same derived document reached the renderer.
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Path A: render directly with --audience.
+    let direct = tmp.path().join("direct.txt");
+    ferrocv()
+        .arg("render")
+        .arg(fixture("master_projection"))
+        .arg("--audience")
+        .arg("security")
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&direct)
+        .assert()
+        .success();
+
+    // Path B: tailor to an intermediate cut, then render that cut.
+    let cut = tmp.path().join("cut.json");
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--audience")
+        .arg("security")
+        .arg("--output")
+        .arg(&cut)
+        .assert()
+        .success();
+    let piped = tmp.path().join("piped.txt");
+    ferrocv()
+        .arg("render")
+        .arg(&cut)
+        .arg("--format")
+        .arg("text")
+        .arg("--output")
+        .arg(&piped)
+        .assert()
+        .success();
+
+    let direct_text = std::fs::read_to_string(&direct).expect("read direct output");
+    let piped_text = std::fs::read_to_string(&piped).expect("read piped output");
+    assert_eq!(
+        direct_text, piped_text,
+        "render --audience must equal tailor --audience | render"
+    );
+}

--- a/tests/tailor_cli.rs
+++ b/tests/tailor_cli.rs
@@ -318,3 +318,97 @@ fn tailor_rejects_unknown_redact_value() {
         .assert()
         .code(2);
 }
+
+/// Highlight strings of a derived `work` entry, in order.
+fn work_highlights(doc: &Value, index: usize) -> Vec<String> {
+    doc["work"][index]["highlights"]
+        .as_array()
+        .expect("highlights is an array")
+        .iter()
+        .map(|h| h.as_str().expect("highlight is a string").to_owned())
+        .collect()
+}
+
+#[test]
+fn tailor_audience_selects_tagged_content() {
+    // The fixture's "Current Corp" is tagged for security+leadership with
+    // per-highlight tags [leadership, leadership, [], security]. For
+    // --audience security: the entry survives (security ∈ tags); its
+    // leadership-only highlights drop, while the universal ([]) and
+    // security highlights stay. Untagged entries are kept whole.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--audience")
+        .arg("security")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    // No tagged entry is dropped by --audience security (all three work
+    // entries are universal or security-tagged).
+    assert_eq!(
+        work_names(&doc),
+        vec!["Current Corp", "Mid Corp", "Old Corp"]
+    );
+    assert_eq!(
+        work_highlights(&doc, 0),
+        vec![
+            "Cut build times in half",
+            "Drove the security review program"
+        ]
+    );
+}
+
+#[test]
+fn tailor_audience_strips_x_ferrocv_from_derived_document() {
+    // Curated selection consumes the tags; the derived document must
+    // carry no x-ferrocv anywhere (ADR 0004 — tidiness + not leaking the
+    // user's targeting topology). #150 owns the exhaustive re-validation;
+    // this is the surface-level guard.
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_projection"))
+        .arg("--audience")
+        .arg("security")
+        .assert()
+        .success();
+    let doc: Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout is valid JSON");
+    // Walk the parsed tree rather than substring-matching the raw bytes:
+    // a substring check would false-pass if a field *value* contained the
+    // text, and would miss a key like `x-ferrocv-extra`.
+    assert!(
+        !contains_x_ferrocv_key(&doc),
+        "derived document must not contain any x-ferrocv key, anywhere"
+    );
+}
+
+/// Recursively check whether any object in `value` has an `x-ferrocv` key.
+fn contains_x_ferrocv_key(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            map.contains_key("x-ferrocv") || map.values().any(contains_x_ferrocv_key)
+        }
+        Value::Array(items) => items.iter().any(contains_x_ferrocv_key),
+        _ => false,
+    }
+}
+
+#[test]
+fn tailor_audience_highlights_mismatch_is_data_error_exit_1() {
+    // A schema-valid master whose x-ferrocv.highlights length differs from
+    // its highlights length is a document defect, not a usage error: it
+    // fails like a schema problem (exit 1), names the offending entry, and
+    // writes nothing to stdout (ADR 0004).
+    ferrocv()
+        .arg("tailor")
+        .arg(fixture("master_audience_mismatch"))
+        .arg("--audience")
+        .arg("security")
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("Misaligned Corp"));
+}


### PR DESCRIPTION
Implements **curated `--audience` selection** — the headline projection capability (CONSTITUTION §7, epic #17). Maintain one master `resume.json` tagged with audiences under `x-ferrocv`, and emit cuts that keep *what's relevant* rather than the first N bullets by position.

## What it does

- `--audience <name>` on both `tailor` and `render`, over the single `project()` transform (ADR 0005).
- **Entry-level** tags drop whole array entries tagged only for other audiences; **highlight-level** index-parallel tags filter individual bullets within surviving entries.
- **Untagged content (and an empty `[]` tag) is universal** — kept in every cut — so tagging can be adopted incrementally (ADR 0004's include-by-default rule).
- Curated selection runs *before* the mechanical `--max-bullets` cap, so the cap applies to the already-curated set.
- Consumed `x-ferrocv` metadata is stripped from the derived document (including `basics`), so a cut never leaks the user's audience-targeting topology.

## Errors & exit codes

- A misaligned `x-ferrocv.highlights` array (length ≠ `highlights`) is a **data defect → exit 1**, distinct from a malformed flag value (`--since banana` → exit 2). The error names the entry at its **master-document index**.

## Tests

- Unit tests in `src/project.rs` (entry/highlight matching, universal/empty-tag rules, strip-from-survivors and `basics`, audience-before-max-bullets, mismatch reports master index, read-only input).
- Scenario tests in `tests/tailor_cli.rs` and `tests/render_cli.rs`, including the ADR 0005 equivalence (`render --audience` ≡ `tailor --audience | render`) and the mismatch → exit-1 negative case.
- `make preflight` green (fmt, clippy, tests, deny, audit, typos, offline-guard).

## Docs

- ADRs 0004 (tag schema) and 0005 (surface) flipped to **Accepted**.
- README documents the `x-ferrocv` tag schema and `--audience` flag. The full tailoring guide + example master is tracked separately under #151.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--audience <NAME>` flag for curated projection, producing audience-tailored output.
  * Projection now applies curated audience selection before mechanical filters.

* **Bug Fixes**
  * Improved projection exit-code handling: invalid `--since` vs master-document highlight-tag mismatches are now distinguished.

* **Documentation**
  * Updated README to explain curated audience tagging (`x-ferrocv`), highlight sub-tagging, universal untagged behavior, and metadata stripping.
  * Marked ADRs 0004 and 0005 as Accepted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->