### PR TITLE
Group minor and patch Actions bumps into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    # Ship minor/patch action bumps as one PR. Individual PRs break CodeQL,
+    # which requires init/autobuild/analyze/upload-sarif on a matching version,
+    # and leave later PRs stale once the first one merges. Majors stay separate.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: cargo
     directory: /


### PR DESCRIPTION
Dependabot opens `github/codeql-action/{init,autobuild,analyze,upload-sarif}` as separate PRs, but CodeQL requires all of its steps to run the same version. Each such PR therefore fails `Analyze`:

```
Loaded a configuration file for version '4.37.0', but running version '4.37.3'
```

Grouping minor/patch action bumps into one PR fixes that, and also removes the staleness race where the first actions PR to merge leaves the rest behind `main`. Majors stay ungrouped so they remain individually reviewable.

This is the same configuration applied to `cacack/gedcom-go`, where the split PRs had left several Dependabot updates stuck.

Related: the auto-merge workflow here still uses `secrets.GITHUB_TOKEN`, which GitHub refuses to accept when enabling auto-merge on a PR that edits `.github/workflows/*`. That is a separate fix — moving to a GitHub App token — and is why the stuck PRs here are specifically the ones touching workflow files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped minor and patch updates for GitHub Actions dependency updates.
  * Kept major updates separate for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->