### PR TITLE
Establish the native theme contract as a shared Typst prelude

### DIFF
--- a/assets/themes/_prelude/LICENSE
+++ b/assets/themes/_prelude/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Clonch and ferrocv contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/themes/_prelude/lib.typ
+++ b/assets/themes/_prelude/lib.typ
@@ -1,0 +1,79 @@
+// _prelude/lib.typ — the shared native-theme contract for ferrocv.
+//
+// This module makes CONSTITUTION §4's `render(data) -> content` native
+// theme contract real. Native themes (e.g. `text-minimal`,
+// `html-minimal`) `#import` this prelude and write *layout*, leaving the
+// defensive field-reading here. The shared piece is **data access only**:
+// layout stays per-theme / per-format — frame-extracted plain text and
+// semantic HTML cannot share a single `render`, so this prelude
+// deliberately ships no layout primitives.
+//
+// Themes still receive the document as the virtual file `/resume.json`
+// and read it with `json("/resume.json")`; the prelude operates on the
+// resulting dictionary. It performs no IO and pulls no `@preview/...`
+// package, so render stays fully offline (CONSTITUTION §6.1).
+//
+// JSON Resume v1.0.0 has zero required fields, so every accessor here
+// tolerates missing keys and never errors on a schema-valid document.
+//
+// First-party ferrocv source (no upstream), redistributable under the
+// crate's MIT-or-Apache-2.0 dual license; the sibling `LICENSE` is
+// duplicated so the prelude stays self-contained if it is ever extracted
+// into its own package.
+
+// --- Optional-field helpers ----------------------------------------
+
+// `opt(d, k)` returns `d.at(k)` if `d` is a dictionary and `k` is
+// present, otherwise `none`. Lets per-section code stay readable
+// without sprinkling `if "x" in d { ... }` everywhere. If `d` is not a
+// dictionary (e.g. `none`, a string, or an array), it returns `none`
+// regardless of `k` — never errors on an unexpected shape.
+#let opt(d, k) = if type(d) == dictionary and k in d { d.at(k) } else { none }
+
+// `nz(s)` collapses both absent and empty-string values to `none` so
+// sections can uniformly check `if value != none`.
+#let nz(s) = if s == none or s == "" { none } else { s }
+
+// Join a list of optional strings with `sep`, dropping `none`/empty.
+// Used for location ("city, region, country") where any subset of
+// components may be missing. Returns the empty string `""` when every
+// part is absent — NOT `none`, so callers guard with `!= ""`. (Typst's
+// `().join(sep)` yields `none`, which would slip past a `!= ""` guard
+// and emit a stray empty element; the explicit `""` keeps the contract
+// "always a string".)
+#let join_present(parts, sep) = {
+  let kept = parts.filter(p => p != none and p != "")
+  if kept.len() == 0 { "" } else { kept.join(sep) }
+}
+
+// Format a date range. Reads `startDate` and `endDate` from `item`
+// (a dictionary); either bound may be missing. An absent `endDate`
+// with a present `startDate` becomes "Present". Returns `none` if both
+// are absent so the caller can skip the line entirely (guard `!= none`).
+#let date_range(item) = {
+  let start = nz(opt(item, "startDate"))
+  let end = nz(opt(item, "endDate"))
+  if start == none and end == none {
+    none
+  } else if start != none and end != none {
+    start + " - " + end
+  } else if start != none {
+    start + " - Present"
+  } else {
+    end
+  }
+}
+
+// --- Normalized section accessors ----------------------------------
+
+// `items(d, key)` returns the value at `key` when it is an array,
+// otherwise an empty array `()`. This collapses the
+// `if x != none and type(x) == array and x.len() > 0 { ... }` guard
+// repeated across every section into a single `for entry in items(...)`
+// (or a `.len() > 0` check before emitting a section heading). Absent
+// keys and non-array values degrade to `()`; an empty array is returned
+// as-is (also length 0, so iteration and `.len()` behave identically).
+#let items(d, key) = {
+  let v = opt(d, key)
+  if v != none and type(v) == array { v } else { () }
+}

--- a/assets/themes/html-minimal/resume.typ
+++ b/assets/themes/html-minimal/resume.typ
@@ -17,49 +17,16 @@
 //   stylesheets, no web fonts, no inline style attributes, no
 //   sourced sub-resources. Resume data never leaves the process.
 // - Defensive optional-field reads — JSON Resume v1.0.0 has zero
-//   required fields; every accessor must tolerate missing keys.
-//   The helper block is duplicated from `text-minimal` rather than
-//   shared; CONSTITUTION §5 says share on the third caller.
+//   required fields; every accessor must tolerate missing keys. The
+//   helpers (`opt`, `nz`, `join_present`, `date_range`) and section
+//   accessor (`items`) come from the shared native-theme prelude
+//   (CONSTITUTION §4); this theme contributes only layout.
 //
 // Typed-HTML API reference: https://typst.app/docs/reference/html/
 
+#import "/themes/_prelude/lib.typ": *
+
 #let resume = json("/resume.json")
