### PR TITLE
Tailoring guide and example master for audience projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ The point of ferrocv is to maintain **one comprehensive master
 reads the master unmodified and produces a derived document that is
 itself valid JSON Resume, which flows into the normal render pipeline.
 
+For a full walkthrough — tagging a master, the include-by-default rule,
+worked cuts, and the gotchas — see the [tailoring
+guide](docs/tailoring.md); [`examples/master.resume.json`](examples/master.resume.json)
+is a tagged master to start from. The rest of this section is the
+condensed reference.
+
 `ferrocv tailor` runs that stage and stops, emitting the derived
 document so you can inspect, commit, or pipe it. The same flags are
 also available on `render`, which projects then renders in one shot —

--- a/docs/tailoring.md
+++ b/docs/tailoring.md
@@ -1,0 +1,219 @@
+# Tailoring guide: one master, many cuts
+
+`ferrocv` is built around a single idea (CONSTITUTION §7): you maintain
+**one comprehensive master `resume.json`** — every role, every highlight,
+five pages if that's what it takes — and emit **targeted, audience-specific
+cuts** from it. A focused two-page "security" resume and a "leadership"
+resume are both *projections* of the same master, never separately
+maintained files that drift apart.
+
+This guide walks through tagging a master and producing cuts. The example
+master it refers to lives at
+[`examples/master.resume.json`](../examples/master.resume.json) — open it
+alongside this page, or copy it as a starting point.
+
+For the precise schema rules and the reasoning behind them, see
+[ADR 0004](adr/0004-audience-tag-schema.md) (tag schema) and
+[ADR 0005](adr/0005-projection-surface.md) (CLI surface). This guide is the
+how-to; the ADRs are the spec.
+
+## The mental model
+
+Projection is a stage **upstream of rendering**. It reads the master
+unmodified and produces a *derived document that is itself valid JSON
+Resume*, which then flows into the normal render pipeline:
+
+```
+master resume.json ──▶ [projection] ──▶ derived (valid JSON Resume) ──▶ [render]
+```
+
+Because the derived document is ordinary JSON Resume, you can inspect it,
+diff two cuts, commit it, or pipe it straight into `render`.
+
+## Two ways to invoke it
+
+There is **one** projection transform behind **two** CLI surfaces:
+
+- **`ferrocv tailor`** runs projection and *stops*, emitting the derived
+  document so you can look at it first:
+
+  ```sh
+  ferrocv tailor examples/master.resume.json --audience security -o security.json
+  ```
+
+  With no `-o`, the derived JSON goes to **stdout** (diagnostics always go
+  to stderr), so it composes in a pipe.
+
+- **`ferrocv render`** accepts the same projection flags and projects then
+  renders in one shot:
+
+  ```sh
+  ferrocv render examples/master.resume.json --audience security --theme text-minimal -o security.pdf
+  ```
+
+These two are equivalent by construction — `render --audience security` is
+the same as `tailor --audience security | render`. Use `tailor` when you
+want to eyeball or commit the cut; use `render --audience` for the quick
+one-shot. With **no** projection flags, `render` behaves exactly as it
+always has — projection is opt-in and inert by default.
+
+## Tagging the master
+
+Audience tags ride under a single `x-ferrocv` object placed *beside* the
+content it applies to (never inside the prose — that would be a content
+rewrite, which §7 forbids). There are two tagging surfaces.
+
+### Tag a whole entry with `audience`
+
+Any object in a JSON Resume array — a `work`, `volunteer`, `project`,
+`skills`, … entry — can carry an `x-ferrocv.audience` list. Here the OWASP
+volunteer entry is restricted to the security cut:
+
+```json
+{
+  "organization": "OWASP Local Chapter",
+  "position": "Workshop Lead",
+  "highlights": ["Ran quarterly secure-coding workshops", "..."],
+  "x-ferrocv": { "audience": ["security"] }
+}
+```
+
+It will appear under `--audience security` and be dropped under
+`--audience leadership`. A dropped entry takes its highlights with it.
+
+### Tag individual bullets with `highlights`
+
+JSON Resume `highlights` are bare strings, so you can't attach a tag to one
+directly. Instead, `x-ferrocv.highlights` is an array **index-parallel** to
+the entry's `highlights`: entry *i* is the tag list for `highlights[i]`.
+
+```json
+{
+  "name": "Northwind Platform",
+  "highlights": [
+    "Led the zero-downtime migration to short-lived workload credentials",
+    "Grew the platform team from 4 to 11 engineers",
+    "Cut median CI time from 18 to 6 minutes",
+    "Drove the SOC 2 Type II audit to a clean report"
+  ],
+  "x-ferrocv": {
+    "audience": ["security", "leadership"],
+    "highlights": [
+      ["security"],
+      ["leadership"],
+      [],
+      ["security"]
+    ]
+  }
+}
+```
+
+Read this as: bullet 0 is for the security cut, bullet 1 for leadership,
+bullet 2 for everyone, bullet 3 for security. The entry itself is tagged
+for both audiences, so it survives either cut; the per-bullet tags then
+decide which highlights show.
+
+### Untagged means universal
+
+The default is **include**. An item with no tag — or with an empty `[]`
+tag — is *universal*: kept in every cut. Only an item that is *tagged and
+doesn't list the selected audience* is dropped. This makes adoption safe
+and incremental: pointing `--audience` at a master you've only partly
+tagged never silently drops a whole job for lack of a tag. Tag the few
+things that are audience-specific; leave everything else untagged.
+
+> An empty `[]` always means "universal," never "exclude from all." If you
+> want to *document* that a bullet is for everyone, `[]` is a fine way to
+> say so — it will never invert on you.
+
+## Worked example
+
+Run the security cut against the example master:
+
+```sh
+ferrocv tailor examples/master.resume.json --audience security
+```
+
+What you get, and why:
+
+| Master content | In `--audience security`? | Reason |
+|---|---|---|
+| Northwind entry | kept | tagged `["security","leadership"]` |
+| └ "Grew the platform team…" bullet | **dropped** | bullet tagged `["leadership"]` only |
+| └ "Cut median CI time…" bullet | kept | bullet tag `[]` → universal |
+| Cobalt entry | kept | untagged entry → universal |
+| └ "Mentored four engineers…" bullet | **dropped** | bullet tagged `["leadership"]` |
+| Riverstone entry | kept | fully untagged → universal |
+| OWASP volunteer entry | kept | tagged `["security"]` |
+| Security skill | kept | tagged `["security"]` |
+
+Now the leadership cut:
+
+```sh
+ferrocv tailor examples/master.resume.json --audience leadership
+```
+
+The difference: the **OWASP volunteer entry and the Security skill
+disappear** (they're tagged security-only), and within Northwind the
+security bullets drop while "Grew the platform team…" stays.
+
+## Mechanical filters
+
+Alongside the curated `--audience`, four theme-agnostic filters trim by
+rule rather than by tag. They compose with `--audience` (and each other):
+
+- **`--since <YYYY|YYYY-MM|YYYY-MM-DD>`** — drop `work` entries that ended
+  before the cutoff; ongoing roles (no `endDate`) are always kept. On the
+  example, `--since 2015` drops the Riverstone role (ended 2014).
+- **`--max-bullets <N>`** — cap every `highlights` list at the first N
+  bullets. It runs **after** `--audience`, so it caps the
+  already-curated set.
+- **`--redact pii`** — remove `basics.location`, `basics.phone`, and
+  `basics.email` from the cut. Identity fields (`name`, `label`,
+  `summary`, `url`, `profiles`) are kept. Useful for a resume you post
+  publicly.
+
+```sh
+# Security cut, last decade only, two bullets max, contact info stripped:
+ferrocv tailor examples/master.resume.json \
+  --audience security --since 2016 --max-bullets 2 --redact pii -o public-security.json
+```
+
+## Tags are stripped from the cut
+
+The `x-ferrocv` metadata is yours, for the tool — it should not travel to a
+recruiter. Projection **removes every `x-ferrocv` key it consumed** from the
+derived document. Your master keeps its tags untouched; only the cut is
+cleaned. (This is enforced: the derived document carries no `x-ferrocv`
+anywhere.)
+
+## Cautions
+
+- **`x-ferrocv.highlights` is positional — re-check it after reordering.**
+  The tag array is matched to bullets *by index*. If you reorder or insert
+  bullets, the tags do not move with them. ferrocv hard-errors if the array
+  *length* stops matching, but a length-preserving reorder (swap two
+  bullets) leaves the array the right size now pointing at the wrong
+  strings — and nothing can detect that. After you reshuffle an entry's
+  highlights, re-check its `x-ferrocv.highlights` lines up.
+
+- **Typos in the namespace fail silently.** Unknown `x-` fields are ignored
+  by design, so `x-ferovcv` (or `highlght`) drops the whole spec with no
+  error — and because untagged content is universal, the resulting cut
+  looks plausible but is actually un-tailored. Double-check the spelling is
+  exactly `x-ferrocv` with `audience` / `highlights`.
+
+- **`tailor` with no `-o` prints full PII to stdout.** The derived document
+  includes everything `--redact` didn't remove. That's fine interactively,
+  but prefer `-o <file>` in shared, recorded, or CI contexts.
+
+## See also
+
+- [`examples/master.resume.json`](../examples/master.resume.json) — the
+  example master used throughout this guide.
+- [ADR 0004](adr/0004-audience-tag-schema.md) — the tag schema and why it
+  looks the way it does.
+- [ADR 0005](adr/0005-projection-surface.md) — why both `tailor` and
+  `render` flags exist over one transform.
+- The README [Projection section](../README.md#projection-one-master-many-cuts)
+  — the condensed flag reference.

--- a/docs/tailoring.md
+++ b/docs/tailoring.md
@@ -23,7 +23,7 @@ Projection is a stage **upstream of rendering**. It reads the master
 unmodified and produces a *derived document that is itself valid JSON
 Resume*, which then flows into the normal render pipeline:
 
-```
+```text
 master resume.json ──▶ [projection] ──▶ derived (valid JSON Resume) ──▶ [render]
 ```
 
@@ -52,7 +52,7 @@ There is **one** projection transform behind **two** CLI surfaces:
   ```
 
 These two are equivalent by construction — `render --audience security` is
-the same as `tailor --audience security | render`. Use `tailor` when you
+the same as `ferrocv tailor --audience security | ferrocv render`. Use `tailor` when you
 want to eyeball or commit the cut; use `render --audience` for the quick
 one-shot. With **no** projection flags, `render` behaves exactly as it
 always has — projection is opt-in and inert by default.
@@ -159,7 +159,7 @@ security bullets drop while "Grew the platform team…" stays.
 
 ## Mechanical filters
 
-Alongside the curated `--audience`, four theme-agnostic filters trim by
+Alongside the curated `--audience`, three theme-agnostic filters trim by
 rule rather than by tag. They compose with `--audience` (and each other):
 
 - **`--since <YYYY|YYYY-MM|YYYY-MM-DD>`** — drop `work` entries that ended

--- a/examples/master.resume.json
+++ b/examples/master.resume.json
@@ -1,0 +1,115 @@
+{
+  "basics": {
+    "name": "Ada Lovelace",
+    "label": "Staff Software Engineer",
+    "summary": "Backend and platform engineer who has led security-critical migrations and grown teams. Maintains one master resume and tailors it per application with ferrocv.",
+    "email": "ada@example.com",
+    "phone": "+1-555-0142",
+    "url": "https://example.com/ada",
+    "location": {
+      "city": "Portland",
+      "region": "OR",
+      "countryCode": "US"
+    },
+    "profiles": [
+      {
+        "network": "GitHub",
+        "username": "ada",
+        "url": "https://github.example.com/ada"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Northwind Platform",
+      "position": "Staff Engineer",
+      "startDate": "2020-04-01",
+      "summary": "Platform team owning auth, CI, and developer tooling.",
+      "highlights": [
+        "Led the zero-downtime migration to short-lived workload credentials",
+        "Grew the platform team from 4 to 11 engineers",
+        "Cut median CI time from 18 to 6 minutes",
+        "Drove the SOC 2 Type II audit to a clean report"
+      ],
+      "x-ferrocv": {
+        "audience": ["security", "leadership"],
+        "highlights": [
+          ["security"],
+          ["leadership"],
+          [],
+          ["security"]
+        ]
+      }
+    },
+    {
+      "name": "Cobalt Analytics",
+      "position": "Senior Backend Engineer",
+      "startDate": "2016-06-01",
+      "endDate": "2020-03-15",
+      "highlights": [
+        "Built the event-ingestion pipeline handling 2B events/day",
+        "Mentored four engineers to senior level",
+        "Owned the on-call rotation and cut paging volume 40%"
+      ],
+      "x-ferrocv": {
+        "highlights": [
+          [],
+          ["leadership"],
+          []
+        ]
+      }
+    },
+    {
+      "name": "Riverstone Software",
+      "position": "Software Engineer",
+      "startDate": "2011-08-01",
+      "endDate": "2014-05-31",
+      "highlights": [
+        "Shipped the original billing service",
+        "Wrote the company's first integration test suite"
+      ]
+    }
+  ],
+  "volunteer": [
+    {
+      "organization": "OWASP Local Chapter",
+      "position": "Workshop Lead",
+      "startDate": "2019-01-01",
+      "highlights": [
+        "Ran quarterly secure-coding workshops",
+        "Built the chapter's CTF training ladder"
+      ],
+      "x-ferrocv": {
+        "audience": ["security"]
+      }
+    },
+    {
+      "organization": "Code Mentors",
+      "position": "Mentor",
+      "startDate": "2017-09-01",
+      "highlights": [
+        "Reviewed capstone projects for bootcamp graduates"
+      ]
+    }
+  ],
+  "skills": [
+    {
+      "name": "Security",
+      "keywords": ["Threat modeling", "OAuth2 / OIDC", "Secrets management"],
+      "x-ferrocv": {
+        "audience": ["security"]
+      }
+    },
+    {
+      "name": "Languages",
+      "keywords": ["Rust", "Go", "Python"]
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of London",
+      "area": "Computer Science",
+      "studyType": "BSc"
+    }
+  ]
+}

--- a/tests/example_master.rs
+++ b/tests/example_master.rs
@@ -1,0 +1,162 @@
+//! Guard tests for the user-facing example master shipped under
+//! `examples/master.resume.json` and documented in `docs/tailoring.md`.
+//!
+//! These spawn the real built binary via `assert_cmd` and assert on
+//! observable behavior only. Their job is to keep the docs honest: if
+//! the example file or the projection behavior drifts from what the
+//! tailoring guide claims, one of these fails rather than the guide
+//! silently going stale.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #1, CLI-visible behavior gets
+//! a scenario test. The example master is part of the #151 docs
+//! deliverable; these tests pin the exact keep/drop the guide documents.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+/// Absolute path to the shipped example master.
+fn example_master() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("examples");
+    path.push("master.resume.json");
+    path
+}
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
+}
+
+/// Names of the `work` entries in a document, in order.
+fn work_names(doc: &Value) -> Vec<String> {
+    doc["work"]
+        .as_array()
+        .expect("work is an array")
+        .iter()
+        .map(|e| {
+            e["name"]
+                .as_str()
+                .expect("work entry has a name")
+                .to_owned()
+        })
+        .collect()
+}
+
+/// Highlights of the named `work` entry, in order.
+fn work_highlights(doc: &Value, name: &str) -> Vec<String> {
+    doc["work"]
+        .as_array()
+        .expect("work is an array")
+        .iter()
+        .find(|e| e["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("work entry `{name}` is present"))
+        .get("highlights")
+        .and_then(Value::as_array)
+        .map(|hs| {
+            hs.iter()
+                .map(|h| h.as_str().expect("highlight is a string").to_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Values of the named string field across an array section's entries.
+fn names_in(doc: &Value, section: &str, key: &str) -> Vec<String> {
+    doc[section]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|e| e[key].as_str().expect("entry has the key").to_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn example_master_is_valid_json_resume() {
+    // The guide tells users to copy this file as a starting point, so it
+    // must pass `validate` (exit 0) like any master would.
+    ferrocv()
+        .arg("validate")
+        .arg(example_master())
+        .assert()
+        .success();
+}
+
+/// Run `tailor --audience <name>` on the example and parse the derived doc.
+fn tailor_audience(name: &str) -> Value {
+    let assert = ferrocv()
+        .arg("tailor")
+        .arg(example_master())
+        .arg("--audience")
+        .arg(name)
+        .assert()
+        .success();
+    serde_json::from_slice(&assert.get_output().stdout).expect("derived stdout is valid JSON")
+}
+
+#[test]
+fn security_cut_matches_the_guide() {
+    let doc = tailor_audience("security");
+
+    // All three work entries survive: Northwind is tagged for security,
+    // Cobalt and Riverstone are untagged (universal).
+    assert_eq!(
+        work_names(&doc),
+        [
+            "Northwind Platform",
+            "Cobalt Analytics",
+            "Riverstone Software"
+        ]
+    );
+
+    // Northwind's leadership-only bullet drops; the security and
+    // universal bullets stay (matching the guide's worked-example table).
+    let northwind = work_highlights(&doc, "Northwind Platform");
+    assert!(
+        !northwind
+            .iter()
+            .any(|h| h.contains("Grew the platform team")),
+        "leadership-only bullet must be dropped from the security cut"
+    );
+    assert!(
+        northwind
+            .iter()
+            .any(|h| h.contains("short-lived workload credentials"))
+    );
+    assert!(northwind.iter().any(|h| h.contains("SOC 2")));
+
+    // The security-tagged volunteer entry and skill are kept.
+    assert!(
+        names_in(&doc, "volunteer", "organization").contains(&"OWASP Local Chapter".to_owned())
+    );
+    assert!(names_in(&doc, "skills", "name").contains(&"Security".to_owned()));
+}
+
+#[test]
+fn leadership_cut_drops_security_only_entries() {
+    let doc = tailor_audience("leadership");
+
+    // The security-only volunteer entry and skill disappear from the
+    // leadership cut; the untagged ones remain.
+    let volunteers = names_in(&doc, "volunteer", "organization");
+    assert!(!volunteers.contains(&"OWASP Local Chapter".to_owned()));
+    assert!(volunteers.contains(&"Code Mentors".to_owned()));
+
+    let skills = names_in(&doc, "skills", "name");
+    assert!(!skills.contains(&"Security".to_owned()));
+    assert!(skills.contains(&"Languages".to_owned()));
+}
+
+#[test]
+fn derived_cut_strips_all_x_ferrocv_metadata() {
+    // The consumed control metadata must not travel into the cut.
+    let doc = tailor_audience("security");
+    let serialized = serde_json::to_string(&doc).expect("re-serialize derived doc");
+    assert!(
+        !serialized.contains("x-ferrocv"),
+        "no x-ferrocv key may survive in the derived document"
+    );
+}

--- a/tests/example_master.rs
+++ b/tests/example_master.rs
@@ -152,11 +152,25 @@ fn leadership_cut_drops_security_only_entries() {
 
 #[test]
 fn derived_cut_strips_all_x_ferrocv_metadata() {
-    // The consumed control metadata must not travel into the cut.
+    // The consumed control metadata must not travel into the cut. Check
+    // object *keys* recursively rather than a serialized substring, which
+    // would also match an `x-ferrocv` literal inside a string value.
     let doc = tailor_audience("security");
-    let serialized = serde_json::to_string(&doc).expect("re-serialize derived doc");
     assert!(
-        !serialized.contains("x-ferrocv"),
+        !contains_x_ferrocv_key(&doc),
         "no x-ferrocv key may survive in the derived document"
     );
+}
+
+/// Recursively check whether any object in `value` carries an `x-ferrocv`
+/// key. Mirrors the helper in `tests/tailor_cli.rs` /
+/// `tests/projection_revalidation.rs`.
+fn contains_x_ferrocv_key(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            map.contains_key("x-ferrocv") || map.values().any(contains_x_ferrocv_key)
+        }
+        Value::Array(items) => items.iter().any(contains_x_ferrocv_key),
+        _ => false,
+    }
 }


### PR DESCRIPTION
## What

Closes #151 — the last open work item under the v0.8.0 projection epic (#17).

Adds the user-facing documentation that the projection engine (ADRs 0004/0005, #148–#150) was missing:

- **`docs/tailoring.md`** — a narrative guide: the one-master/many-cuts model, the `tailor` vs `render --audience` surfaces and their pipe-equivalence, object-level and index-parallel highlight tagging, the include-by-default / empty-`[]`-is-universal rule, a worked keep/drop table, the mechanical filters (`--since` / `--max-bullets` / `--redact pii`), tag-stripping, and the three gotchas (positional-highlight reorder fragility, silent `x-ferrocv` typos, stdout PII).
- **`examples/master.resume.json`** — a realistic tagged master users can copy as a starting point, exercising object + per-highlight tags across two audiences, untagged universal content, and PII in `basics`.
- **`README.md`** — a pointer from the existing condensed Projection reference to the new guide and example.
- **`tests/example_master.rs`** — guard tests pinning the documented behavior: the example validates, the `security`/`leadership` cuts match the guide's keep/drop table, and no `x-ferrocv` survives the derived document.

## Why it is trustworthy

Every keep/drop claim in the guide was captured from the real binary, and the guard tests assert those same outcomes so the docs cannot silently rot when projection changes.

## Notes

- `docs(projection):` commit — hidden in the changelog per project convention.
- The CONSTITUTION §7 positional-fragility warning that ADR 0004 explicitly asks the guide to carry is included.
- After merge, #151 closing also clears epic #17; only the externally-blocked CI advisory cleanup (#154) remains in v0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive tailoring guide explaining the "one master, many cuts" workflow for creating audience-specific resume versions.
  * Added annotated example master resume demonstrating the tailoring approach.

* **Tests**
  * Added integration tests validating the example tailoring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->