### PR TITLE
Add merge queue support to CI and CodeQL workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   schedule:
     - cron: '0 6 * * 3'
 


### PR DESCRIPTION
## What

Add a `merge_group:` trigger to the `on:` block of both `ci.yml` and `codeql.yml`, mirroring each file's existing `pull_request:` filter (bare for `ci.yml`, `branches: [main]` for `codeql.yml`).

## Why

A GitHub merge queue creates a temporary merge commit and waits for every **required** status check to report on the `merge_group` event. If a required check's workflow doesn't trigger on `merge_group`, the queue hangs forever.

This repo's required status checks are:

- **CI Success** — the aggregator gate in `ci.yml`
- **Analyze (actions)** and **Analyze (rust)** — the matrix `Analyze` job in `codeql.yml` (CodeQL)

Both workflows previously triggered only on `push` and `pull_request` (plus a schedule for CodeQL), so an enabled merge queue would never receive these checks and would stall. Adding `merge_group:` makes them report on the queue's merge commit.

(The external "GitGuardian Security Checks" app check is unaffected and untouched.)

## Gate behavior verified

- **CI Success** uses `if: always()` with `contains(needs.*.result, 'failure')` / `'cancelled')`. Skipped needs report `skipped` (not `failure`/`cancelled`), so any PR-only jobs that skip won't fail the gate.
- The CodeQL **Analyze** job has no `if: github.event_name == 'pull_request'` guard, so it runs normally under `merge_group` and reports both `Analyze (actions)` and `Analyze (rust)`.

## Scope

No-op until a merge queue is actually enabled on the repo ruleset. Only `ci.yml` and `codeql.yml` are touched; no other workflows are modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks to also run for merge queue activity, alongside existing push and pull request events.
  * Added security/code analysis coverage for merge queue events targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->