### PR TITLE
Surface x- extension fields in the native theme prelude

### DIFF
--- a/assets/themes/_prelude/lib.typ
+++ b/assets/themes/_prelude/lib.typ
@@ -77,3 +77,32 @@
   let v = opt(d, key)
   if v != none and type(v) == array { v } else { () }
 }
+
+// --- Extension fields (`x-` namespaces) ----------------------------
+
+// Read a JSON Resume `x-<namespace>` extension field — CONSTITUTION §1's
+// only sanctioned extension point — from any dict `d` (the whole
+// document or a single section item). `namespace` is the bare name
+// WITHOUT the `x-` prefix, so themes never hardcode the literal key
+// string. Returns the field value (often itself a dict) or `none` when
+// the namespace is absent or `d` is not a dict — never errors (JSON
+// Resume has zero required fields).
+//
+// Worked example — badge a highlight an author tagged for an audience:
+//   #let tag = opt(ext(entry, "myorg"), "audience")  // none if absent
+//   #if tag != none { /* render a badge, reorder, etc. */ }
+//
+// Sub-keys are read by chaining `opt` (as above), NOT via dot-notation or
+// a second argument — both of these silently return `none`:
+//   ext(d, "myorg.audience")  // WRONG: reads the literal key "x-myorg.audience"
+//   ext(d, "x-myorg")         // WRONG: double-prefixes to "x-x-myorg"
+// (A dedicated sub-key parameter can be added when a second caller needs
+// it — CONSTITUTION §5.)
+//
+// The `ferrocv` namespace is RESERVED for ferrocv's own use — do not read
+// or write `x-ferrocv` from a theme. ferrocv's projection (§7) consumes
+// and strips its `x-ferrocv` control keys from a derived document
+// (`src/project.rs`), so `ext(d, "ferrocv")` yields `none` on projected
+// output by design. This accessor is for author-defined namespaces a
+// theme chooses to honor, not ferrocv's internal projection metadata.
+#let ext(d, namespace) = opt(d, "x-" + namespace)

--- a/tests/prelude.rs
+++ b/tests/prelude.rs
@@ -180,3 +180,82 @@ fn items_normalizes_section_access() {
         "iterating a missing section must produce no output; got:\n{text}"
     );
 }