-
-// --- Optional-field helpers ----------------------------------------
-//
-// `opt(d, k)` returns `d.at(k)` if `d` is a dictionary and `k` is
-// present, otherwise `none`. Lets per-section code stay readable
-// without sprinkling `if "x" in d { ... }` everywhere.
-#let opt(d, k) = if type(d) == dictionary and k in d { d.at(k) } else { none }
-
-// `nz(s)` collapses both absent and empty-string values to `none` so
-// sections can uniformly check `if value != none`.
-#let nz(s) = if s == none or s == "" { none } else { s }
-
-// Join a list of optional strings with `sep`, dropping `none`/empty.
-// Used for location ("city, region, country") where any subset of
-// components may be missing.
-#let join_present(parts, sep) = {
-  let kept = parts.filter(p => p != none and p != "")
-  kept.join(sep)
-}
-
-// Format a date range. Either bound may be missing; an absent
-// `endDate` becomes "Present". Returns `none` if both are absent so
-// the caller can skip the line entirely.
-#let date_range(item) = {
-  let start = nz(opt(item, "startDate"))
-  let end = nz(opt(item, "endDate"))
-  if start == none and end == none {
-    none
-  } else if start != none and end != none {
-    start + " - " + end
-  } else if start != none {
-    start + " - Present"
-  } else {
-    end
-  }
-}
 
 // --- Document ------------------------------------------------------
 //
@@ -108,8 +75,8 @@
       // Treated as header continuation rather than a separate section
       // so the rendering matches how social profiles read on a real
       // resume.
-      #let profiles = opt(basics, "profiles")
-      #if profiles != none and type(profiles) == array and profiles.len() > 0 {
+      #let profiles = items(basics, "profiles")
+      #if profiles.len() > 0 {
         html.ul[
           #for profile in profiles {
             let network = nz(opt(profile, "network"))
@@ -145,8 +112,8 @@
   }
 
   // --- Work --------------------------------------------------------
-  #let work = opt(resume, "work")
-  #if work != none and type(work) == array and work.len() > 0 {
+  #let work = items(resume, "work")
+  #if work.len() > 0 {
     html.section[
       #html.h2[Work]
       #for entry in work {
@@ -175,16 +142,13 @@
           #if work_summary != none {
             html.p[#work_summary]
           }
-          #let highlights = opt(entry, "highlights")
-          #if highlights != none and type(highlights) == array {
-            let kept = highlights.filter(h => h != none and h != "")
-            if kept.len() > 0 {
-              html.ul[
-                #for h in kept {
-                  html.li[#h]
-                }
-              ]
-            }
+          #let kept = items(entry, "highlights").filter(h => h != none and h != "")
+          #if kept.len() > 0 {
+            html.ul[
+              #for h in kept {
+                html.li[#h]
+              }
+            ]
           }
         ]
       }
@@ -192,8 +156,8 @@
   }
 
   // --- Volunteer ---------------------------------------------------
-  #let volunteer = opt(resume, "volunteer")
-  #if volunteer != none and type(volunteer) == array and volunteer.len() > 0 {
+  #let volunteer = items(resume, "volunteer")
+  #if volunteer.len() > 0 {
     html.section[
       #html.h2[Volunteer]
       #for entry in volunteer {
@@ -222,16 +186,13 @@
           #if v_summary != none {
             html.p[#v_summary]
           }
-          #let highlights = opt(entry, "highlights")
-          #if highlights != none and type(highlights) == array {
-            let kept = highlights.filter(h => h != none and h != "")
-            if kept.len() > 0 {
-              html.ul[
-                #for h in kept {
-                  html.li[#h]
-                }
-              ]
-            }
+          #let kept = items(entry, "highlights").filter(h => h != none and h != "")
+          #if kept.len() > 0 {
+            html.ul[
+              #for h in kept {
+                html.li[#h]
+              }
+            ]
           }
         ]
       }
@@ -239,8 +200,8 @@
   }
 
   // --- Education ---------------------------------------------------
-  #let education = opt(resume, "education")
-  #if education != none and type(education) == array and education.len() > 0 {
+  #let education = items(resume, "education")
+  #if education.len() > 0 {
     html.section[
       #html.h2[Education]
       #for entry in education {
@@ -269,8 +230,8 @@
   }
 
   // --- Awards ------------------------------------------------------
-  #let awards = opt(resume, "awards")
-  #if awards != none and type(awards) == array and awards.len() > 0 {
+  #let awards = items(resume, "awards")
+  #if awards.len() > 0 {
     html.section[
       #html.h2[Awards]
       #for entry in awards {
@@ -289,16 +250,13 @@
           #if a_summary != none {
             html.p[#a_summary]
           }
-          #let highlights = opt(entry, "highlights")
-          #if highlights != none and type(highlights) == array {
-            let kept = highlights.filter(h => h != none and h != "")
-            if kept.len() > 0 {
-              html.ul[
-                #for h in kept {
-                  html.li[#h]
-                }
-              ]
-            }
+          #let kept = items(entry, "highlights").filter(h => h != none and h != "")
+          #if kept.len() > 0 {
+            html.ul[
+              #for h in kept {
+                html.li[#h]
+              }
+            ]
           }
         ]
       }
