### PR TITLE
Scaffold starter native themes with themes new

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,15 @@ test stub. The emitted `resume.typ` `#import`s ferrocv's shared
 native-theme prelude and renders the major JSON Resume sections, so it
 renders straight away — point `render --theme` at the file:
 
-```
-$ ferrocv themes new mytheme
-$ ferrocv render resume.json --theme mytheme/resume.typ --output resume.pdf
+```sh
+ferrocv themes new mytheme
+ferrocv render resume.json --theme mytheme/resume.typ --output resume.pdf
 ```
 
 `<name>` must be a bare directory name (letters, digits, `-`, `_`; no
-path separators or `..`), and the command refuses to write into an
-existing target rather than clobber it. A fuller authoring walkthrough is
+leading `-`, no path separators or `..`), and the command refuses to
+write into an existing target rather than clobber it. A fuller authoring
+walkthrough is
 tracked separately; for now the generated file's comments and the bundled
 `classic` theme are the reference.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ ferrocv render resume.json --format html
 # List bundled themes (machine-readable, one name per line)
 ferrocv themes list
 
+# Scaffold a starter native theme to author your own
+ferrocv themes new mytheme
+
 # Project a master resume into a narrower cut (mechanical filters):
 # drop roles that ended before 2015, cap each job at 4 bullets, and
 # strip PII. Writes the derived JSON Resume to stdout (or use -o).
@@ -165,6 +168,24 @@ for unattended or shared/recorded contexts.
 `themes list` prints registered theme names to stdout, one per line,
 sorted lexicographically, with no decoration — a stable
 machine-readable contract.
+
+`themes new <name>` scaffolds a starter native theme to author your own.
+It writes a new `<name>/` directory (in the current directory, or under
+`--out <dir>`) containing a ready-to-edit `resume.typ` and a `golden.txt`
+test stub. The emitted `resume.typ` `#import`s ferrocv's shared
+native-theme prelude and renders the major JSON Resume sections, so it
+renders straight away — point `render --theme` at the file:
+
+```
+$ ferrocv themes new mytheme
+$ ferrocv render resume.json --theme mytheme/resume.typ --output resume.pdf
+```
+
+`<name>` must be a bare directory name (letters, digits, `-`, `_`; no
+path separators or `..`), and the command refuses to write into an
+existing target rather than clobber it. A fuller authoring walkthrough is
+tracked separately; for now the generated file's comments and the bundled
+`classic` theme are the reference.
 
 `themes install` resolves transitive `@preview/...` dependencies
 recursively: installing one package also fetches every `@preview/...`

