### PR TITLE
Reconcile codeql-action version skew (init + analyze to v4.37.1)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,11 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Dependabot split the `github/codeql-action` monorepo bump into three separate PRs — `init` (#205), `analyze` (#204), and `upload-sarif` (#208). CodeQL requires all three to run at the **same version**; a single-ref bump fails CI with:

> Loaded a configuration file for version '4.36.2', but running version '4.37.1'

So #204 and #205 can never pass on their own. `upload-sarif` already merged to v4.37.1 via #208, leaving `init`/`analyze` skewed at v4.36.2 on main.

This bumps `init` and `analyze` to v4.37.1 (all three now pinned to `7188fc3`), reconciling the skew in one commit.

Once merged, #204 and #205 are redundant (their target already on main) and Dependabot will auto-close them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated security analysis workflow to use the latest pinned CodeQL action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->