### PR TITLE
Stop nightly fuzz build breaks from filing false crash issues

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -64,12 +64,23 @@ jobs:
       # x86_64-unknown-linux-musl` here, where (a) the musl std isn't
       # installed and (b) AddressSanitizer is incompatible with musl's
       # static libc. Forcing -gnu sidesteps both.
+      # Build is split from run so a *compile* failure (e.g. a nightly
+      # rustc regression breaking typst-library) is distinguishable from
+      # a *fuzz* failure. Only the run step writes a crash corpus, so only
+      # a run-step failure should file the "crash" issue below — a build
+      # break fails the job red without the misleading corpus-link issue.
+      # The run step reuses this cached build, so there is no extra cost.
+      - name: Build ${{ matrix.target }}
+        working-directory: fuzz
+        run: cargo +nightly fuzz build --target x86_64-unknown-linux-gnu ${{ matrix.target }}
+
       - name: Fuzz ${{ matrix.target }}
+        id: run
         working-directory: fuzz
         run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=120
 
       - name: Upload crash artifacts
-        if: failure()
+        if: failure() && steps.run.conclusion == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashes-${{ matrix.target }}-${{ github.run_id }}
@@ -78,7 +89,7 @@ jobs:
           retention-days: 30
 
       - name: Assemble issue body
-        if: failure()
+        if: failure() && steps.run.conclusion == 'failure'
         run: |
           cat > /tmp/fuzz-issue-body.md <<'FUZZBODY'
           # Nightly fuzz failure: `${{ matrix.target }}`
@@ -104,7 +115,7 @@ jobs:
           FUZZBODY
 
       - name: File issue on failure
-        if: failure()
+        if: failure() && steps.run.conclusion == 'failure'
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: "Nightly fuzz failure: ${{ matrix.target }} @ ${{ github.sha }}"


### PR DESCRIPTION
## What

The nightly fuzz workflow gated every step on `if: failure()`, so a *compile* failure filed a "crash corpus" issue indistinguishable from a real libfuzzer crash — with a dead artifact link, since a build break produces no corpus.

This is exactly what produced the false-alarm issues #167 and #168: a one-day transient nightly-rustc regression in `typst-library` (`E0119: conflicting implementations of trait From<…HourBase>`) broke the fuzz *build*, and the workflow filed two "Nightly fuzz failure" issues pointing at a non-existent corpus. The same commit `20271a56` was green on the nightlies before and after, confirming it was a toolchain blip, not a code defect.

## Change

- Split the build step (`cargo fuzz build`) from the run step.
- Give the run step `id: run`.
- Gate the **Upload crash artifacts**, **Assemble issue body**, and **File issue on failure** steps on `failure() && steps.run.conclusion == 'failure'`.

A build break now fails the job red without filing a misleading issue; a genuine crash (which writes `fuzz/artifacts/<target>/`) files exactly as before. The run step reuses the cached build, so there is no extra build cost.

## Verification

- `actionlint .github/workflows/fuzz.yml` passes.
- Gating logic: build-step failure ⇒ run step skipped ⇒ `steps.run.conclusion == 'skipped'` ⇒ issue-filing steps skipped; run-step failure ⇒ `== 'failure'` ⇒ issue-filing steps run.

Recurrence fix for #167 and #168 (both already closed as false alarms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fuzzing workflow to prevent creating false crash issues when build steps fail instead of fuzz run steps

* **Chores**
  * Improved failure detection by separating build and fuzz run steps in the nightly fuzzing workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->