--- a/assets/scaffold/resume.typ
+++ b/assets/scaffold/resume.typ
@@ -1,0 +1,188 @@
+// A starter ferrocv native theme — scaffolded by `ferrocv themes new`.
+//
+// This is YOUR theme. Edit it freely: the layout below is a minimal,
+// readable starting point that renders the major JSON Resume sections.
+// Add sections, restyle, or rip it apart — it is a single self-contained
+// `.typ` file with no external dependencies beyond ferrocv's prelude.
+//
+// How it works
+// ------------
+// ferrocv hands every theme two virtual files:
+//   - `/resume.json`            — the JSON Resume document being rendered
+//   - `/themes/_prelude/lib.typ` — ferrocv's shared native-theme prelude
+// The prelude (imported just below) is the native-theme contract from
+// CONSTITUTION §4: defensive *data access* only (it ships no layout).
+// JSON Resume v1.0.0 has zero required fields, so read everything
+// through these helpers — they never error on a missing or oddly-shaped
+// key:
+//   opt(d, k)            -> d.k if present, else none
+//   nz(s)                -> none for none/"" (collapse empties)
+//   items(d, k)          -> the array at k, or () when absent/non-array
+//   date_range(item)     -> "2019 - 2022" / "2019 - Present" / none
+//   join_present(xs, ", ") -> xs joined, dropping none/"" (— "" if all gone)
+//   ext(d, "ns")         -> the `x-ns` extension field, or none (§1)
+//
+// Render it:
+//   ferrocv render resume.json --theme ./<this-dir>/resume.typ -o out.pdf
+// Swap `--format text` / `--format html` to target the other outputs —
+// but note this starter is tuned for PDF. See the authoring guide for
+// format-specific concerns.
+
+#import "/themes/_prelude/lib.typ": *
+
+#let resume = json("/resume.json")
+
+// --- Layout helpers (yours to change — layout lives in the theme, §4) -
+
+// A section: a bold heading with a rule beneath it, then the body.
+#let section(title, body) = {
+  v(7pt)
+  text(weight: "bold", size: 11pt, tracking: 0.4pt)[#upper(title)]
+  v(1pt)
+  line(length: 100%, stroke: 0.5pt)
+  v(3pt)
+  body
+}
+
+// An entry header: title (bold) left, dates (italic) flush right.
+// Either side may be absent.
+#let entry_head(title, dates) = {
+  grid(
+    columns: (1fr, auto),
+    align: (left, right),
+    if title != none { text(weight: "bold")[#title] } else { [] },
+    if dates != none { text(style: "italic", size: 9.5pt)[#dates] } else { [] },
+  )
+}
+
+// --- Page setup -----------------------------------------------------
+// "Libertinus Serif" ships in ferrocv's bundled fonts and is Typst's
+// default, so output is reproducible on any host with no system-font
+// dependency (CONSTITUTION §6). Pick another family only if you vendor
+// it; otherwise rendering may vary machine to machine.
+#set page(margin: (x: 0.9in, y: 0.8in), numbering: none)
+#set text(font: "Libertinus Serif", size: 10.5pt)
+#set par(justify: false, leading: 0.62em, spacing: 0.62em)
+#set list(indent: 4pt, body-indent: 5pt, spacing: 0.55em)
+
+// --- Header ---------------------------------------------------------
+#let basics = opt(resume, "basics")
+#if basics != none {
+  let name = nz(opt(basics, "name"))
+  if name != none {
+    align(center, text(size: 20pt, weight: "bold")[#name])
+  }
+  let label = nz(opt(basics, "label"))
+  if label != none {
+    align(center, text(size: 11.5pt, style: "italic")[#label])
+  }
+
+  // Contact line: email · phone · website. join_present drops any that
+  // are absent and returns "" if all are — so guard with `!= ""`.
+  let contact = join_present(
+    (nz(opt(basics, "email")), nz(opt(basics, "phone")), nz(opt(basics, "url"))),
+    "  ·  ",
+  )
+  if contact != "" {
+    align(center, text(size: 9.5pt)[#contact])
+  }
+
+  // Extension fields (§1): read author-defined `x-<namespace>` data with
+  // `ext`. Here we surface a `meta.x-audience` tag (set by a tailored
+  // cut) as a tagline. Delete if you don't use it.
+  let audience = ext(opt(resume, "meta"), "audience")
+  if audience != none and type(audience) == str and audience != "" {
+    v(2pt)
+    align(center, text(size: 9.5pt, style: "italic")[Tailored for: #audience])
+  }
+}
+
+// --- Summary --------------------------------------------------------
+#let summary = if basics != none { nz(opt(basics, "summary")) } else { none }
+#if summary != none {
+  section("Summary", [#summary])
+}
+
+// --- Experience -----------------------------------------------------
+#let work = items(resume, "work")
+#if work.len() > 0 {
+  section("Experience", {
+    for (i, entry) in work.enumerate() {
+      let name = nz(opt(entry, "name"))
+      let position = nz(opt(entry, "position"))
+      let title = if position != none and name != none {
+        position + ", " + name
+      } else if position != none {
+        position
+      } else { name }
+      entry_head(title, date_range(entry))
+      let wsum = nz(opt(entry, "summary"))
+      if wsum != none { text(size: 10pt)[#wsum]; linebreak() }
+      // highlights is an array of strings; filter empties before listing.
+      let highlights = items(entry, "highlights").filter(h => h != none and h != "")
+      if highlights.len() > 0 {
+        list(..highlights.map(h => [#h]))
+      }
+      if i < work.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Education ------------------------------------------------------
+#let education = items(resume, "education")
+#if education.len() > 0 {
+  section("Education", {
+    for (i, entry) in education.enumerate() {
+      let institution = nz(opt(entry, "institution"))
+      entry_head(institution, date_range(entry))
+      let degree = join_present(
+        (nz(opt(entry, "studyType")), nz(opt(entry, "area"))),
+        ", ",
+      )
+      if degree != "" { text(size: 10pt)[#degree]; linebreak() }
+      if i < education.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// --- Skills ---------------------------------------------------------
+#let skills = items(resume, "skills")
+#if skills.len() > 0 {
+  section("Skills", {
+    for skill in skills {
+      let name = nz(opt(skill, "name"))
+      let keywords = items(skill, "keywords").filter(k => k != none and k != "")
+      let kws = if keywords.len() > 0 { keywords.join(", ") } else { none }
+      if name != none {
+        text(weight: "semibold")[#name]
+        if kws != none { [: #kws] }
+        linebreak()
+      } else if kws != none {
+        [#kws]; linebreak()
+      }
+    }
+  })
+}
+
+// --- Projects -------------------------------------------------------
+#let projects = items(resume, "projects")
+#if projects.len() > 0 {
+  section("Projects", {
+    for (i, entry) in projects.enumerate() {
+      let name = nz(opt(entry, "name"))
+      entry_head(name, date_range(entry))
+      let desc = nz(opt(entry, "description"))
+      if desc != none { text(size: 10pt)[#desc]; linebreak() }
+      let highlights = items(entry, "highlights").filter(h => h != none and h != "")
+      if highlights.len() > 0 {
+        list(..highlights.map(h => [#h]))
+      }
+      if i < projects.len() - 1 { v(4pt) }
+    }
+  })
+}
+
+// Add more sections the same way — `volunteer`, `awards`, `certificates`,
+// `publications`, `languages`, `interests`, `references` are all arrays
+// you can iterate with `items(resume, "<name>")`. See the bundled
+// `classic` theme for a fuller, every-section example.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,7 +191,8 @@ enum ThemesCommands {
     /// - 2: invalid name, target already exists, or IO error.
     New {
         /// Name of the theme to scaffold. Becomes the new directory's
-        /// name; letters, digits, `-`, and `_` only.
+        /// name; letters, digits, `-`, and `_` only, and must not start
+        /// with `-`.
         name: String,
         /// Parent directory to create `<name>/` inside. Defaults to the
         /// current directory. Created if missing, including any
@@ -584,13 +585,24 @@ then commit it next to the theme and diff against it in your tests.
 ";
 
 /// Validate a scaffold theme name: a bare directory component made of
-/// ASCII letters, digits, `-`, or `_`. Rejects empty, path separators,
-/// `.`/`..`, and anything else that could escape the target directory
-/// or produce a surprising path. Mirrors the "no separators, no `.typ`"
-/// constraint bundled theme names already satisfy.
+/// ASCII letters, digits, `-`, or `_`, not starting with `-`. Rejects
+/// empty, path separators, `.`/`..`, and anything else that could escape
+/// the target directory or produce a surprising path. Mirrors the "no
+/// separators, no `.typ`" constraint bundled theme names already satisfy.
+///
+/// The leading-`-` rejection matters because the emitted theme is meant
+/// to be passed straight back as `--theme <name>/resume.typ`; a name like
+/// `-x` would make that value start with `-`, which clap parses as a flag.
+/// (clap also blocks a bare `themes new -x` before this runs, but a user
+/// can still reach the validator via `themes new -- -x`.)
 fn validate_theme_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("theme name must not be empty".to_owned());
+    }
+    if name.starts_with('-') {
+        return Err(format!(
+            "invalid theme name `{name}`: must not start with `-`"
+        ));
     }
     if !name
         .chars()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,6 +165,40 @@ enum Commands {
 enum ThemesCommands {
     /// List registered theme names, one per line, sorted.
     List,
+    /// Scaffold a starter native theme wired to the shared prelude.
+    ///
+    /// Writes a new directory `<name>/` (under the current directory,
+    /// or under `--out <dir>`) containing a ready-to-edit `resume.typ`
+    /// that `#import`s ferrocv's native-theme prelude
+    /// (`/themes/_prelude/lib.typ`) and renders the major JSON Resume
+    /// sections, plus a `golden.txt` test stub. The generated theme
+    /// renders straight away — point `render --theme` at the emitted
+    /// file:
+    ///
+    /// ```text
+    /// ferrocv themes new mytheme
+    /// ferrocv render resume.json --theme mytheme/resume.typ -o out.pdf
+    /// ```
+    ///
+    /// `<name>` must be a bare directory name: letters, digits, `-`,
+    /// and `_` only (no path separators, no `..`), so it can never
+    /// escape the target directory. The command refuses to write into
+    /// an existing target — it never clobbers; remove the directory or
+    /// pick another name to re-run.
+    ///
+    /// Exit codes:
+    /// - 0: theme scaffolded.
+    /// - 2: invalid name, target already exists, or IO error.
+    New {
+        /// Name of the theme to scaffold. Becomes the new directory's
+        /// name; letters, digits, `-`, and `_` only.
+        name: String,
+        /// Parent directory to create `<name>/` inside. Defaults to the
+        /// current directory. Created if missing, including any
+        /// intermediate directories.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Download a Typst Universe package into the local cache so
     /// later `render` invocations can resolve `@preview/<name>:<version>`
     /// offline.
@@ -350,6 +384,7 @@ pub fn run() -> Result<ExitCode> {
         } => run_tailor(path.as_deref(), &projection.to_spec(), output.as_deref()),
         Commands::Themes { command } => match command {
             ThemesCommands::List => run_themes_list(),
+            ThemesCommands::New { name, out } => run_themes_new(&name, out.as_deref()),
             #[cfg(feature = "install")]
             ThemesCommands::Install { spec } => run_themes_install(&spec),
         },
@@ -520,6 +555,143 @@ fn run_themes_list() -> Result<ExitCode> {
         }
     }
     Ok(ExitCode::SUCCESS)
+}
+
+// --- `themes new` scaffold -------------------------------------------
+// The two emitted-file constants, then the validation + write logic.
+
+/// Starter `resume.typ` emitted by `ferrocv themes new`. Baked in at
+/// compile time so the scaffold needs no filesystem access to its own
+/// templates and stays in lockstep with the prelude it imports.
+const SCAFFOLD_RESUME_TYP: &str = include_str!("../assets/scaffold/resume.typ");
+
+/// Placeholder golden-test stub emitted alongside the theme. A real
+/// golden is a verbatim text extraction of the rendered output; the
+/// scaffold can't render at write time (no Typst here), so it drops a
+/// placeholder the author overwrites once the theme renders the way
+/// they want (testing doctrine §2).
+const SCAFFOLD_GOLDEN_STUB: &str = "\
+ferrocv golden-test stub — replace this file.
+
+A golden file is a committed, verbatim copy of your theme's rendered
+text output, so a future change that alters the output shows up as a
+diff you must explain (CONSTITUTION testing doctrine §2). Generate one
+by rendering a fixture to text and saving the extraction here, e.g.:
+
+    ferrocv render resume.json --theme resume.typ --format text -o golden.txt
+
+then commit it next to the theme and diff against it in your tests.
+";
+
+/// Validate a scaffold theme name: a bare directory component made of
+/// ASCII letters, digits, `-`, or `_`. Rejects empty, path separators,
+/// `.`/`..`, and anything else that could escape the target directory
+/// or produce a surprising path. Mirrors the "no separators, no `.typ`"
+/// constraint bundled theme names already satisfy.
+fn validate_theme_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("theme name must not be empty".to_owned());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "invalid theme name `{name}`: use ASCII letters, digits, `-`, or `_` only \
+             (no path separators or dots)"
+        ));
+    }
+    Ok(())
+}
+
+/// Run `ferrocv themes new <name>`.
+///
+/// Scaffolds `<base>/<name>/` (base = `out`, or the current directory)
+/// with a ready-to-edit `resume.typ` and a `golden.txt` stub. Refuses
+/// to write into an existing target so it never clobbers user work. All
+/// diagnostics go to stderr; the success path prints the created paths
+/// and a render hint to stdout. Exit 2 on any failure.
+fn run_themes_new(name: &str, out: Option<&Path>) -> Result<ExitCode> {
+    if let Err(msg) = validate_theme_name(name) {
+        eprintln!("error: {msg}");
+        return Ok(ExitCode::from(2));
+    }
+
+    // Target is `<out>/<name>`, or just `<name>` (relative to the cwd)
+    // when `--out` is omitted — keeping the path relative so the printed
+    // render hint is portable rather than an absolute, machine-specific
+    // path the user might paste into a shared script.
+    let target = match out {
+        Some(dir) => dir.join(name),
+        None => PathBuf::from(name),
+    };
+
+    // Create any missing ancestors of the target first (so `--out
+    // some/new/dir` works), but NOT the target itself — that we create
+    // exclusively below. When `--out` is omitted the parent is the cwd
+    // (an empty `""` component), which already exists, so skip it.
+    if let Some(parent) = target.parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        eprintln!("error: failed to create {}: {err}", parent.display());
+        return Ok(ExitCode::from(2));
+    }
+
+    // Exclusive create: `create_dir` (not `create_dir_all`) fails with
+    // `AlreadyExists` if anything — a dir, file, or even a dangling
+    // symlink — already occupies the path. That gives us refuse-if-exists
+    // AND closes the TOCTOU window a separate "check then create" pair
+    // would open (where a symlink planted in the gap could redirect our
+    // writes). After this returns Ok the directory is one we just made,
+    // so the rollback below is safe.
+    if let Err(err) = std::fs::create_dir(&target) {
+        if err.kind() == std::io::ErrorKind::AlreadyExists {
+            eprintln!(
+                "error: target already exists: {} (remove it or choose another name)",
+                target.display()
+            );
+        } else {
+            eprintln!("error: failed to create {}: {err}", target.display());
+        }
+        return Ok(ExitCode::from(2));
+    }
+
+    // Roll the freshly-created directory back on any write failure so a
+    // half-written scaffold doesn't strand the user behind the
+    // refuse-if-exists guard on their next attempt.
+    if let Err(err) = write_scaffold_files(&target) {
+        eprintln!("error: {err}");
+        let _ = std::fs::remove_dir_all(&target);
+        return Ok(ExitCode::from(2));
+    }
+
+    let resume_path = target.join("resume.typ");
+    println!("Scaffolded native theme `{name}`:");
+    println!("  {}", resume_path.display());
+    println!("  {}", target.join("golden.txt").display());
+    println!();
+    println!("Render it with:");
+    println!(
+        "  ferrocv render resume.json --theme {} -o out.pdf",
+        resume_path.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Write the scaffold's files into an already-created `target` dir.
+/// Split out so the caller can roll the directory back on the first
+/// failure without duplicating per-file error plumbing.
+fn write_scaffold_files(target: &Path) -> Result<(), String> {
+    for (name, contents) in [
+        ("resume.typ", SCAFFOLD_RESUME_TYP),
+        ("golden.txt", SCAFFOLD_GOLDEN_STUB),
+    ] {
+        let path = target.join(name);
+        std::fs::write(&path, contents)
+            .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+    }
+    Ok(())
 }
 
 fn run_validate(path: Option<&Path>) -> Result<ExitCode> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub use render::{
     compile_text_resolved, compile_theme, compile_theme_resolved,
 };
 pub use theme::{
-    OwnedTheme, PRELUDE_PATH, ResolvedTheme, THEMES, Theme, ThemeResolveError, find_theme,
-    resolve_theme,
+    OwnedTheme, PRELUDE_BYTES, PRELUDE_PATH, ResolvedTheme, THEMES, Theme, ThemeResolveError,
+    find_theme, resolve_theme,
 };
 pub use validate::{ValidationError, validate_value};
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -52,10 +52,13 @@
 //! - **§6.4 — Themes run under Typst's native sandbox, nothing more.**
 //!   We do not add filesystem-wide access, shell-escape, or any
 //!   custom capabilities. The World exposes exactly the virtual
-//!   files the caller registers plus the always-present
-//!   `/resume.json` slot wired to the caller-supplied JSON Resume
-//!   bytes. HTML compilation gains no new capabilities; it only
-//!   selects a different compile target inside the same sandbox.
+//!   files the caller registers, plus two always-present slots: the
+//!   `/resume.json` document wired to the caller-supplied JSON Resume
+//!   bytes, and the first-party native-theme prelude at
+//!   `/themes/_prelude/lib.typ` (baked in, so any theme can `#import`
+//!   the contract without carrying its own copy). HTML compilation
+//!   gains no new capabilities; it only selects a different compile
+//!   target inside the same sandbox.
 //!
 //! # Experimental upstream status
 //!
@@ -801,13 +804,28 @@ impl FerrocvWorld {
     }
 
     /// Common tail of both constructors — wires the `/resume.json`
-    /// slot from `data` and returns the assembled World.
+    /// slot from `data`, injects the shared native-theme prelude, and
+    /// returns the assembled World.
+    ///
+    /// The prelude (`crate::theme::PRELUDE_PATH`) is served in **every**
+    /// World so any theme — bundled, programmatic [`OwnedTheme`], or a
+    /// local single-file `.typ` (including ones `ferrocv themes new`
+    /// emits) — can `#import "/themes/_prelude/lib.typ"`. `or_insert`
+    /// makes it idempotent: bundled native themes that already carry the
+    /// prelude in their `files` keep their (byte-identical) entry, while
+    /// themes that don't gain it for free. The bytes are baked in at
+    /// compile time, so this adds no IO and keeps render offline (§6.1).
     fn assemble(
         entrypoint: FileId,
         entrypoint_source: Source,
-        theme_files: HashMap<FileId, Bytes>,
+        mut theme_files: HashMap<FileId, Bytes>,
         data: &Value,
     ) -> Self {
+        let prelude_id = project_file_id(crate::theme::PRELUDE_PATH);
+        theme_files
+            .entry(prelude_id)
+            .or_insert_with(|| Bytes::new(crate::theme::PRELUDE_BYTES));
+
         let resume_id = project_file_id(RESUME_JSON_PATH);
         // `serde_json::to_vec` is infallible for `Value` — the Value
         // tree by construction never fails to serialize. Unwrap is

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -271,16 +271,17 @@ const _: () = {
 /// Virtual path of the shared native-theme prelude (CONSTITUTION §4).
 ///
 /// The prelude (`assets/themes/_prelude/lib.typ`) is first-party ferrocv
-/// source — not a vendored upstream — bundled into every **native**
-/// theme that opts into the contract by `#import`ing it. It exposes the
-/// optional-field helpers (`opt`, `nz`, `join_present`, `date_range`)
-/// and normalized section accessors (`items`) that `text-minimal` and
-/// `html-minimal` previously copy-pasted. Interning the file into each
-/// native theme's [`Theme::files`] is what makes the absolute import
-/// (`#import "/themes/_prelude/lib.typ": *`) resolve inside
-/// [`crate::render::FerrocvWorld`]. Adapters do not carry it — they wrap
-/// upstream templates and never touch the native contract, keeping the
-/// two layers separable (§4).
+/// source — not a vendored upstream — exposing the optional-field
+/// helpers (`opt`, `nz`, `join_present`, `date_range`) and normalized
+/// section accessors (`items`) that native themes build layout on. The
+/// absolute import `#import "/themes/_prelude/lib.typ": *` resolves
+/// because [`crate::render::FerrocvWorld`] serves the prelude bytes at
+/// this path in **every** World it builds (see
+/// [`crate::theme::PRELUDE_BYTES`]) — so bundled native themes,
+/// programmatic [`OwnedTheme`]s, and local single-file `.typ` themes
+/// (including ones emitted by `ferrocv themes new`) can all import the
+/// contract without each having to carry a copy of the file. Adapters
+/// simply never reference it, keeping the two layers separable (§4).
 ///
 /// Exported so callers building a [`OwnedTheme`] programmatically (and
 /// the prelude's own contract test) reference the canonical path rather
@@ -289,15 +290,24 @@ const _: () = {
 /// "file not found" at render time.
 pub const PRELUDE_PATH: &str = "/themes/_prelude/lib.typ";
 
+/// Raw bytes of the shared native-theme prelude, baked into the binary
+/// at compile time (`include_bytes!` — no filesystem access at render
+/// time, CONSTITUTION §6.1).
+///
+/// Exported so [`crate::render::FerrocvWorld`] can inject the prelude
+/// into every World at [`PRELUDE_PATH`], making the native-theme
+/// contract universally importable (see that path's docs).
+pub const PRELUDE_BYTES: &[u8] = include_bytes!("../assets/themes/_prelude/lib.typ");
+
 /// `(virtual_path, bytes)` entry for the shared prelude.
 ///
-/// Identical in both native themes, so it is centralized here rather
-/// than repeated. `include_bytes!` bakes the source into the binary at
-/// compile time (no filesystem access at render time — §6.1).
-const PRELUDE_FILE: (&str, &[u8]) = (
-    PRELUDE_PATH,
-    include_bytes!("../assets/themes/_prelude/lib.typ"),
-);
+/// Still interned into each native theme's [`Theme::files`] for clarity
+/// (the theme's dependency on the prelude stays visible at its
+/// definition site); the World also injects the same bytes
+/// unconditionally, so the per-theme entry is now idempotent rather
+/// than load-bearing. Identical across native themes, so it is
+/// centralized here rather than repeated.
+const PRELUDE_FILE: (&str, &[u8]) = (PRELUDE_PATH, PRELUDE_BYTES);
 
 /// Virtual path of the `text-minimal` theme's entrypoint.
 ///

--- a/tests/themes_new_cli.rs
+++ b/tests/themes_new_cli.rs
@@ -181,6 +181,31 @@ fn scaffold_rejects_name_with_path_separator() {
 }
 
 #[test]
+fn scaffold_rejects_leading_hyphen_name() {
+    // A name like `-x` would make the emitted `--theme -x/resume.typ`
+    // value start with `-` (which clap parses as a flag), so the
+    // validator rejects it. clap blocks a bare `themes new -x` itself,
+    // so reach the validator the only way a user can: through `--`.
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("--out")
+        .arg(tmp.path())
+        .arg("--")
+        .arg("-leading")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("must not start with"));
+
+    assert!(
+        !tmp.path().join("-leading").exists(),
+        "a rejected name must not create a directory"
+    );
+}
+
+#[test]
 fn scaffold_rejects_dotdot_name() {
     let tmp = TempDir::new().expect("create temp dir");
 

--- a/tests/themes_new_cli.rs
+++ b/tests/themes_new_cli.rs
@@ -1,0 +1,223 @@
+//! Scenario-style black-box tests for `ferrocv themes new` (issue #181).
+//!
+//! These spawn the real built binary via `assert_cmd` and assert on
+//! observable behavior only: exit code, emitted files, and — the
+//! headline acceptance criterion — that the scaffolded theme renders
+//! BOTH golden fixtures (`render_full.json`, `render_sparse.json`) out
+//! of the box, with no edits, through the same binary.
+//!
+//! Per `CONSTITUTION.md` §Testing doctrine #1 (every CLI-visible
+//! behavior has a scenario test) and #4 (no mocking Typst — the render
+//! step drives the real embedded compiler). The exit-code contract:
+//! - `0` — theme scaffolded / render succeeded
+//! - `2` — invalid name, target already exists, or IO error
+//!
+//! The "renders out of the box" guarantee exercises the universal
+//! prelude injection: the emitted `resume.typ` is a *local single-file*
+//! theme, yet it `#import`s `/themes/_prelude/lib.typ`, which only
+//! resolves because `FerrocvWorld` now serves the prelude in every
+//! World (not just bundled themes). A regression there would surface as
+//! a Typst "file not found" and fail the render assertions below.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// PDF magic bytes; every valid PDF stream starts with `%PDF-`.
+const PDF_MAGIC: &[u8] = b"%PDF-";
+
+/// Build a `Command` for the `ferrocv` binary under test.
+fn ferrocv() -> Command {
+    Command::cargo_bin("ferrocv").expect("binary `ferrocv` must be built")
+}
+
+/// Absolute path to a JSON fixture by filename stem (no extension).
+fn fixture(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(format!("{name}.json"));
+    path
+}
+
+/// Render `fixture_stem` through the local-path `theme` to `out`, and
+/// assert it produced a real PDF. Drives the real embedded Typst.
+fn assert_renders(theme: &Path, fixture_stem: &str, out: &Path) {
+    ferrocv()
+        .arg("render")
+        .arg(fixture(fixture_stem))
+        .arg("--theme")
+        .arg(theme)
+        .arg("-o")
+        .arg(out)
+        .assert()
+        .success();
+
+    let bytes = fs::read(out).expect("render must have written the output file");
+    assert!(
+        bytes.starts_with(PDF_MAGIC),
+        "scaffolded theme rendered `{fixture_stem}` to a non-PDF output: {:?}",
+        &bytes[..bytes.len().min(8)],
+    );
+}
+
+#[test]
+fn scaffold_emits_files_and_renders_both_fixtures() {
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("mytheme")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .success();
+
+    let theme_dir = tmp.path().join("mytheme");
+    let resume_typ = theme_dir.join("resume.typ");
+    assert!(resume_typ.is_file(), "scaffold must emit resume.typ");
+    assert!(
+        theme_dir.join("golden.txt").is_file(),
+        "scaffold must emit a golden-test stub"
+    );
+
+    // The acceptance criterion: the generated theme renders both
+    // fixtures with no edits, through the already-built binary.
+    assert_renders(&resume_typ, "render_full", &tmp.path().join("full.pdf"));
+    assert_renders(&resume_typ, "render_sparse", &tmp.path().join("sparse.pdf"));
+}
+
+#[test]
+fn scaffold_defaults_out_to_current_directory() {
+    // With no --out, the theme dir is created relative to the process
+    // cwd. Run the binary with cwd set to a temp dir so the scaffold
+    // lands there and we don't litter the repo.
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .current_dir(tmp.path())
+        .arg("themes")
+        .arg("new")
+        .arg("here")
+        .assert()
+        .success();
+
+    assert!(
+        tmp.path().join("here").join("resume.typ").is_file(),
+        "scaffold without --out must write under the current directory"
+    );
+}
+
+#[test]
+fn scaffold_refuses_to_clobber_existing_target() {
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("dup")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .success();
+
+    // Second run against the same target must refuse (exit 2) and
+    // leave the existing theme untouched.
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("dup")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn scaffold_refuses_when_target_is_a_nondirectory() {
+    // Exclusive `create_dir` must refuse even when a *file* (not a
+    // directory) already occupies the target path — regression guard for
+    // the refuse-if-exists / no-clobber contract.
+    let tmp = TempDir::new().expect("create temp dir");
+    let occupied = tmp.path().join("taken");
+    fs::write(&occupied, b"not a theme").expect("seed a file at the target path");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("taken")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("already exists"));
+
+    // The pre-existing file must be left untouched.
+    assert_eq!(
+        fs::read(&occupied).expect("file still present"),
+        b"not a theme",
+        "refused scaffold must not clobber the existing file"
+    );
+}
+
+#[test]
+fn scaffold_rejects_name_with_path_separator() {
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("a/b")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid theme name"));
+}
+
+#[test]
+fn scaffold_rejects_dotdot_name() {
+    let tmp = TempDir::new().expect("create temp dir");
+
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("../escape")
+        .arg("--out")
+        .arg(tmp.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid theme name"));
+
+    // The traversal target must not have been created.
+    assert!(
+        !tmp.path().parent().unwrap().join("escape").exists(),
+        "a `..` name must never escape the target directory"
+    );
+}
+
+#[test]
+fn help_documents_new_subcommand() {
+    // `themes --help` lists the subcommand...
+    ferrocv()
+        .arg("themes")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("new"));
+
+    // ...and `themes new --help` documents what it does.
+    ferrocv()
+        .arg("themes")
+        .arg("new")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("prelude"))
+        .stdout(predicate::str::contains("--out"));
+}


### PR DESCRIPTION
## What & why

Adds `ferrocv themes new <name>` — the last build task in the v0.9.0
native-theme-contract arc (#179 prelude → #180 `x-` fields → #182
`classic` → #188 default). It scaffolds a starter native theme wired to
the shared prelude, so authoring a JSON-Resume-first theme no longer
starts from a blank file.

## What it does

```
$ ferrocv themes new mytheme
Scaffolded native theme `mytheme`:
  mytheme/resume.typ
  mytheme/golden.txt

Render it with:
  ferrocv render resume.json --theme mytheme/resume.typ -o out.pdf
```

- Writes `<name>/` in the cwd, or under `--out <dir>` (intermediate
  directories created as needed).
- Emits a heavily-commented `resume.typ` that `#import`s the prelude and
  renders the major sections defensively, plus a `golden.txt` test stub.
- `<name>` is allowlist-validated (letters, digits, `-`, `_`; no path
  separators or dots), so it can never escape the target directory.
- The directory is created **exclusively** (`create_dir`, not
  `create_dir_all` on the leaf): an existing target — including a
  dangling symlink — is refused with exit 2 rather than clobbered, which
  also closes the check-then-create TOCTOU window. A write failure rolls
  the directory back so a half-written scaffold can't strand the next run.

## The enabling change: serve the prelude in every render World

A local single-file `.typ` theme (what `--theme ./mytheme/resume.typ`
loads) previously got only its own file, so it couldn't `#import` the
prelude. `FerrocvWorld::assemble` now injects the first-party prelude at
`/themes/_prelude/lib.typ` in **every** World — baked-in bytes, inserted
idempotently via `or_insert_with`, so bundled native themes that already
carry it are unaffected. Render stays fully offline (CONSTITUTION §6.1);
the prelude is `include_bytes!`'d, never fetched.

## Tests

`tests/themes_new_cli.rs` — scenario coverage (testing doctrine §1, §4):
scaffold → render **both** golden fixtures out of the box (the headline
acceptance criterion, exercising the universal-prelude path end-to-end),
default-cwd, refuse-if-exists (dir and non-directory), path-separator and
`..` rejection, and `--help`.

## Review notes

Incorporates a panel review pass: partial-directory rollback on write
failure, exclusive-create to close the symlink-race TOCTOU, portable
relative render-hint path, `--out` help wording, `PRELUDE_BYTES`
re-export, and a stronger `..` test. Two findings were deliberately
deferred as out-of-scope: extracting the repo-wide `ferrocv()`/`fixture()`
test-helper duplication (spans 8 existing files — its own cleanup), and
validating the trusted `--out` path (unwarranted for a single-user
offline tool).

`make preflight` green (fmt, clippy, tests, deny, audit, typos).

Closes #181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `ferrocv themes new <name> [--out <dir>]` command to scaffold a starter native theme.
  * Starter scaffold generates a resume Typst template (`resume.typ`) and a reference file (`golden.txt`) and is ready to render to PDF.

* **Bug Fixes**
  * Improved validation and safety: rejects unsafe names (e.g., `../`, path separators, leading `-`), prevents overwriting existing targets, and cleans up partial scaffolds on write failure.

* **Documentation**
  * Updated README with the new `themes new` workflow, expected output directory behavior, and example render commands.

* **Tests**
  * Added CLI integration coverage for success, help text, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->