### PR TITLE
Make classic the default PDF theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,11 @@ strings there are kept in lockstep with `.github/workflows/ci.yml`.
     `assets/themes/<name>/` — each with its own `VENDORING.md` recording
     upstream SHA and any patches (e.g. `modern-cv` was patched to drop
     `@preview/fontawesome` and `@preview/linguify`).
-  - *Native themes* (currently just `text-minimal`) author Typst
-    directly against the JSON Resume schema; this is what
-    `--format text` and `--format html` default to.
+  - *Native themes* (`text-minimal`, `html-minimal`, `classic`) author
+    Typst directly against the JSON Resume schema via the shared prelude
+    (`assets/themes/_prelude/lib.typ`). Each format defaults to one:
+    `--format pdf` → `classic`, `--format text` → `text-minimal`,
+    `--format html` → `html-minimal`.
 - **Schema embedding.** `assets/schema/jsonresume-v1.0.0.json` is
   vendored and baked into the binary via `include_str!` in `src/lib.rs`.
   `jsonschema` is built without default features to avoid pulling

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Render [JSON Resume](https://jsonresume.org/) to PDF, HTML, and text via
 ## Status
 
 **Early.** PDF, plain-text, and HTML output all work today (PDF via
-any registered PDF-capable theme, plain text via the native
-`text-minimal` default, and HTML via the native `html-minimal`
-semantic theme). Additional themes and native-theme
+the native PDF-first `classic` default or any registered theme, plain
+text via the native `text-minimal` default, and HTML via the native
+`html-minimal` semantic theme). Additional themes and native-theme
 tooling are tracked as
 [GitHub issues](https://github.com/cacack/ferrocv/issues) and
 organized into phase milestones. HTML uses Typst's upstream-experimental
@@ -56,13 +56,15 @@ schema and replaces the rendering pipeline with something more robust:
 # Validate a resume against the JSON Resume schema
 ferrocv validate resume.json
 
-# Render to PDF (defaults to the native `text-minimal` theme;
+# Render to PDF (defaults to the native PDF-first `classic` theme;
 # `--theme` is optional)
 ferrocv render resume.json
 
-# Pick a visually richer PDF theme: `classic` is the native PDF-first
-# theme (no external template), or use an adapter like typst-jsonresume-cv
-ferrocv render resume.json --theme classic --output resume.pdf
+# Keep the previous extraction-tuned PDF default (pre-v0.9 `text-minimal`)
+ferrocv render resume.json --theme text-minimal --output resume.pdf
+
+# Or use an adapter that wraps an upstream Typst Universe template
+ferrocv render resume.json --theme typst-jsonresume-cv --output resume.pdf
 
 # `classic` shows a "Tailored for: <label>" tagline when the resume's
 # `meta` object carries an `x-audience` string, e.g.
@@ -70,7 +72,7 @@ ferrocv render resume.json --theme classic --output resume.pdf
 # (the tag lives under `meta`, not the document root, because JSON Resume
 # permits `x-` extension fields inside objects but not at the top level)
 
-# Render to plain text (also defaults to `text-minimal`)
+# Render to plain text (defaults to `text-minimal`)
 ferrocv render resume.json --format text
 
 # Render to HTML (defaults to the native `html-minimal` semantic theme).
@@ -97,8 +99,10 @@ on every push via GitHub Actions (using the `setup-ferrocv` composite
 action below) and publishes the result to GitHub Pages.
 
 `render` defaults to `--format pdf`. `--theme` is optional for every
-format: PDF and text default to the native `text-minimal` theme, while
-HTML defaults to the native `html-minimal` semantic theme. When
+format: PDF defaults to the native PDF-first `classic` theme, text to
+the native `text-minimal` theme, and HTML to the native `html-minimal`
+semantic theme. (The PDF default became `classic` in v0.9; if you relied
+on the older extraction-tuned PDF, pass `--theme text-minimal`.) When
 `--output` is omitted, the output lands at `dist/resume.pdf` for PDF,
 `dist/resume.txt` for text, and `dist/resume.html` for HTML; parent
 directories are created as needed. `validate`, `render`, and `tailor`

--- a/docs/tailoring.md
+++ b/docs/tailoring.md
@@ -48,7 +48,7 @@ There is **one** projection transform behind **two** CLI surfaces:
   renders in one shot:
 
   ```sh
-  ferrocv render examples/master.resume.json --audience security --theme text-minimal -o security.pdf
+  ferrocv render examples/master.resume.json --audience security -o security.pdf
   ```
 
 These two are equivalent by construction — `render --audience security` is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,9 +51,9 @@ enum Commands {
     /// Render a JSON Resume document to PDF, plain text, or HTML via
     /// the named theme.
     ///
-    /// `--theme` is optional for all formats. PDF and text default to
-    /// `text-minimal`; HTML defaults to `html-minimal`. `--theme` also
-    /// accepts a path to a local `.typ` file — either relative
+    /// `--theme` is optional for all formats. PDF defaults to `classic`,
+    /// text defaults to `text-minimal`, HTML defaults to `html-minimal`.
+    /// `--theme` also accepts a path to a local `.typ` file — either relative
     /// (`./resume.typ`), absolute (`/abs/path/resume.typ`), or any
     /// string ending in `.typ` or containing a path separator — in
     /// which case the file's bytes are loaded at invocation time and
@@ -79,8 +79,8 @@ enum Commands {
         /// `ferrocv themes list`) resolve out of the compile-time
         /// registry; anything ending in `.typ` or containing a path
         /// separator loads from the local filesystem. Optional for
-        /// all formats: PDF and text default to `text-minimal`; HTML
-        /// defaults to `html-minimal`.
+        /// all formats: PDF defaults to `classic`, text to `text-minimal`,
+        /// HTML to `html-minimal`.
         #[arg(long)]
         theme: Option<String>,
         /// Output format: `pdf`, `text`, or `html`. Defaults to `pdf`.
@@ -294,17 +294,18 @@ enum RedactArg {
 /// Resolve which theme name to use given the format and the optional
 /// `--theme` argument.
 ///
-/// PDF and text default to the native `text-minimal` theme. HTML
-/// defaults to the semantic-HTML native theme `html-minimal`. An
-/// explicit `--theme` always wins. See CONSTITUTION §3 for why each
-/// format gets its own native default rather than a single shared
-/// anchor.
+/// PDF defaults to the native PDF-first theme `classic`; text defaults to
+/// the extraction-tuned native `text-minimal`; HTML defaults to the
+/// semantic-HTML native `html-minimal`. An explicit `--theme` always wins.
+/// See CONSTITUTION §3 for why each format gets its own native default
+/// rather than a single shared anchor.
 fn resolve_theme_name(format: Format, requested: Option<&str>) -> &str {
     match requested {
         Some(name) => name,
         None => match format {
+            Format::Pdf => "classic",
+            Format::Text => "text-minimal",
             Format::Html => "html-minimal",
-            Format::Pdf | Format::Text => "text-minimal",
         },
     }
 }
@@ -578,9 +579,9 @@ fn run_render(
     }
 
     // Step 1: resolve theme name first. Every format now has a default
-    // (`text-minimal` for PDF/text, `html-minimal` for HTML), so this
-    // is infallible — an explicit `--theme` overrides, otherwise the
-    // native default applies.
+    // (`classic` for PDF, `text-minimal` for text, `html-minimal` for
+    // HTML), so this is infallible — an explicit `--theme` overrides,
+    // otherwise the native default applies.
     let theme_name = resolve_theme_name(format, theme_name);
 
     // Step 2: read input. IO failures bubble up via anyhow and main
@@ -811,5 +812,36 @@ fn read_input(path: Option<&Path>) -> Result<String> {
             std::fs::read_to_string(p).with_context(|| format!("failed to read {}", p.display()))
         }
         None => std::io::read_to_string(std::io::stdin()).context("failed to read JSON from stdin"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The per-format native defaults (issue #188): PDF renders via the
+    /// PDF-first `classic` theme, while text and HTML keep their
+    /// extraction- and semantic-HTML-tuned defaults. CONSTITUTION §3:
+    /// each format gets its own native default.
+    #[test]
+    fn resolve_theme_name_uses_per_format_native_defaults() {
+        assert_eq!(resolve_theme_name(Format::Pdf, None), "classic");
+        assert_eq!(resolve_theme_name(Format::Text, None), "text-minimal");
+        assert_eq!(resolve_theme_name(Format::Html, None), "html-minimal");
+    }
+
+    /// An explicit `--theme` always wins over the per-format default,
+    /// for every format.
+    #[test]
+    fn resolve_theme_name_explicit_request_wins() {
+        assert_eq!(
+            resolve_theme_name(Format::Pdf, Some("text-minimal")),
+            "text-minimal"
+        );
+        assert_eq!(resolve_theme_name(Format::Text, Some("classic")), "classic");
+        assert_eq!(
+            resolve_theme_name(Format::Html, Some("typst-jsonresume-cv")),
+            "typst-jsonresume-cv"
+        );
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -419,9 +419,10 @@ const CLASSIC_RESUME_PATH: &str = "/themes/classic/resume.typ";
 /// JSON Resume schema permits `x-` extensions inside objects but not at the
 /// document root).
 ///
-/// `classic` is currently selected via `--theme classic`; the PDF default
-/// remains `text-minimal`. Promoting `classic` to the default PDF theme is
-/// a deliberate, user-facing change tracked as a follow-up.
+/// `classic` is the default PDF theme as of issue #188 (text still defaults
+/// to `text-minimal`, HTML to `html-minimal`); the default mapping lives in
+/// `resolve_theme_name` in `src/cli.rs`. Pass `--theme text-minimal` to opt
+/// back into the extraction-tuned PDF output.
 ///
 /// The MIT-licensed source under `assets/themes/classic/` is also
 /// redistributable under the `ferrocv` crate's MIT-or-Apache-2.0 dual

--- a/tests/render_cli.rs
+++ b/tests/render_cli.rs
@@ -336,13 +336,13 @@ fn render_text_rejects_invalid_resume_with_exit_one() {
 }
 
 #[test]
-fn render_pdf_uses_text_minimal_when_theme_omitted() {
+fn render_pdf_uses_classic_when_theme_omitted() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let out = tmp.path().join("out.pdf");
 
     // No `--theme`; explicit `--format pdf` (also the default). Since
-    // #52, PDF defaults to the native `text-minimal` theme like text
-    // and HTML do.
+    // #188, PDF defaults to the PDF-first native `classic` theme (text
+    // still defaults to `text-minimal`, HTML to `html-minimal`).
     ferrocv()
         .arg("render")
         .arg(fixture("render_full"))
@@ -362,11 +362,27 @@ fn render_pdf_uses_text_minimal_when_theme_omitted() {
     );
     let size = std::fs::metadata(&out).expect("stat").len();
     assert!(size > 1024, "PDF should be > 1 KiB, was {size} bytes");
+
+    // Confirm the *default* really resolved to `classic`, not just that
+    // some PDF was produced. `classic` emits uppercase section headings
+    // (e.g. `EXPERIENCE`); `text-minimal` uses title-case `Work` and has
+    // no such heading — so the heading's presence pins the default theme.
+    let bytes = std::fs::read(&out).expect("read rendered PDF");
+    let text = pdf_extract::extract_text_from_mem(&bytes).expect("extract PDF text");
+    assert!(
+        text.contains("EXPERIENCE"),
+        "default PDF must render via `classic` (expected its `EXPERIENCE` \
+         heading); got:\n{text}"
+    );
 }
 
 #[test]
 fn render_pdf_default_output_path_is_dist_resume_pdf() {
     // No `--output`, no `--theme`, no `--format` (pdf is the default).
+    // This asserts the default *output path* only; it also exercises the
+    // default PDF theme (`classic` since #188), so it depends on `classic`
+    // being registered — theme *identity* is pinned by
+    // `render_pdf_uses_classic_when_theme_omitted`.
     // `current_dir` is set to a tempdir so the default `dist/resume.pdf`
     // lands under the temp tree rather than polluting the workspace.
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## What

Changes the default `--format pdf` theme from `text-minimal` to the PDF-first `classic` theme (#182). Text still defaults to `text-minimal`, HTML to `html-minimal`, and an explicit `--theme` still wins for every format. One-line split of the `Format::Pdf | Format::Text` arm in `resolve_theme_name` (`src/cli.rs`).

## Why

`text-minimal` is tuned for frame-extracted plain text (single column, no glyphs) — the right default for `--format text`, a poor one for PDF. `classic` is the native theme designed to look good on the page, so it's the better out-of-the-box PDF. This is the capstone of the native-theme-contract arc (#179 → #180 → #182): native themes become first-class by being what users get by default.

## ⚠️ User-facing behavior change

`ferrocv render resume.json` (no `--theme`, PDF) now produces a **`classic`-styled PDF** instead of `text-minimal`. Anyone relying on the previous extraction-tuned output — e.g. an ATS pipeline or CI job tuned against `text-minimal` — can **pass `--theme text-minimal`** to keep the old behavior. This migration note is in the README quickstart and the defaults paragraph.

## Testing

- New `resolve_theme_name` unit tests (`src/cli.rs`): per-format defaults (pdf→classic, text→text-minimal, html→html-minimal) and explicit-override-wins.
- Renamed `render_pdf_uses_classic_when_theme_omitted` (`tests/render_cli.rs`) extracts the rendered PDF and asserts the `classic`-only `EXPERIENCE` heading — pins the default wiring end-to-end, not just "a PDF rendered."
- Text/HTML default tests unchanged and still pass. No theme files touched → goldens untouched. `make preflight` green.

## Docs

README (quickstart + defaults paragraph, with migration hint), CLI `--help`/doc comments, the `CLASSIC` doc comment in `src/theme.rs`, `CLAUDE.md` (native-themes list + default mapping), and the `docs/tailoring.md` example all updated to reflect the new default.

A multi-persona panel review ran before this PR; all valid findings (stale `CLASSIC`/CLAUDE.md docs, missing migration hint, README/doc-comment polish, path-test clarity, tailoring example) were addressed in-branch.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to reflect new PDF rendering default: `classic` theme instead of `text-minimal`
  * Documented how to use `--theme text-minimal` to restore previous PDF output behavior
  * Clarified that text and HTML outputs maintain their existing defaults

* **Tests**
  * Enhanced test coverage to verify correct default theme selection by output format and explicit theme overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->