### PR TITLE
Clear new RustSec advisories blocking CI on all branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2804,9 +2804,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,8 @@ ignore = [
     { id = "RUSTSEC-2024-0320", reason = "transitive via typst → syntect; upstream syntect to migrate to yaml-rust2 (#154)" },
     # ttf-parser 0.25.1 unmaintained; transitive: typst → fontdb/typst-library → ttf-parser.
     { id = "RUSTSEC-2026-0192", reason = "transitive via typst → fontdb; upstream typst/fontdb to migrate" },
+    # rustybuzz 0.20.1 unmaintained; transitive: typst → typst-layout/typst-pdf → (krilla) → rustybuzz.
+    { id = "RUSTSEC-2026-0206", reason = "transitive via typst → typst-layout/krilla; upstream to migrate" },
     # quick-xml 0.38.4 DoS (quadratic attribute scan / unbounded ns alloc); transitive:
     # typst → typst-library → hayagriva → citationberg → quick-xml. Only reachable via
     # typst's bibliography path, not user input. Fixed in quick-xml >=0.41.0; blocked


### PR DESCRIPTION
Three RustSec advisories landed after main last ran CI (2026-07-06), turning `cargo-deny` and `cargo-audit` red on every open branch — including all seven open Dependabot PRs, none of which touch these crates. This clears them at the source.

## Advisories

| Advisory | Crate | Class | Resolution |
|----------|-------|-------|------------|
| RUSTSEC-2026-0204 | crossbeam-epoch 0.9.18 | vulnerability (invalid pointer deref in `fmt::Pointer`) | Lockfile bump → 0.9.20 — the sole failure `cargo-audit` reported |
| RUSTSEC-2026-0206 | rustybuzz 0.20.1 | unmaintained | `deny.toml` ignore; transitive via typst → typst-layout/typst-pdf → krilla, unfixable from this crate |
| — | spin 0.9.8 | yanked | Lockfile bump → 0.9.9 |
| RUSTSEC-2026-0186 | memmap2 0.9.10 | unsound | No action — warning only; fails neither check |

No `audit.toml` change: the crossbeam vulnerability is resolved by the lockfile bump, and the unmaintained/yanked advisories are warnings there, not failures — keeping `audit.toml` a subset limited to vulnerabilities we cannot fix.

## Verification

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo audit` → exit 0
- `cargo check --all-features` → builds clean

Once merged, the seven open Dependabot PRs rebase onto green main and unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)