### PR TITLE
Add a PDF-first native theme (classic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ ferrocv validate resume.json
 # `--theme` is optional)
 ferrocv render resume.json
 
-# Pick a visually richer PDF theme
-ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
+# Pick a visually richer PDF theme: `classic` is the native PDF-first
+# theme (no external template), or use an adapter like typst-jsonresume-cv
+ferrocv render resume.json --theme classic --output resume.pdf
+
+# `classic` shows a "Tailored for: <label>" tagline when the resume's
+# `meta` object carries an `x-audience` string, e.g.
+#   { "meta": { "x-audience": "security" }, ... }
+# (the tag lives under `meta`, not the document root, because JSON Resume
+# permits `x-` extension fields inside objects but not at the top level)
 
 # Render to plain text (also defaults to `text-minimal`)
 ferrocv render resume.json --format text

--- a/assets/themes/classic/LICENSE
+++ b/assets/themes/classic/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Clonch and ferrocv contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/themes/classic/resume.typ
+++ b/assets/themes/classic/resume.typ
@@ -1,0 +1,359 @@
+// classic — a PDF-first native ferrocv theme (CONSTITUTION §4).
+//
+// Authored directly against the JSON Resume v1.0.0 schema via the shared
+// prelude (`/themes/_prelude/lib.typ`), and designed to look good on the
+// page as a PDF — unlike `text-minimal` (tuned for frame-extracted plain
+// text) and `html-minimal` (semantic HTML). This is the proof that the
+// prelude contract supports real layout, not just minimal output.
+//
+// Design constraints (see CLAUDE.md, CONSTITUTION.md §3, §4, §6):
+// - Single column, classic serif look. Uses "Libertinus Serif", which
+//   ships in `typst-assets` (the only bundled non-mono family) and is
+//   Typst's default — so output is reproducible across hosts with no
+//   system-font dependency (§6). No `@preview/...` imports (§6.1).
+// - Defensive optional-field reads — every accessor comes from the
+//   prelude (`opt`, `nz`, `items`, `date_range`, `join_present`) and
+//   tolerates missing keys; JSON Resume has zero required fields, so the
+//   sparse fixture (basics + work only) must render cleanly.
+// - Layout lives here, not in the prelude: section headings, the rule,
+//   and the title-left / dates-right entry header are this theme's own
+//   (the prelude is data access only — §4).
+//
+// Audience-aware rendering (demonstrates the `ext` accessor, #180): if
+// the document's `meta` object carries an `x-audience` string — e.g. a
+// tailored cut stamped "security" — it is surfaced as a "Tailored for:
+// <label>" tagline under the header. The tag lives under `meta` (not the
+// document root) because JSON Resume's schema forbids unknown properties
+// at the root but permits `x-` extensions inside objects like `meta`.
+// Absent `meta.x-audience` ⇒ no tagline.
+//
+// The MIT-licensed source under `assets/themes/classic/` is also
+// redistributable under the crate's MIT-or-Apache-2.0 dual license; the
+// sibling `LICENSE` is duplicated so the theme stays self-contained if it
+// is ever extracted into its own package.
+
+#import "/themes/_prelude/lib.typ": *
+
+#let resume = json("/resume.json")
+
+// --- Layout helpers (theme-scoped; layout stays per-theme, §4) ------
+
+// A section: a spaced, letter-tracked bold heading with a full-width
+// rule beneath it, then the section body.
+#let section(title, body) = {
+  v(7pt)
+  text(weight: "bold", size: 11pt, tracking: 0.4pt)[#upper(title)]
+  v(1pt)
+  line(length: 100%, stroke: 0.5pt)
+  v(3pt)
+  body
+}
+
+// An entry header: title (bold) on the left, dates (italic) flush right
+// on the same row. Either side may be absent.
+#let entry_head(title, dates) = {
+  grid(
+    columns: (1fr, auto),
+    align: (left, right),
+    if title != none { text(weight: "bold")[#title] } else { [] },
+    if dates != none { text(style: "italic", size: 9.5pt)[#dates] } else { [] },
+  )
+}
+
+// --- Page setup -----------------------------------------------------
+#set page(margin: (x: 0.9in, y: 0.8in), numbering: none)
+#set text(font: "Libertinus Serif", size: 10.5pt)
+#set par(justify: false, leading: 0.62em, spacing: 0.62em)
+#set list(indent: 4pt, body-indent: 5pt, spacing: 0.55em)
+
+// --- Header ---------------------------------------------------------
+#let basics = opt(resume, "basics")
+#if basics != none {
+  let name = nz(opt(basics, "name"))
+  if name != none {
+    align(center, text(size: 20pt, weight: "bold")[#name])
+  }
+  let label = nz(opt(basics, "label"))
+  if label != none {
+    align(center, text(size: 11.5pt, style: "italic")[#label])
+  }
+
+  let email = nz(opt(basics, "email"))
+  let phone = nz(opt(basics, "phone"))
+  let url = nz(opt(basics, "url"))
+  let location = opt(basics, "location")
+  let loc_line = if location != none {
+    let city = nz(opt(location, "city"))
+    let region = nz(opt(location, "region"))
+    let country = nz(opt(location, "countryCode"))
+    let joined = join_present((city, region, country), ", ")
+    if joined == "" { none } else { joined }
+  } else { none }
+  let contact = join_present((email, phone, url, loc_line), "  ·  ")
+  if contact != "" {
+    align(center, text(size: 9.5pt)[#contact])
+  }
+
+  // Profiles render as one centered, separated line.
+  let profile_lines = ()
+  for profile in items(basics, "profiles") {
+    let network = nz(opt(profile, "network"))
+    let username = nz(opt(profile, "username"))
+    let purl = nz(opt(profile, "url"))
+    let label_part = if network != none and username != none {
+      network + ": " + username
+    } else if network != none {
+      network
+    } else if username != none {
+      username
+    } else { none }
+    let entry = if label_part != none and purl != none {
+      label_part + " (" + purl + ")"
+    } else if label_part != none {
+      label_part
+    } else if purl != none {
+      purl
+    } else { none }
+    if entry != none { profile_lines.push(entry) }
+  }
+  if profile_lines.len() > 0 {
+    align(center, text(size: 9.5pt)[#profile_lines.join("  ·  ")])
+  }
+
+  // Audience tagline — read the `x-audience` extension from the `meta`
+  // sub-dict (the schema's `meta` object permits `x-` extensions; the
+  // document root forbids extras). Pass the bare namespace `"audience"`
+  // to `ext`, which prepends the `x-` prefix — never a dotted path.
+  let audience = ext(opt(resume, "meta"), "audience")
+  if audience != none and type(audience) == str and audience != "" {
+    v(2pt)
+    align(center, text(size: 9.5pt, style: "italic")[Tailored for: #audience])
+  }
+}
+
+// --- Summary --------------------------------------------------------
+#let summary = if basics != none { nz(opt(basics, "summary")) } else { none }
+#if summary != none {
+  section("Summary", [#summary])
+}
+
+// --- Experience -----------------------------------------------------
+#let work = items(resume, "work")
+#if work.len() > 0 {
+  section("Experience", {
+    for (i, entry) in work.enumerate() {
+      let name = nz(opt(entry, "name"))
+      let position = nz(opt(entry, "position"))
+      let title = if position != none and name != none {
+        position + ", " + name
+      } else if position != none {
+        position
+      } else { name }
+      entry_head(title, date_range(entry))
+      let wsum = nz(opt(entry, "summary"))
+      if wsum != none { text(size: 10pt)[#wsum]; linebreak() }
+      let highlights = items(entry, "highlights").filter(h => h != none and h != "")
+      if highlights.len() > 0 {
+        list(..highlights.map(h => [#h]))
+      }
+      if i < work.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Education ------------------------------------------------------
+#let education = items(resume, "education")
+#if education.len() > 0 {
+  section("Education", {
+    for (i, entry) in education.enumerate() {
+      // Renders institution, study type/area, and dates. `score`,
+      // `courses`, and `url` are deliberately omitted to keep the entry
+      // compact; add them here if a fuller education block is wanted.
+      let institution = nz(opt(entry, "institution"))
+      entry_head(institution, date_range(entry))
+      let study_type = nz(opt(entry, "studyType"))
+      let area = nz(opt(entry, "area"))
+      let degree = join_present((study_type, area), ", ")
+      if degree != "" { text(size: 10pt)[#degree]; linebreak() }
+      if i < education.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Projects -------------------------------------------------------
+#let projects = items(resume, "projects")
+#if projects.len() > 0 {
+  section("Projects", {
+    for (i, entry) in projects.enumerate() {
+      let name = nz(opt(entry, "name"))
+      entry_head(name, date_range(entry))
+      let desc = nz(opt(entry, "description"))
+      if desc != none { text(size: 10pt)[#desc]; linebreak() }
+      let url = nz(opt(entry, "url"))
+      if url != none { text(size: 9pt, style: "italic")[#url]; linebreak() }
+      let highlights = items(entry, "highlights").filter(h => h != none and h != "")
+      if highlights.len() > 0 {
+        list(..highlights.map(h => [#h]))
+      }
+      if i < projects.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Skills ---------------------------------------------------------
+#let skills = items(resume, "skills")
+#if skills.len() > 0 {
+  section("Skills", {
+    for skill in skills {
+      let name = nz(opt(skill, "name"))
+      let level = nz(opt(skill, "level"))
+      let keywords = items(skill, "keywords").filter(k => k != none and k != "")
+      let kws = if keywords.len() > 0 { keywords.join(", ") } else { none }
+      let label_part = if name != none and level != none {
+        name + " (" + level + ")"
+      } else if name != none {
+        name
+      } else { level }
+      if label_part != none {
+        text(weight: "semibold")[#label_part]
+        if kws != none { [: #kws] }
+        linebreak()
+      } else if kws != none {
+        [#kws]
+        linebreak()
+      }
+    }
+  })
+}
+
+// --- Volunteer ------------------------------------------------------
+#let volunteer = items(resume, "volunteer")
+#if volunteer.len() > 0 {
+  section("Volunteer", {
+    for (i, entry) in volunteer.enumerate() {
+      let organization = nz(opt(entry, "organization"))
+      let position = nz(opt(entry, "position"))
+      let title = if position != none and organization != none {
+        position + ", " + organization
+      } else if position != none {
+        position
+      } else { organization }
+      entry_head(title, date_range(entry))
+      let vsum = nz(opt(entry, "summary"))
+      if vsum != none { text(size: 10pt)[#vsum]; linebreak() }
+      let highlights = items(entry, "highlights").filter(h => h != none and h != "")
+      if highlights.len() > 0 {
+        list(..highlights.map(h => [#h]))
+      }
+      if i < volunteer.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Awards ---------------------------------------------------------
+#let awards = items(resume, "awards")
+#if awards.len() > 0 {
+  section("Awards", {
+    for (i, entry) in awards.enumerate() {
+      let title = nz(opt(entry, "title"))
+      let date = nz(opt(entry, "date"))
+      entry_head(title, date)
+      let awarder = nz(opt(entry, "awarder"))
+      if awarder != none { text(size: 10pt)[#awarder]; linebreak() }
+      let asum = nz(opt(entry, "summary"))
+      if asum != none { text(size: 10pt)[#asum] }
+      if i < awards.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Certificates ---------------------------------------------------
+#let certificates = items(resume, "certificates")
+#if certificates.len() > 0 {
+  section("Certificates", {
+    for (i, entry) in certificates.enumerate() {
+      let name = nz(opt(entry, "name"))
+      let date = nz(opt(entry, "date"))
+      entry_head(name, date)
+      let issuer = nz(opt(entry, "issuer"))
+      if issuer != none { text(size: 10pt)[#issuer]; linebreak() }
+      let url = nz(opt(entry, "url"))
+      if url != none { text(size: 9pt, style: "italic")[#url]; linebreak() }
+      if i < certificates.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Publications ---------------------------------------------------
+#let publications = items(resume, "publications")
+#if publications.len() > 0 {
+  section("Publications", {
+    for (i, entry) in publications.enumerate() {
+      let name = nz(opt(entry, "name"))
+      let release = nz(opt(entry, "releaseDate"))
+      entry_head(name, release)
+      let publisher = nz(opt(entry, "publisher"))
+      if publisher != none { text(size: 10pt)[#publisher]; linebreak() }
+      let psum = nz(opt(entry, "summary"))
+      if psum != none { text(size: 10pt)[#psum]; linebreak() }
+      let url = nz(opt(entry, "url"))
+      if url != none { text(size: 9pt, style: "italic")[#url]; linebreak() }
+      if i < publications.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Languages ------------------------------------------------------
+#let languages = items(resume, "languages")
+#if languages.len() > 0 {
+  // Languages render as one ` · `-separated line ("English (Native) ·
+  // German (Reading)") — a conventional resume style, and unambiguous in
+  // text extraction (one-entry-per-line risks adjacent short lines being
+  // fused by the golden's pdf-extract reader).
+  let lang_lines = ()
+  for entry in languages {
+    let language = nz(opt(entry, "language"))
+    let fluency = nz(opt(entry, "fluency"))
+    let line = if language != none and fluency != none {
+      language + " (" + fluency + ")"
+    } else if language != none {
+      language
+    } else { fluency }
+    if line != none { lang_lines.push(line) }
+  }
+  if lang_lines.len() > 0 {
+    section("Languages", [#lang_lines.join("  ·  ")])
+  }
+}
+
+// --- Interests ------------------------------------------------------
+#let interests = items(resume, "interests")
+#if interests.len() > 0 {
+  section("Interests", {
+    for entry in interests {
+      let name = nz(opt(entry, "name"))
+      let keywords = items(entry, "keywords").filter(k => k != none and k != "")
+      let kws = if keywords.len() > 0 { keywords.join(", ") } else { none }
+      let line = if name != none and kws != none {
+        name + ": " + kws
+      } else if name != none {
+        name
+      } else { kws }
+      if line != none { [#line]; linebreak() }
+    }
+  })
+}
+
+// --- References -----------------------------------------------------
+#let references = items(resume, "references")
+#if references.len() > 0 {
+  section("References", {
+    for (i, entry) in references.enumerate() {
+      let name = nz(opt(entry, "name"))
+      if name != none { text(weight: "bold")[#name]; linebreak() }
+      let reference = nz(opt(entry, "reference"))
+      if reference != none { text(size: 10pt, style: "italic")[#reference] }
+      if i < references.len() - 1 { v(4pt) }
+    }
+  })
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -39,10 +39,10 @@
 //!
 //! # Why a static slice, not a `HashMap` or `ThemeRegistry`
 //!
-//! Phase 2/3 ships six themes total: four adapters
+//! Phase 2/3 ships seven themes total: four adapters
 //! (`typst-jsonresume-cv`, `fantastic-cv`, `modern-cv`, `basic-resume`)
-//! and two native themes (`text-minimal`, `html-minimal`). A linear
-//! scan over `THEMES` is O(n) for small n; CONSTITUTION §5 ("simple
+//! and three native themes (`text-minimal`, `html-minimal`, `classic`).
+//! A linear scan over `THEMES` is O(n) for small n; CONSTITUTION §5 ("simple
 //! now, iterate later") calls for the narrower solution here.
 //! Generalizing to a hashed lookup or a builder pattern should wait
 //! for a caller that actually needs it.
@@ -394,11 +394,56 @@ pub const HTML_MINIMAL: Theme = Theme {
     entrypoint: HTML_MINIMAL_RESUME_PATH,
 };
 
+/// Virtual path of the `classic` theme's entrypoint.
+///
+/// Single per-file constant shared by the [`Theme::files`] key and the
+/// [`Theme::entrypoint`] field. Like the other native themes, this uses
+/// the per-file-path-constant form rather than the adapters'
+/// `PREFIX` + `const _: () = assert!(...)` shape; see
+/// [`TEXT_MINIMAL_RESUME_PATH`] for why that divergence is deliberate.
+const CLASSIC_RESUME_PATH: &str = "/themes/classic/resume.typ";
+
+/// `classic` — a **native theme** (per CONSTITUTION §4) authored directly
+/// against the JSON Resume v1.0.0 schema via the shared prelude, and the
+/// first native theme designed to **look good as a PDF** rather than to
+/// degrade to plain text ([`TEXT_MINIMAL`]) or semantic HTML
+/// ([`HTML_MINIMAL`]). It is the proof that the prelude contract supports
+/// real layout — section rules, a title-left/dates-right entry header,
+/// bullet highlights — not just minimal output.
+///
+/// Single-column classic serif layout in "Libertinus Serif" (bundled in
+/// `typst-assets` and Typst's default, so output is reproducible with no
+/// system-font dependency — §6). It also demonstrates the prelude's `ext`
+/// accessor (#180): a `meta.x-audience` string renders as a
+/// "Tailored for: <label>" tagline (the tag lives under `meta` because the
+/// JSON Resume schema permits `x-` extensions inside objects but not at the
+/// document root).
+///
+/// `classic` is currently selected via `--theme classic`; the PDF default
+/// remains `text-minimal`. Promoting `classic` to the default PDF theme is
+/// a deliberate, user-facing change tracked as a follow-up.
+///
+/// The MIT-licensed source under `assets/themes/classic/` is also
+/// redistributable under the `ferrocv` crate's MIT-or-Apache-2.0 dual
+/// license; the file-level `LICENSE` is duplicated so the theme remains
+/// self-contained if it is ever extracted into its own package.
+pub const CLASSIC: Theme = Theme {
+    name: "classic",
+    files: &[
+        PRELUDE_FILE,
+        (
+            CLASSIC_RESUME_PATH,
+            include_bytes!("../assets/themes/classic/resume.typ"),
+        ),
+    ],
+    entrypoint: CLASSIC_RESUME_PATH,
+};
+
 /// All themes registered with this build of `ferrocv`.
 ///
 /// Phase 2/3 ships four adapters (`typst-jsonresume-cv`, `fantastic-cv`,
-/// `modern-cv`, `basic-resume`) and two native themes (`text-minimal`,
-/// `html-minimal`). See the module doc for why this is a `&[&Theme]`
+/// `modern-cv`, `basic-resume`) and three native themes (`text-minimal`,
+/// `html-minimal`, `classic`). See the module doc for why this is a `&[&Theme]`
 /// rather than a `HashMap` or a builder pattern — a linear scan over
 /// a handful of entries is fine, and CONSTITUTION §5 calls for the
 /// narrower solution until a caller actually needs more. See the
@@ -411,6 +456,7 @@ pub const THEMES: &[&Theme] = &[
     &BASIC_RESUME,
     &TEXT_MINIMAL,
     &HTML_MINIMAL,
+    &CLASSIC,
 ];
 
 /// Look up a [`Theme`] by name. Returns `None` for unknown names.

--- a/tests/fixtures/render_sections.json
+++ b/tests/fixtures/render_sections.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Alan Turing",
+    "label": "Mathematician"
+  },
+  "volunteer": [
+    {
+      "organization": "Government Code and Cypher School",
+      "position": "Cryptanalyst",
+      "url": "https://example.com/gccs",
+      "startDate": "1939-09-01",
+      "endDate": "1945-08-01",
+      "summary": "Led Hut 8, responsible for German naval cryptanalysis.",
+      "highlights": [
+        "Designed the Bombe to speed Enigma decryption",
+        "Devised statistical techniques later called Banburismus"
+      ]
+    }
+  ],
+  "awards": [
+    {
+      "title": "Order of the British Empire",
+      "date": "1946-01-01",
+      "awarder": "United Kingdom",
+      "summary": "Recognized for wartime services."
+    }
+  ],
+  "publications": [
+    {
+      "name": "On Computable Numbers",
+      "publisher": "Proceedings of the London Mathematical Society",
+      "releaseDate": "1936-11-01",
+      "url": "https://example.com/computable-numbers",
+      "summary": "Introduced the universal machine and the halting problem."
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    },
+    {
+      "language": "German",
+      "fluency": "Reading"
+    }
+  ],
+  "references": [
+    {
+      "name": "Max Newman",
+      "reference": "A mathematician of the first rank, with a rare gift for machinery."
+    }
+  ]
+}

--- a/tests/goldens/classic-sections.txt
+++ b/tests/goldens/classic-sections.txt
@@ -1,0 +1,25 @@
+Alan Turing
+ Mathematician
+
+VOLUNTEER
+
+Cryptanalyst, Government Code and Cypher School 1939-09-01 - 1945-08-01
+Led Hut 8, responsible for German naval cryptanalysis. • Designed the Bombe to speed Enigma decryption
+• Devised statistical techniques later called Banburismus
+
+AWARDS
+Order of the British Empire 1946-01-01
+United Kingdom
+Recognized for wartime services.
+
+PUBLICATIONS
+
+On Computable Numbers 1936-11-01
+Proceedings of the London Mathematical Society
+Introduced the universal machine and the halting problem.https://example.com/computable-numbers
+LANGUAGES
+
+English (Native speaker)  ·  German (Reading)
+REFERENCES
+
+Max NewmanA mathematician of the first rank, with a rare gift for machinery.

--- a/tests/goldens/classic-sparse.txt
+++ b/tests/goldens/classic-sparse.txt
@@ -1,0 +1,11 @@
+Grace Hopper
+ Computer Scientist
+
+SUMMARY
+
+Rear admiral and pioneer of computer programming.
+EXPERIENCE
+
+Rear Admiral, US Navy 1944-07-01 - Present
+• Worked on the Mark I computer at Harvard.
+• Developed the first compiler for a computer programming language.

--- a/tests/goldens/classic.txt
+++ b/tests/goldens/classic.txt
@@ -1,0 +1,36 @@
+Ada Lovelace
+ Computing Pioneer
+ada@example.com  ·  +44-20-0000-0000  ·  https://example.com/ada  ·  London, England, GB
+GitHub: ada (https://github.example.com/ada)  ·  LinkedIn: ada-lovelace (https://linkedin.example.com/in/ada-lovelace)
+
+SUMMARY
+
+Mathematician and writer, chiefly known for her work on Charles Babbage's proposed mechanical general-purpose computer, the Analytical Engine.
+EXPERIENCE
+
+Programmer, Analytical Engines Ltd 1843-01-01 - 1852-11-27
+Translated and annotated Menabrea's paper on the Analytical Engine; wrote the first published algorithm intended for machine execution. • Published the first algorithm designed for a machine (Bernoulli numbers)
+• Introduced the concept of a general-purpose computing device
+
+EDUCATION
+
+University of London 1833-01-01 - 1843-01-01
+Self-directed, Mathematics
+
+PROJECTS
+
+Notes on the Analytical Engine 1842-01-01 - 1843-07-01
+Expanded translation of Menabrea's sketch, including the first published algorithm for a computing machine.https://example.com/notes-g • Note G — the Bernoulli-number algorithm
+
+SKILLS
+
+Programming (Pioneer) : Analytical Engine, Algorithms
+Mathematics (Expert) : Calculus, Symbolic logic
+
+CERTIFICATES
+
+Honorary Fellowship in Computing History 1843-09-01
+Analytical Engines Ltdhttps://example.com/cert
+INTERESTS
+
+Poetical Science: Imagination, Mathematics

--- a/tests/render_theme.rs
+++ b/tests/render_theme.rs
@@ -152,6 +152,97 @@ fn basic_resume_renders_grace_hopper_sparse_to_expected_text() {
     );
 }
 
+// classic native-theme goldens (PDF-first; same PDF→text→normalize
+// pipeline as the adapters above, since `classic` is designed for PDF).
+#[test]
+fn classic_renders_ada_lovelace_to_expected_text() {
+    run_golden(
+        "classic",
+        "tests/fixtures/render_full.json",
+        "tests/goldens/classic.txt",
+        "Ada Lovelace",
+    );
+}
+
+#[test]
+fn classic_renders_grace_hopper_sparse_to_expected_text() {
+    run_golden(
+        "classic",
+        "tests/fixtures/render_sparse.json",
+        "tests/goldens/classic-sparse.txt",
+        "Grace Hopper",
+    );
+}
+
+/// Exercises the section renderers the two shared fixtures omit —
+/// volunteer, awards, publications, languages, references. `render_full`
+/// and `render_sparse` cover basics/work/education/projects/skills/
+/// interests/certificates; without this, those five renderers would have
+/// no golden coverage and could regress silently (testing-doctrine §2).
+/// This fixture is `classic`-scoped on purpose: extending the shared
+/// `render_full.json` would force regenerating every other theme's golden.
+#[test]
+fn classic_renders_all_sections_to_expected_text() {
+    run_golden(
+        "classic",
+        "tests/fixtures/render_sections.json",
+        "tests/goldens/classic-sections.txt",
+        "Alan Turing",
+    );
+}
+
+/// Audience-aware rendering (issue #182, exercising the `ext` accessor
+/// from #180): `classic` surfaces a `meta.x-audience` string as a
+/// "Tailored for: <label>" tagline. This is intentionally NOT a committed
+/// golden — it asserts the tagline appears (and its absence when no tag is
+/// present) by extracting the compiled PDF text, mirroring `run_golden`'s
+/// PDF→text pipeline but with inline data so no fixture/golden is needed.
+///
+/// The tag lives under `meta` (not the document root) because the JSON
+/// Resume schema forbids unknown root properties but permits `x-`
+/// extensions inside objects — so a real `ferrocv render` of such a
+/// document validates and renders the tagline.
+#[test]
+fn classic_renders_audience_tag_from_meta() {
+    let theme = ferrocv::find_theme("classic").expect("classic must be registered");
+
+    // With `meta.x-audience`, the tagline appears.
+    let tagged = serde_json::json!({
+        "meta": { "x-audience": "security" },
+        "basics": { "name": "Ada Lovelace", "label": "Engineer" },
+        "work": [ { "position": "Engineer", "name": "Acme", "startDate": "2020" } ],
+    });
+    let bytes = ferrocv::compile_theme(theme, &tagged)
+        .expect("classic must compile the audience-tagged document");
+    let text = pdf_extract::extract_text_from_mem(&bytes)
+        .expect("pdf-extract must parse the compiled PDF");
+    assert!(
+        text.contains("Tailored for: security"),
+        "a meta.x-audience tag must render as a 'Tailored for:' tagline; got:\n{text}"
+    );
+    // Exactly one tagline — guards against a renderer that duplicated it
+    // or emitted it in addition to some other (mislocated) copy.
+    assert_eq!(
+        text.matches("Tailored for:").count(),
+        1,
+        "the audience tagline must render exactly once; got:\n{text}"
+    );
+
+    // Without the tag, no tagline (and no stray 'Tailored for:' text).
+    let untagged = serde_json::json!({
+        "basics": { "name": "Ada Lovelace", "label": "Engineer" },
+        "work": [ { "position": "Engineer", "name": "Acme", "startDate": "2020" } ],
+    });
+    let bytes = ferrocv::compile_theme(theme, &untagged)
+        .expect("classic must compile the untagged document");
+    let text = pdf_extract::extract_text_from_mem(&bytes)
+        .expect("pdf-extract must parse the compiled PDF");
+    assert!(
+        !text.contains("Tailored for:"),
+        "no tagline must render when meta.x-audience is absent; got:\n{text}"
+    );
+}
+
 /// Shared golden-file workflow: compile the named adapter against the
 /// named fixture, extract and normalize the PDF text, and compare
 /// against (or rewrite, under `UPDATE_GOLDEN`) the committed golden.

--- a/tests/themes_cli.rs
+++ b/tests/themes_cli.rs
@@ -25,7 +25,7 @@ fn themes_list_prints_sorted_names() {
         .assert()
         .success()
         .stdout(predicate::eq(
-            "basic-resume\nfantastic-cv\nhtml-minimal\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
+            "basic-resume\nclassic\nfantastic-cv\nhtml-minimal\nmodern-cv\ntext-minimal\ntypst-jsonresume-cv\n",
         ))
         .stderr(predicate::str::is_empty());
 }


### PR DESCRIPTION
## What

Adds **`classic`**, the first native theme designed to look good as a PDF. It's authored directly against the JSON Resume schema via the shared prelude (#179) instead of wrapping an upstream Typst template — proving the prelude contract supports real layout (section rules, a title-left / dates-right entry header, bullet highlights), not just the minimal output of `text-minimal` (frame-extracted text) and `html-minimal` (semantic HTML).

Selectable via `--theme classic`. Single-column classic serif layout in Libertinus Serif (bundled in typst-assets and Typst's default → reproducible, no system-font dependency, §6). No `@preview/...` imports; render stays offline (§6.1).

## Why

The PDF default, `text-minimal`, is tuned for ATS extraction, not for looking good on the page; every visually-rich PDF option was previously an adapter. `classic` makes native themes genuinely first-class. Part of the v0.9.0 native-theme-contract milestone; the intended first consumer of the `ext` accessor from #180.

## Notable details

- **Audience-aware rendering (demonstrates `ext`, #180):** a `meta.x-audience` string renders as a "Tailored for: \<label>" tagline.
- **Schema note:** the audience tag lives under `meta`, **not** the document root — JSON Resume's schema sets `additionalProperties: false` at the root (so a top-level `x-audience` is rejected by `validate`) but permits `x-` extensions inside objects like `meta`. A real `ferrocv render` of a `meta.x-audience` document validates and renders the tagline (verified end-to-end). Worth keeping in mind for #183: `ext` is for `x-` fields *inside* objects.
- **Optional-field tolerance:** every field is read through the prelude's accessors, so the sparse fixture (basics+work only) degrades cleanly.

## Recommendation (per the issue's "consider whether this becomes the default")

`classic` is a strong candidate to become the **default PDF theme**, but that's a user-facing change touching `cli.rs` (`default_theme_for_format`), the `render_pdf_uses_text_minimal_when_theme_omitted` test, and the README. **Left to a follow-up issue** so the default switch gets its own review. The default stays `text-minimal` in this PR.

## Testing

- Golden tests (testing-doctrine §2) for the shared `render_full` and `render_sparse` fixtures, **plus a dedicated all-sections fixture** (`render_sections.json`) covering volunteer/awards/publications/languages/references — which the shared fixtures omit — so every section renderer has coverage.
- A focused test asserts the audience tagline renders **exactly once** (presence + no duplication).
- Three new committed goldens; no other theme's golden touched. `make preflight` green.

A multi-persona panel review ran before this PR; all valid findings (section coverage, README discoverability, audience-test strength, several doc fixes) were addressed in-branch. Two findings were declined with rationale (by-design non-string skip; length cap inconsistent with all other unbounded fields).

Closes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native "classic" resume theme for PDF rendering with professional formatting and layout
  * Supports displaying audience-specific taglines from resume metadata for targeted resume variants

* **Documentation**
  * Updated README "Render to PDF" usage example to showcase the new classic theme

<!-- end of auto-generated comment: release notes by coderabbit.ai -->