@@ -306,8 +264,8 @@
   }
 
   // --- Certificates ------------------------------------------------
-  #let certificates = opt(resume, "certificates")
-  #if certificates != none and type(certificates) == array and certificates.len() > 0 {
+  #let certificates = items(resume, "certificates")
+  #if certificates.len() > 0 {
     html.section[
       #html.h2[Certificates]
       #for entry in certificates {
@@ -332,8 +290,8 @@
   }
 
   // --- Publications ------------------------------------------------
-  #let publications = opt(resume, "publications")
-  #if publications != none and type(publications) == array and publications.len() > 0 {
+  #let publications = items(resume, "publications")
+  #if publications.len() > 0 {
     html.section[
       #html.h2[Publications]
       #for entry in publications {
@@ -362,16 +320,16 @@
   }
 
   // --- Skills ------------------------------------------------------
-  #let skills = opt(resume, "skills")
-  #if skills != none and type(skills) == array and skills.len() > 0 {
+  #let skills = items(resume, "skills")
+  #if skills.len() > 0 {
     html.section[
       #html.h2[Skills]
       #html.ul[
         #for skill in skills {
           let name = nz(opt(skill, "name"))
           let level = nz(opt(skill, "level"))
-          let keywords = opt(skill, "keywords")
-          let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+          let keywords = items(skill, "keywords")
+          let keywords_str = if keywords.len() > 0 {
             keywords.filter(k => k != none and k != "").join(", ")
           } else { none }
           let label_part = if name != none and level != none {
@@ -397,8 +355,8 @@
   }
 
   // --- Languages ---------------------------------------------------
-  #let languages = opt(resume, "languages")
-  #if languages != none and type(languages) == array and languages.len() > 0 {
+  #let languages = items(resume, "languages")
+  #if languages.len() > 0 {
     html.section[
       #html.h2[Languages]
       #html.ul[
@@ -421,15 +379,15 @@
   }
 
   // --- Interests ---------------------------------------------------
-  #let interests = opt(resume, "interests")
-  #if interests != none and type(interests) == array and interests.len() > 0 {
+  #let interests = items(resume, "interests")
+  #if interests.len() > 0 {
     html.section[
       #html.h2[Interests]
       #html.ul[
         #for entry in interests {
           let name = nz(opt(entry, "name"))
-          let keywords = opt(entry, "keywords")
-          let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+          let keywords = items(entry, "keywords")
+          let keywords_str = if keywords.len() > 0 {
             keywords.filter(k => k != none and k != "").join(", ")
           } else { none }
           let line = if name != none and keywords_str != none and keywords_str != "" {
@@ -448,8 +406,8 @@
   }
 
   // --- Projects ----------------------------------------------------
-  #let projects = opt(resume, "projects")
-  #if projects != none and type(projects) == array and projects.len() > 0 {
+  #let projects = items(resume, "projects")
+  #if projects.len() > 0 {
     html.section[
       #html.h2[Projects]
       #for entry in projects {
@@ -476,8 +434,8 @@
   }
 
   // --- References --------------------------------------------------
-  #let references = opt(resume, "references")
-  #if references != none and type(references) == array and references.len() > 0 {
+  #let references = items(resume, "references")
+  #if references.len() > 0 {
     html.section[
       #html.h2[References]
       #for entry in references {

--- a/assets/themes/text-minimal/resume.typ
+++ b/assets/themes/text-minimal/resume.typ
@@ -12,45 +12,14 @@
 // - Default font and size — no font-family directives so the output
 //   is reproducible across hosts (CONSTITUTION §6).
 // - Defensive optional-field reads — JSON Resume v1.0.0 has zero
-//   required fields; every accessor must tolerate missing keys.
+//   required fields; every accessor must tolerate missing keys. The
+//   helpers (`opt`, `nz`, `join_present`, `date_range`) and section
+//   accessor (`items`) come from the shared native-theme prelude
+//   (CONSTITUTION §4); this theme contributes only layout.
+
+#import "/themes/_prelude/lib.typ": *
 
 #let resume = json("/resume.json")
-
-// --- Optional-field helpers ----------------------------------------
-//
-// `opt(d, k)` returns `d.at(k)` if `d` is a dictionary and `k` is
-// present, otherwise `none`. Lets per-section code stay readable
-// without sprinkling `if "x" in d { ... }` everywhere.
-#let opt(d, k) = if type(d) == dictionary and k in d { d.at(k) } else { none }
-
-// `nz(s)` collapses both absent and empty-string values to `none` so
-// sections can uniformly check `if value != none`.
-#let nz(s) = if s == none or s == "" { none } else { s }
-
-// Join a list of optional strings with `sep`, dropping `none`/empty.
-// Used for location ("city, region, country") where any subset of
-// components may be missing.
-#let join_present(parts, sep) = {
-  let kept = parts.filter(p => p != none and p != "")
-  kept.join(sep)
-}
-
-// Format a date range. Either bound may be missing; an absent
-// `endDate` becomes "Present". Returns `none` if both are absent so
-// the caller can skip the line entirely.
-#let date_range(item) = {
-  let start = nz(opt(item, "startDate"))
-  let end = nz(opt(item, "endDate"))
-  if start == none and end == none {
-    none
-  } else if start != none and end != none {
-    start + " - " + end
-  } else if start != none {
-    start + " - Present"
-  } else {
-    end
-  }
-}
 
 // --- Page setup ----------------------------------------------------
 //
@@ -90,30 +59,27 @@
   // basics.profiles — emit each as a contact-style line. Treated as
   // header continuation rather than a separate section so the
   // rendering matches how social profiles read on a real resume.
-  let profiles = opt(basics, "profiles")
-  if profiles != none and type(profiles) == array {
-    for profile in profiles {
-      let network = nz(opt(profile, "network"))
-      let username = nz(opt(profile, "username"))
-      let url = nz(opt(profile, "url"))
-      let label_part = if network != none and username != none {
-        network + ": " + username
-      } else if network != none {
-        network
-      } else if username != none {
-        username
-      } else { none }
-      let line = if label_part != none and url != none {
-        label_part + " - " + url
-      } else if label_part != none {
-        label_part
-      } else if url != none {
-        url
-      } else { none }
-      if line != none {
-        [#line]
-        linebreak()
-      }
+  for profile in items(basics, "profiles") {
+    let network = nz(opt(profile, "network"))
+    let username = nz(opt(profile, "username"))
+    let url = nz(opt(profile, "url"))
+    let label_part = if network != none and username != none {
+      network + ": " + username
+    } else if network != none {
+      network
+    } else if username != none {
+      username
+    } else { none }
+    let line = if label_part != none and url != none {
+      label_part + " - " + url
+    } else if label_part != none {
+      label_part
+    } else if url != none {
+      url
+    } else { none }
+    if line != none {
+      [#line]
+      linebreak()
     }
   }
   parbreak()
@@ -129,8 +95,8 @@
 }
 
 // --- Work ----------------------------------------------------------
-#let work = opt(resume, "work")
-#if work != none and type(work) == array and work.len() > 0 {
+#let work = items(resume, "work")
+#if work.len() > 0 {
   text(weight: "bold")[Work]
   parbreak()
   for entry in work {
@@ -157,18 +123,15 @@
       [#work_summary]
       linebreak()
     }
-    let highlights = opt(entry, "highlights")
-    if highlights != none and type(highlights) == array {
-      for h in highlights {
-        if h != none and h != "" {
-          // Pre-build the prefixed string in code mode so the literal
-          // "- " never enters Typst markup mode, where it would be
-          // parsed as a list item and rendered with a `•` bullet.
-          // Bullets survive frame extraction and add ATS noise.
-          let prefixed = "- " + h
-          [#prefixed]
-          linebreak()
-        }
+    for h in items(entry, "highlights") {
+      if h != none and h != "" {
+        // Pre-build the prefixed string in code mode so the literal
+        // "- " never enters Typst markup mode, where it would be
+        // parsed as a list item and rendered with a `•` bullet.
+        // Bullets survive frame extraction and add ATS noise.
+        let prefixed = "- " + h
+        [#prefixed]
+        linebreak()
       }
     }
     parbreak()
@@ -176,8 +139,8 @@
 }
 
 // --- Education -----------------------------------------------------
-#let education = opt(resume, "education")
-#if education != none and type(education) == array and education.len() > 0 {
+#let education = items(resume, "education")
+#if education.len() > 0 {
   text(weight: "bold")[Education]
   parbreak()
   for entry in education {
@@ -203,15 +166,15 @@
 }
 
 // --- Skills --------------------------------------------------------
-#let skills = opt(resume, "skills")
-#if skills != none and type(skills) == array and skills.len() > 0 {
+#let skills = items(resume, "skills")
+#if skills.len() > 0 {
   text(weight: "bold")[Skills]
   parbreak()
   for skill in skills {
     let name = nz(opt(skill, "name"))
     let level = nz(opt(skill, "level"))
-    let keywords = opt(skill, "keywords")
-    let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+    let keywords = items(skill, "keywords")
+    let keywords_str = if keywords.len() > 0 {
       keywords.filter(k => k != none and k != "").join(", ")
     } else { none }
     let label_part = if name != none and level != none {
@@ -237,8 +200,8 @@
 }
 
 // --- Projects ------------------------------------------------------
-#let projects = opt(resume, "projects")
-#if projects != none and type(projects) == array and projects.len() > 0 {
+#let projects = items(resume, "projects")
+#if projects.len() > 0 {
   text(weight: "bold")[Projects]
   parbreak()
   for entry in projects {
@@ -267,8 +230,8 @@
 }
 
 // --- Volunteer -----------------------------------------------------
-#let volunteer = opt(resume, "volunteer")
-#if volunteer != none and type(volunteer) == array and volunteer.len() > 0 {
+#let volunteer = items(resume, "volunteer")
+#if volunteer.len() > 0 {
   text(weight: "bold")[Volunteer]
   parbreak()
   for entry in volunteer {
@@ -295,14 +258,11 @@
       [#v_summary]
       linebreak()
     }
-    let highlights = opt(entry, "highlights")
-    if highlights != none and type(highlights) == array {
-      for h in highlights {
-        if h != none and h != "" {
-          let prefixed = "- " + h
-          [#prefixed]
-          linebreak()
-        }
+    for h in items(entry, "highlights") {
+      if h != none and h != "" {
+        let prefixed = "- " + h
+        [#prefixed]
+        linebreak()
       }
     }
     parbreak()
@@ -310,8 +270,8 @@
 }
 
 // --- Awards --------------------------------------------------------
-#let awards = opt(resume, "awards")
-#if awards != none and type(awards) == array and awards.len() > 0 {
+#let awards = items(resume, "awards")
+#if awards.len() > 0 {
   text(weight: "bold")[Awards]
   parbreak()
   for entry in awards {
@@ -337,8 +297,8 @@
 }
 
 // --- Certificates --------------------------------------------------
-#let certificates = opt(resume, "certificates")
-#if certificates != none and type(certificates) == array and certificates.len() > 0 {
+#let certificates = items(resume, "certificates")
+#if certificates.len() > 0 {
   text(weight: "bold")[Certificates]
   parbreak()
   for entry in certificates {
@@ -364,8 +324,8 @@
 }
 
 // --- Publications --------------------------------------------------
-#let publications = opt(resume, "publications")
-#if publications != none and type(publications) == array and publications.len() > 0 {
+#let publications = items(resume, "publications")
+#if publications.len() > 0 {
   text(weight: "bold")[Publications]
   parbreak()
   for entry in publications {
@@ -396,8 +356,8 @@
 }
 
 // --- Languages -----------------------------------------------------
-#let languages = opt(resume, "languages")
-#if languages != none and type(languages) == array and languages.len() > 0 {
+#let languages = items(resume, "languages")
+#if languages.len() > 0 {
   text(weight: "bold")[Languages]
   parbreak()
   for entry in languages {
@@ -419,14 +379,14 @@
 }
 
 // --- Interests -----------------------------------------------------
-#let interests = opt(resume, "interests")
-#if interests != none and type(interests) == array and interests.len() > 0 {
+#let interests = items(resume, "interests")
+#if interests.len() > 0 {
   text(weight: "bold")[Interests]
   parbreak()
   for entry in interests {
     let name = nz(opt(entry, "name"))
-    let keywords = opt(entry, "keywords")
-    let keywords_str = if keywords != none and type(keywords) == array and keywords.len() > 0 {
+    let keywords = items(entry, "keywords")
+    let keywords_str = if keywords.len() > 0 {
       keywords.filter(k => k != none and k != "").join(", ")
     } else { none }
     let line = if name != none and keywords_str != none and keywords_str != "" {
@@ -445,8 +405,8 @@
 }
 
 // --- References ----------------------------------------------------
-#let references = opt(resume, "references")
-#if references != none and type(references) == array and references.len() > 0 {
+#let references = items(resume, "references")
+#if references.len() > 0 {
   text(weight: "bold")[References]
   parbreak()
   for entry in references {

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -19,8 +19,14 @@ adapter work; this guide refers to them by number throughout.
   upstream changes is accepted in exchange for visual variety.
 - **Native themes** implement a `render(data) -> content` contract
   directly against parsed JSON Resume data, with no upstream to wrap.
-  The `text-minimal` theme in `src/theme.rs` is the only native theme
-  shipped today.
+  The contract is a shared Typst prelude
+  (`assets/themes/_prelude/lib.typ`, served at `/themes/_prelude/lib.typ`
+  in the embedded `FerrocvWorld`): a native theme `#import`s it for the
+  optional-field helpers (`opt`, `nz`, `join_present`, `date_range`) and
+  section accessors (`items`), then writes only its own layout.
+  `text-minimal` (plain text) and `html-minimal` (semantic HTML) both
+  ride it today — proof the data-access layer is shared while layout
+  stays per-format.
 
 Pick **adapter** when:
 
@@ -42,9 +48,10 @@ Pick **native theme** when:
 
 The two layers stay separable: adapter code does not leak into native
 themes, and native themes do not depend on adapter internals
-(CONSTITUTION §4). This guide covers adapters only; a native-theme
-guide will land when there's a second native theme to draw the
-pattern from.
+(CONSTITUTION §4). This guide covers adapters only; the full
+native-theme authoring guide (the prelude API, the scaffold command,
+golden-test setup) is tracked under issue #183. For now, the prelude
+source and the two themes that import it are the worked examples.
 
 ## Two ways to use a Typst Universe template
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ pub use render::{
     compile_text_resolved, compile_theme, compile_theme_resolved,
 };
 pub use theme::{
-    OwnedTheme, ResolvedTheme, THEMES, Theme, ThemeResolveError, find_theme, resolve_theme,
+    OwnedTheme, PRELUDE_PATH, ResolvedTheme, THEMES, Theme, ThemeResolveError, find_theme,
+    resolve_theme,
 };
 pub use validate::{ValidationError, validate_value};
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -25,14 +25,17 @@
 //!
 //! Per CONSTITUTION §4 the two layers are kept separable: adapter
 //! code does not leak into native themes, and native themes do not
-//! depend on adapter internals. §4 also promises that native themes
-//! will eventually live in a dedicated module. For Phase 2, with two
-//! small native themes colocated here (`text-minimal` and
-//! `html-minimal`), splitting into a dedicated module would add
-//! scaffolding without saving anything — the themes share no Rust
-//! code, only a registration pattern. Extract when shared
-//! native-theme infrastructure actually warrants it (CONSTITUTION §5:
-//! "simple now, iterate later").
+//! depend on adapter internals. The native-theme contract itself is a
+//! shared **Typst** prelude (`assets/themes/_prelude/lib.typ`, served
+//! at [`PRELUDE_PATH`]): `text-minimal` and `html-minimal` `#import` it
+//! for optional-field helpers and section accessors, so they share data
+//! access while each keeps its own format-specific layout. They still
+//! share no *Rust* code — only the registration pattern below. §4 also
+//! promises that native themes will eventually live in a dedicated
+//! module; for Phase 2, with two small native themes colocated here,
+//! splitting would add scaffolding without saving anything. Extract
+//! when shared native-theme infrastructure actually warrants it
+//! (CONSTITUTION §5: "simple now, iterate later").
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
@@ -265,6 +268,37 @@ const _: () = {
     assert!(!BASIC_RESUME_PREFIX.is_empty());
 };
 
+/// Virtual path of the shared native-theme prelude (CONSTITUTION §4).
+///
+/// The prelude (`assets/themes/_prelude/lib.typ`) is first-party ferrocv
+/// source — not a vendored upstream — bundled into every **native**
+/// theme that opts into the contract by `#import`ing it. It exposes the
+/// optional-field helpers (`opt`, `nz`, `join_present`, `date_range`)
+/// and normalized section accessors (`items`) that `text-minimal` and
+/// `html-minimal` previously copy-pasted. Interning the file into each
+/// native theme's [`Theme::files`] is what makes the absolute import
+/// (`#import "/themes/_prelude/lib.typ": *`) resolve inside
+/// [`crate::render::FerrocvWorld`]. Adapters do not carry it — they wrap
+/// upstream templates and never touch the native contract, keeping the
+/// two layers separable (§4).
+///
+/// Exported so callers building a [`OwnedTheme`] programmatically (and
+/// the prelude's own contract test) reference the canonical path rather
+/// than re-hardcoding the literal — a rename then surfaces as a Rust
+/// compile error at every call site instead of a confusing Typst
+/// "file not found" at render time.
+pub const PRELUDE_PATH: &str = "/themes/_prelude/lib.typ";
+
+/// `(virtual_path, bytes)` entry for the shared prelude.
+///
+/// Identical in both native themes, so it is centralized here rather
+/// than repeated. `include_bytes!` bakes the source into the binary at
+/// compile time (no filesystem access at render time — §6.1).
+const PRELUDE_FILE: (&str, &[u8]) = (
+    PRELUDE_PATH,
+    include_bytes!("../assets/themes/_prelude/lib.typ"),
+);
+
 /// Virtual path of the `text-minimal` theme's entrypoint.
 ///
 /// Single per-file constant used by both the [`Theme::files`] key and
@@ -310,10 +344,13 @@ const TEXT_MINIMAL_RESUME_PATH: &str = "/themes/text-minimal/resume.typ";
 /// later"). See the module-level doc for the full rationale.
 pub const TEXT_MINIMAL: Theme = Theme {
     name: "text-minimal",
-    files: &[(
-        TEXT_MINIMAL_RESUME_PATH,
-        include_bytes!("../assets/themes/text-minimal/resume.typ"),
-    )],
+    files: &[
+        PRELUDE_FILE,
+        (
+            TEXT_MINIMAL_RESUME_PATH,
+            include_bytes!("../assets/themes/text-minimal/resume.typ"),
+        ),
+    ],
     entrypoint: TEXT_MINIMAL_RESUME_PATH,
 };
 
@@ -347,10 +384,13 @@ const HTML_MINIMAL_RESUME_PATH: &str = "/themes/html-minimal/resume.typ";
 /// package.
 pub const HTML_MINIMAL: Theme = Theme {
     name: "html-minimal",
-    files: &[(
-        HTML_MINIMAL_RESUME_PATH,
-        include_bytes!("../assets/themes/html-minimal/resume.typ"),
-    )],
+    files: &[
+        PRELUDE_FILE,
+        (
+            HTML_MINIMAL_RESUME_PATH,
+            include_bytes!("../assets/themes/html-minimal/resume.typ"),
+        ),
+    ],
     entrypoint: HTML_MINIMAL_RESUME_PATH,
 };
 

--- a/tests/prelude.rs
+++ b/tests/prelude.rs
@@ -1,0 +1,182 @@
+//! Tests for the shared native-theme prelude
+//! (`assets/themes/_prelude/lib.typ`).
+//!
+//! The prelude is the data-access half of CONSTITUTION §4's
+//! `render(data) -> content` native-theme contract. `text-minimal` and
+//! `html-minimal` already exercise it indirectly through their committed
+//! goldens, but those pin *layout*; this file pins the *contract* —
+//! the optional-field helpers (`opt`, `nz`, `join_present`,
+//! `date_range`) and the normalized section accessor (`items`) — on its
+//! own so a regression shows up here rather than as a confusing golden
+//! diff in two unrelated themes.
+//!
+//! Doctrine §4 (no mocking Typst): we drive the real embedded compiler
+//! via [`ferrocv::compile_text_resolved`]. The prelude is served to the
+//! World as a file in an [`ferrocv::OwnedTheme`], exactly as the bundled
+//! native themes serve it — the test entrypoint `#import`s it by the
+//! same absolute virtual path the real themes use.
+
+use std::fs;
+use std::path::PathBuf;
+
+use ferrocv::{OwnedTheme, PRELUDE_PATH, ResolvedTheme, compile_text_resolved};
+use serde_json::json;
+
+/// Virtual path for the throwaway test entrypoint.
+const ENTRY_VPATH: &str = "/themes/prelude-test/resume.typ";
+
+/// Build a [`ResolvedTheme::Owned`] whose files are the real prelude
+/// bytes plus an entrypoint that imports the prelude and then runs
+/// `body`, then render it to text against `data`.
+///
+/// The import line is generated from the exported [`ferrocv::PRELUDE_PATH`]
+/// — the same constant the bundled themes register the prelude under —
+/// so the test and production can never drift on the prelude's location.
+fn render_with_prelude(body: &str, data: &serde_json::Value) -> String {
+    let prelude_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/themes/_prelude/lib.typ");
+    let prelude_bytes = fs::read(&prelude_path).unwrap_or_else(|e| {
+        panic!(
+            "prelude must be readable at {}: {e}",
+            prelude_path.display()
+        )
+    });
+
+    let entry_src = format!("#import \"{PRELUDE_PATH}\": *\n#set page(margin: 1in)\n{body}");
+
+    let theme = ResolvedTheme::Owned(OwnedTheme {
+        name: "prelude-test".to_owned(),
+        files: vec![
+            (PRELUDE_PATH.to_owned(), prelude_bytes),
+            (ENTRY_VPATH.to_owned(), entry_src.into_bytes()),
+        ],
+        entrypoint: ENTRY_VPATH.to_owned(),
+    });
+
+    compile_text_resolved(&theme, data).expect("prelude-test theme must compile to text")
+}
+
+/// The four helpers behave as documented: `nz` collapses empty/none,
+/// `opt` reads present keys and tolerates wrong/missing shapes,
+/// `join_present` drops blanks (and yields `""`, not `none`, when every
+/// part is absent), and `date_range` covers all four bound combinations.
+#[test]
+fn helpers_behave_as_documented() {
+    // Each line emits a marker only when the helper behaves correctly,
+    // so a regression flips a marker (or removes it) in the extracted
+    // text. `date_range` has four branches — all are exercised here so a
+    // regression surfaces in this test rather than as a golden diff.
+    let body = r#"
+#[#("DR-START:" + date_range((startDate: "2020")))]
+#linebreak()
+#[#("DR-BOTH:" + date_range((startDate: "2019", endDate: "2023")))]
+#linebreak()
+#[#("DR-END:" + date_range((endDate: "2021")))]
+#linebreak()
+#[#(if date_range((:)) == none { "DR-NONE-OK" } else { "DR-NONE-BUG" })]
+#linebreak()
+
+#[#("JP:" + join_present(("a", none, "", "b"), ", "))]
+#linebreak()
+#[#("JP-EMPTY:[" + join_present((none, ""), " - ") + "]")]
+#linebreak()
+
+#[#(if nz("") == none and nz("x") == "x" { "NZ-OK" } else { "NZ-BUG" })]
+#linebreak()
+
+#[#(if opt((k: "v"), "k") == "v" and opt((:), "missing") == none and opt("not-a-dict", "k") == none { "OPT-OK" } else { "OPT-BUG" })]
+"#;
+    let text = render_with_prelude(body, &json!({}));
+
+    assert!(
+        text.contains("DR-START:2020 - Present"),
+        "date_range start-only must append ' - Present'; got:\n{text}"
+    );
+    assert!(
+        text.contains("DR-BOTH:2019 - 2023"),
+        "date_range with both bounds must join them; got:\n{text}"
+    );
+    assert!(
+        text.contains("DR-END:2021"),
+        "date_range end-only must yield the end date; got:\n{text}"
+    );
+    assert!(
+        text.contains("DR-NONE-OK"),
+        "date_range with neither bound must return none; got:\n{text}"
+    );
+    assert!(
+        text.contains("JP:a, b"),
+        "join_present must drop none/empty parts; got:\n{text}"
+    );
+    assert!(
+        text.contains("JP-EMPTY:[]"),
+        "join_present must yield the empty string (not none) when all parts absent; got:\n{text}"
+    );
+    assert!(
+        text.contains("NZ-OK"),
+        "nz must collapse empty/none; got:\n{text}"
+    );
+    assert!(
+        text.contains("OPT-OK"),
+        "opt must read present keys and tolerate missing keys and non-dict inputs; got:\n{text}"
+    );
+}
+
+/// `items` yields the array for a present non-empty key and an empty
+/// array for missing keys, non-array values, and empty arrays — so a
+/// `for` over it is safe on any schema-valid (or even malformed)
+/// document without a guard.
+#[test]
+fn items_normalizes_section_access() {
+    let body = r#"
+#let data = json("/resume.json")
+
+#[#("PRESENT:" + str(items(data, "work").len()))]
+#linebreak()
+#[#("MISSING:" + str(items(data, "education").len()))]
+#linebreak()
+#[#("NONARRAY:" + str(items(data, "basics").len()))]
+#linebreak()
+#[#("EMPTY:" + str(items(data, "skills").len()))]
+#linebreak()
+
+#for w in items(data, "work") {
+  let n = nz(opt(w, "name"))
+  if n != none { [#("W:" + n)]; linebreak() }
+}
+#for _ in items(data, "education") { [SHOULD-NOT-APPEAR]; linebreak() }
+"#;
+    // `basics` is a dictionary (non-array), `skills` is an empty array,
+    // `education` is absent — all three must normalize to length 0.
+    let data = json!({
+        "basics": { "name": "Ada" },
+        "skills": [],
+        "work": [ { "name": "Acme" }, { "name": "Beta" } ],
+    });
+    let text = render_with_prelude(body, &data);
+
+    assert!(
+        text.contains("PRESENT:2"),
+        "present array length; got:\n{text}"
+    );
+    assert!(
+        text.contains("MISSING:0"),
+        "absent key -> empty; got:\n{text}"
+    );
+    assert!(
+        text.contains("NONARRAY:0"),
+        "non-array value -> empty; got:\n{text}"
+    );
+    assert!(
+        text.contains("EMPTY:0"),
+        "empty array stays empty; got:\n{text}"
+    );
+    assert!(
+        text.contains("W:Acme") && text.contains("W:Beta"),
+        "iterates present array; got:\n{text}"
+    );
+    assert!(
+        !text.contains("SHOULD-NOT-APPEAR"),
+        "iterating a missing section must produce no output; got:\n{text}"
+    );
+}


### PR DESCRIPTION
## What

Turns CONSTITUTION §4's `render(data) -> content` native-theme contract from aspirational into real code. Native themes previously each re-implemented their own field-reading plumbing — `text-minimal` and `html-minimal` carried byte-for-byte copies of `opt`, `nz`, `join_present`, `date_range` plus the same array-section guard repeated per section.

This ships one first-party Typst prelude, `assets/themes/_prelude/lib.typ`, `include_bytes!`'d into each native theme's bundle and served at `/themes/_prelude/lib.typ`. Both native themes now `#import` it and drop their local copies. The shared piece is **data access only** — layout stays per-theme/per-format (frame-extracted text vs semantic HTML can't share one `render`).

## Why

Foundational for the v0.9.0 native-theme-contract milestone: it **blocks** #180 (x- surfacing), #181 (`themes new` scaffold), and #182 (PDF-first reference theme).

**Design decision (settled here):** express the contract as a Typst prelude, **not** a Rust normalization pass. §7 already guarantees themes receive valid, already-narrowed JSON Resume, so what was missing is ergonomics, not a Rust-side schema mirror. A prelude also keeps render fully offline (§6.1).

## Notable details

- Prelude exposes the four helpers plus a normalized `items(d, key)` section accessor (array-or-empty).
- `join_present` returns `""` (not Typst's `none` from an empty `.join`) when all parts are absent, matching the `!= ""` guards the callers were written against — fixes a latent stray-empty-element path surfaced in review.
- `PRELUDE_PATH` is exported so the contract test and any programmatic `OwnedTheme` reference the canonical path instead of re-hardcoding the literal.
- Offline guarantee intact: the prelude is baked into the binary and contains no `@preview/...` imports.

## Testing

- `tests/goldens/text-minimal*.txt` are **byte-identical** — `render_text` / `render_html` pass unchanged.
- New `tests/prelude.rs` covers all four helpers (including every `date_range` branch) and `items` normalization against the real embedded Typst compiler (doctrine §4).
- `make preflight` green.

A multi-persona panel review ran before this PR; all valid findings (prelude-path export, `join_present` contract, `date_range` branch coverage, doc clarity) were addressed in-branch.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized theme template code structure with shared utility functions for improved consistency and maintainability.

* **Documentation**
  * Updated theme adapter contribution guide with prelude contract documentation.

* **Tests**
  * Added comprehensive tests for theme prelude utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->