+
+/// `ext` reads `x-<namespace>` extension fields (CONSTITUTION §1) at both
+/// the document and item level by bare namespace, and yields `none` when
+/// the namespace is absent — the negative case the issue requires, which
+/// must compile rather than error.
+#[test]
+fn ext_reads_x_namespace_fields() {
+    // Assert via `==` (nil-safe) rather than string concatenation: a
+    // missing sub-key surfaces as a failed assertion, not a Typst type
+    // error — and the test never models the unsafe `"str" + none` idiom.
+    let body = r#"
+#let data = json("/resume.json")
+
+// Document-level: read x-myorg, then chain opt for a sub-key.
+#[#(if opt(ext(data, "myorg"), "audience") == "security" { "DOC-OK" } else { "DOC-BUG" })]
+#linebreak()
+
+// Item-level: the same accessor works on a section entry's dict.
+#let first = items(data, "work").at(0)
+#[#(if opt(ext(first, "myorg"), "team") == "blue" { "ITEM-OK" } else { "ITEM-BUG" })]
+#linebreak()
+
+// Absent namespace yields none (no error) at both document and item level.
+#[#(if ext(data, "absent-ns") == none { "ABSENT-OK" } else { "ABSENT-BUG" })]
+#linebreak()
+#[#(if ext(first, "absent-ns") == none { "ITEM-ABSENT-OK" } else { "ITEM-ABSENT-BUG" })]
+#linebreak()
+
+// Non-dict `d`: the doc promises `ext` never errors when `d` is not a
+// dictionary — `none` and a plain string must both yield `none`.
+#[#(if ext(none, "myorg") == none and ext("not-a-dict", "myorg") == none { "NONDICT-OK" } else { "NONDICT-BUG" })]
+"#;
+    let data = json!({
+        "x-myorg": { "audience": "security" },
+        "work": [ { "name": "Acme", "x-myorg": { "team": "blue" } } ],
+    });
+    let text = render_with_prelude(body, &data);
+
+    assert!(
+        text.contains("DOC-OK"),
+        "ext must read a document-level x- namespace value; got:\n{text}"
+    );
+    assert!(
+        text.contains("ITEM-OK"),
+        "ext must read an item-level x- namespace value; got:\n{text}"
+    );
+    assert!(
+        text.contains("ABSENT-OK"),
+        "ext on an absent namespace must yield none (document level); got:\n{text}"
+    );
+    assert!(
+        text.contains("ITEM-ABSENT-OK"),
+        "ext on an absent namespace must yield none (item level); got:\n{text}"
+    );
+    assert!(
+        text.contains("NONDICT-OK"),
+        "ext must yield none (never error) when d is not a dict; got:\n{text}"
+    );
+}
+
+/// Negative test (issue acceptance): a document with NO `x-` fields at all
+/// compiles cleanly and every `ext` lookup returns `none`.
+#[test]
+fn ext_on_document_without_x_fields_yields_none() {
+    let body = r#"
+#let data = json("/resume.json")
+#[#(if ext(data, "myorg") == none { "NO-X-FIELDS-OK" } else { "NO-X-FIELDS-BUG" })]
+"#;
+    let data = json!({
+        "basics": { "name": "Ada" },
+        "work": [ { "name": "Acme" } ],
+    });
+    let text = render_with_prelude(body, &data);
+
+    assert!(
+        text.contains("NO-X-FIELDS-OK"),
+        "a document with no x- fields must compile and ext must yield none; got:\n{text}"
+    );
+}


### PR DESCRIPTION
## What

Adds an `ext(d, namespace)` accessor to the shared native-theme Typst prelude so themes can read JSON Resume `x-<namespace>` extension fields — CONSTITUTION §1's only sanctioned extension mechanism — by bare namespace, without hardcoding the literal key string. It delegates to the existing `opt` helper and prepends the `x-` prefix, inheriting `opt`'s tolerance: an absent namespace or a non-dict `d` yields `none`, never an error.

## Why

Connects native themes to the targeted-projection work (§7): a curated cut can tag content under an `x-<namespace>` field, and a theme may opt into it (badge a highlight, reorder a section). The PDF-first reference theme (#182) is the intended first consumer. No existing theme uses `ext` yet, so rendering — and the committed goldens — are unchanged.

Foundational follow-on to #179; part of the v0.9.0 native-theme-contract milestone.

## Notable details

- Single accessor `ext(d, namespace)`; sub-keys are read by chaining `opt` (`opt(ext(d, ns), "key")`) rather than a dedicated parameter (§5 — add when a second caller needs it).
- The `ferrocv` namespace is documented as **reserved**: projection already consumes and strips its `x-ferrocv` control keys (`src/project.rs`), so `ext(d, "ferrocv")` yields `none` on projected output by design.
- Doc comment flags the dot-notation (`ext(d, "myorg.audience")`) and double-prefix (`ext(d, "x-myorg")`) misuse traps, both of which return `none` silently.
- Offline guarantee intact: pure in-memory dict lookup, no IO, no `@preview/...` import.

## Testing

- New `tests/prelude.rs` coverage: document-level and item-level reads, absent namespaces (both levels), a document with no `x-` fields at all (the issue's required negative case), and non-dict inputs — all via the real embedded Typst compiler (doctrine §4). Assertions use nil-safe `==` comparisons rather than string concatenation.
- Goldens **byte-identical** (no theme edits).
- `make preflight` green.

A multi-persona panel review ran before this PR; all valid findings (dot-notation/double-prefix doc traps, reserved-namespace clarity, non-dict test coverage, nil-safe test idiom) were addressed in-branch.

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
